### PR TITLE
ci: add puppeteer web e2e job (smoke) + harden run.mjs for headless

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ name: CI
 #   build-check -- freezes the web editor .exe on Windows x64 exactly like
 #                  release.yml, but does NOT upload or release it; it just
 #                  proves the freeze still succeeds.
+#   e2e         -- builds the bundled fingertip example into a URDF package,
+#                  serves it, and drives the web editor with puppeteer +
+#                  headless Chrome (guards the browser UI, incl. the i18n).
 
 on:
   push:
@@ -66,3 +69,65 @@ jobs:
             Write-Error "PyInstaller did not produce the expected .exe"
             exit 1
           }
+
+  e2e:
+    name: web e2e (puppeteer)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Chrome
+        id: chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: stable
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ".[ui]"
+
+      - name: Build the fingertip example into a URDF package
+        run: |
+          python -m sw2robot.exporter.build examples/fingertip \
+            --config examples/fingertip/fingertip.joints.yaml
+
+      - name: Start the web editor server
+        run: |
+          nohup python -m sw2robot.editor.webserver examples/fingertip --port 8090 \
+            > server.log 2>&1 &
+          for i in $(seq 1 60); do
+            if curl -fsS http://localhost:8090/api/info >/dev/null 2>&1; then
+              echo "server up"; exit 0
+            fi
+            sleep 1
+          done
+          echo "server did not come up"; cat server.log; exit 1
+
+      - name: Install e2e dependencies
+        working-directory: tests/e2e
+        run: npm install
+
+      - name: Run the e2e suite
+        working-directory: tests/e2e
+        env:
+          CHROME_PATH: ${{ steps.chrome.outputs.chrome-path }}
+          # headless WebGL needs SwiftShader (three.js); the minimal bundled
+          # fixture has no movable joints, so run the smoke subset.
+          CHROME_ARGS: '--no-sandbox,--disable-setuid-sandbox,--enable-unsafe-swiftshader,--use-gl=angle,--use-angle=swiftshader'
+          E2E_SMOKE: '1'
+        run: node run.mjs http://localhost:8090
+
+      - name: Server log (on failure)
+        if: failure()
+        run: cat server.log

--- a/tests/e2e/run.mjs
+++ b/tests/e2e/run.mjs
@@ -17,6 +17,12 @@ import { fileURLToPath } from 'node:url';
 // regardless of the test machine's browser locale (?lang= overrides detection)
 const BASE = process.argv[2] ?? 'http://localhost:8090';
 const URL = BASE + (BASE.includes('?') ? '&' : '?') + 'lang=ja';
+
+// Smoke mode (E2E_SMOKE=1, used by CI against the tiny bundled fingertip
+// example): skip the sections that need a package with movable joints /
+// many meshes (the auto-limits sweep), which the minimal fixture can't
+// exercise.  Local full runs against a real package leave it unset.
+const SMOKE = process.env.E2E_SMOKE === '1';
 const CHROME = process.env.CHROME_PATH
   ?? 'C:/Program Files/Google/Chrome/Application/chrome.exe';
 
@@ -27,8 +33,13 @@ const check = (name, ok, detail = '') => {
 };
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 
+// CI (headless Linux) needs --no-sandbox etc.; pass them via CHROME_ARGS so
+// local runs keep their default launch flags untouched.
+const EXTRA_ARGS = (process.env.CHROME_ARGS ?? '')
+  .split(',').map(s => s.trim()).filter(Boolean);
 const browser = await puppeteer.launch({
-  executablePath: CHROME, headless: 'new', args: ['--disable-gpu'] });
+  executablePath: CHROME, headless: 'new',
+  args: ['--disable-gpu', ...EXTRA_ARGS] });
 const page = await browser.newPage();
 const pageErrors = [];
 page.on('pageerror', e => pageErrors.push(e.message.split('\n')[0]));
@@ -170,8 +181,11 @@ const descended = await page.evaluate(async () => {
   await new Promise(r => setTimeout(r, 1000));
   return document.getElementById('fspath').textContent;
 });
-check('fs: descend into a folder', !!descended && descended !== fs1.path,
-      `-> "${descended}"`);
+if (descended === null) {
+  console.log('SKIP  fs: descend into a folder (no sub-folder under the browse root)');
+} else {
+  check('fs: descend into a folder', descended !== fs1.path, `-> "${descended}"`);
+}
 await page.click('#fsclose');
 const fsClosed = await page.evaluate(
   () => document.getElementById('fsmodal').style.display);
@@ -306,6 +320,10 @@ if (colReady) {
 // The flow does an async rebuild+reload (~20s for 126 meshes), so POLL for
 // the expected joint state rather than fixed sleeps -- and only undo AFTER
 // the apply-reload has landed, or the two reloads race.
+if (SMOKE) {
+  console.log('SKIP  auto-limits + box-select (smoke mode: minimal fixture has no movable joints)');
+}
+if (!SMOKE) {
 const countContinuous = () => page.evaluate(() =>
   Object.values(document.getElementById('viewer').robot?.joints ?? {})
     .filter(j => j.jointType === 'continuous').length);
@@ -382,6 +400,7 @@ let movRestored = movAfter;
 for (let i = 0; i < 40; i++) { await sleep(2000); movRestored = await movable(); if (movRestored === movBefore) break; }
 check('box-select: undo restores joint types',
       movRestored === movBefore, `back to ${movRestored}`);
+}  // end if (!SMOKE) -- auto-limits + box-select block
 
 // ---- 10. extraction loading UI (mock /api/extract*, no SolidWorks) ---------
 // B: determinate bar during mesh export; C: cold-start reassurance; seconds.


### PR DESCRIPTION
- ci.yml: new e2e job -- builds the bundled fingertip example into a URDF package, serves it, and drives the web editor in headless Chrome via puppeteer, guarding the browser UI (incl. the JA/EN i18n rendering).
- run.mjs:
  - accept CHROME_ARGS so CI can pass SwiftShader + --no-sandbox flags (headless three.js/WebGL needs software GL).
  - add an E2E_SMOKE subset that skips the auto-limits / box-select sections the minimal bundled fixture (no movable joints) can't drive.
  - make "fs: descend into a folder" SKIP (not FAIL) when the browse root has no sub-folder, so the check is environment-independent.