### PR TITLE
ci: run CI on PRs only (drop redundant push-to-main run)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,12 @@
 name: CI
 
-# Runs on every push to main and on every PR, so problems are caught
-# BEFORE a release tag is cut (the release workflow only runs on a vX.Y.Z
-# tag, so without this the PyInstaller freeze would fail at release time
-# with no earlier warning).
+# Runs on every PR (and on demand), so problems are caught BEFORE a release
+# tag is cut (the release workflow only runs on a vX.Y.Z tag, so without
+# this the PyInstaller freeze would fail at release time with no warning).
+#
+# PR-only on purpose: everything lands via the bump-version PR flow, so a
+# push to main is always a just-tested merge -- re-running CI on that push
+# is pure duplication.  workflow_dispatch is kept for manual main runs.
 #
 #   test        -- the pytest suite (Linux, no SolidWorks needed)
 #   build-check -- freezes the web editor .exe on Windows x64 exactly like
@@ -14,9 +17,8 @@ name: CI
 #                  headless Chrome (guards the browser UI, incl. the i18n).
 
 on:
-  push:
-    branches: [main]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## What

Change the CI workflow trigger from `push: branches: [main]` + `pull_request` to **`pull_request` only** (plus `workflow_dispatch` for manual runs).

## Why

Every change lands via the bump-version PR flow, so a push to main is always the merge of an already-tested PR. Re-running the full suite (pytest + Windows freeze + puppeteer e2e) on that push just duplicates the work that already ran on the PR.

- PR still runs the full CI (the gate before merge).
- `workflow_dispatch` kept for on-demand runs on main.
- `release.yml` is unaffected (tag-driven).