### PR TITLE
lint: add ruff (bug-focused) + CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ name: CI
 # push to main is always a just-tested merge -- re-running CI on that push
 # is pure duplication.  workflow_dispatch is kept for manual main runs.
 #
+#   lint        -- ruff (bug-focused rule set; config in pyproject.toml)
 #   test        -- the pytest suite (Linux, no SolidWorks needed)
 #   build-check -- freezes the web editor .exe on Windows x64 exactly like
 #                  release.yml, but does NOT upload or release it; it just
@@ -28,6 +29,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    name: ruff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+        with:
+          version: "0.15.17"   # pinned; bump deliberately
+
   test:
     name: pytest
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,16 @@ packages = ["sw2robot"]
 # put the repo root on sys.path so `sw2robot` imports without an install
 pythonpath = ["."]
 testpaths = ["tests"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "C4", "PIE", "RUF"]
+ignore = [
+    "E501", "E701", "E702", "E731", "E741",  # intentional compact one-liners
+    "B023",     # closures run in the same loop iteration
+    "B905",     # TODO: add zip(strict=)
+    "RUF059",
+]

--- a/sw2robot/editor/__init__.py
+++ b/sw2robot/editor/__init__.py
@@ -15,7 +15,7 @@ and the vendored ``sw2robot.editor._vendor.rc_config`` (ROS/MoveIt/Gazebo
 config generators).
 """
 
-from .state import JointEdit, RobotCompilerState
 from . import core
+from .state import JointEdit, RobotCompilerState
 
-__all__ = ["RobotCompilerState", "JointEdit", "core"]
+__all__ = ["JointEdit", "RobotCompilerState", "core"]

--- a/sw2robot/editor/_autolimits_cli.py
+++ b/sw2robot/editor/_autolimits_cli.py
@@ -20,7 +20,6 @@ import sys
 import tempfile
 
 
-
 def _fast_urdf(urdf):
     """Return a URDF path whose mesh refs prefer the ``.3dxml.glb`` caches.
 
@@ -54,6 +53,7 @@ def main():
     urdf, step_deg, max_deg = sys.argv[1], float(sys.argv[2]), float(sys.argv[3])
     import trimesh
     from skrobot.models.urdf import RobotModelFromURDF
+
     from sw2robot.editor import autoinit
 
     load_urdf, is_tmp = _fast_urdf(urdf)

--- a/sw2robot/editor/_vendor/rc_config/__init__.py
+++ b/sw2robot/editor/_vendor/rc_config/__init__.py
@@ -11,18 +11,16 @@ This module provides generators for:
 from .export import export_all_configs
 from .gazebo_generator import generate_gazebo_config
 from .imitation_generator import generate_il_config
-from .moveit_generator import generate_controllers_yaml
-from .moveit_generator import generate_srdf
+from .moveit_generator import generate_controllers_yaml, generate_srdf
 from .servo_mapping import generate_servo_mapping_yaml
 from .urdf_parser import parse_urdf_content
 
-
 __all__ = [
-    "parse_urdf_content",
-    "generate_srdf",
+    "export_all_configs",
     "generate_controllers_yaml",
     "generate_gazebo_config",
     "generate_il_config",
     "generate_servo_mapping_yaml",
-    "export_all_configs",
+    "generate_srdf",
+    "parse_urdf_content",
 ]

--- a/sw2robot/editor/_vendor/rc_config/export.py
+++ b/sw2robot/editor/_vendor/rc_config/export.py
@@ -5,14 +5,12 @@ Creates ZIP archives containing all configuration files.
 """
 
 import io
-from typing import Any
 import zipfile
+from typing import Any
 
-from .gazebo_generator import generate_gazebo_config
-from .gazebo_generator import generate_ros2_control_xacro
+from .gazebo_generator import generate_gazebo_config, generate_ros2_control_xacro
 from .imitation_generator import generate_il_config
-from .moveit_generator import generate_controllers_yaml
-from .moveit_generator import generate_srdf
+from .moveit_generator import generate_controllers_yaml, generate_srdf
 from .servo_mapping import generate_servo_mapping_yaml
 
 

--- a/sw2robot/editor/_vendor/rc_config/urdf_parser.py
+++ b/sw2robot/editor/_vendor/rc_config/urdf_parser.py
@@ -4,8 +4,8 @@ URDF Parser for configuration page.
 Extracts joint and link information from URDF content.
 """
 
-from typing import Any
 import xml.etree.ElementTree as ET
+from typing import Any
 
 
 def parse_urdf_content(urdf_content: str) -> dict[str, Any]:

--- a/sw2robot/editor/core.py
+++ b/sw2robot/editor/core.py
@@ -24,17 +24,34 @@ import shutil
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
-from .state import JointEdit, RobotCompilerState
+from .state import RobotCompilerState
 
 __all__ = [
-    "import_module", "extract_and_import", "sw_recent_assemblies",
-    "sw_session_status", "load_module", "register_module",
-    "rename_joint", "set_limits", "set_mimic", "set_servo",
-    "set_axis_flip", "set_joint_type", "reverse_direction",
-    "set_actuator", "apply_servo_profile", "SERVO_PROFILES",
-    "chain_related", "movable_names", "validate",
-    "build_urdf", "export_ros_package",
-    "state_path", "save_state", "load_state", "load_edits",
+    "SERVO_PROFILES",
+    "apply_servo_profile",
+    "build_urdf",
+    "chain_related",
+    "export_ros_package",
+    "extract_and_import",
+    "import_module",
+    "load_edits",
+    "load_module",
+    "load_state",
+    "movable_names",
+    "register_module",
+    "rename_joint",
+    "reverse_direction",
+    "save_state",
+    "set_actuator",
+    "set_axis_flip",
+    "set_joint_type",
+    "set_limits",
+    "set_mimic",
+    "set_servo",
+    "state_path",
+    "sw_recent_assemblies",
+    "sw_session_status",
+    "validate",
 ]
 
 JOINT_TYPES = ("fixed", "revolute", "continuous", "prismatic")
@@ -253,7 +270,7 @@ def sw_recent_assemblies(limit: int = 10) -> list:
     # paths, parts AND assemblies mixed); keep the .sldasm ones in File-number
     # order so File1 (most-recently-opened) is first.
     for ver in sorted(versions, reverse=True):
-        sub = r"%s\%s\Recent File List" % (base, ver)
+        sub = rf"{base}\{ver}\Recent File List"
         items = []
         try:
             with winreg.OpenKey(winreg.HKEY_CURRENT_USER, sub) as key:
@@ -361,8 +378,8 @@ SERVO_PROFILES = {
 
 
 def set_actuator(state: RobotCompilerState, joint: str,
-                 effort: Optional[float] = None,
-                 velocity: Optional[float] = None) -> None:
+                 effort: float | None = None,
+                 velocity: float | None = None) -> None:
     """Set the joint's effort (N*m) and/or velocity (rad/s) limits."""
     _require_joint(state, joint)
     e = state.edit_for(joint)
@@ -373,7 +390,7 @@ def set_actuator(state: RobotCompilerState, joint: str,
 
 
 def apply_servo_profile(state: RobotCompilerState, joint: str,
-                        model: Optional[str]) -> Optional[dict]:
+                        model: str | None) -> dict | None:
     """Record the servo model and, if known, auto-fill effort / velocity / range
     from its profile.  Returns the applied profile (or None)."""
     _require_joint(state, joint)
@@ -592,8 +609,8 @@ def export_ros_package(state: RobotCompilerState, out_path,
     """Produce the final ROS/MoveIt/Gazebo/IL config ZIP via the vendored
     ``rc_config.export_all_configs``.  With ``strict=True`` a non-empty
     ``validate(state)`` raises instead of writing a broken package."""
-    from ._vendor.rc_config.urdf_parser import parse_urdf_content
     from ._vendor.rc_config.export import export_all_configs
+    from ._vendor.rc_config.urdf_parser import parse_urdf_content
 
     problems = validate(state)
     if problems and strict:

--- a/sw2robot/editor/state.py
+++ b/sw2robot/editor/state.py
@@ -7,8 +7,6 @@ REST/WebSocket payload without change.
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import BaseModel, Field
 
 
@@ -22,22 +20,22 @@ class JointEdit(BaseModel):
     sw2robot.exporter's job (joint-config YAML), not an export-time overlay.
     """
 
-    rename: Optional[str] = None
-    lower: Optional[float] = None
-    upper: Optional[float] = None
-    mimic_joint: Optional[str] = None
+    rename: str | None = None
+    lower: float | None = None
+    upper: float | None = None
+    mimic_joint: str | None = None
     mimic_multiplier: float = 1.0
     mimic_offset: float = 0.0
-    servo_id: Optional[int] = None
+    servo_id: int | None = None
     direction: int = 1            # +1 normal, -1 reversed
     angle_offset: float = 0.0
     # Actuator limits (None = keep the CAD URDF default); effort N*m, velocity rad/s
-    effort: Optional[float] = None
-    velocity: Optional[float] = None
-    servo_model: Optional[str] = None   # e.g. "HLS3606M" (drives profile auto-fill)
+    effort: float | None = None
+    velocity: float | None = None
+    servo_model: str | None = None   # e.g. "HLS3606M" (drives profile auto-fill)
     # CAD-specific edits robot-compiler can't do (axis/type live in the URDF):
     flip_axis: bool = False       # negate the joint's <axis xyz>
-    jtype: Optional[str] = None   # override joint type (revolute/continuous/...)
+    jtype: str | None = None   # override joint type (revolute/continuous/...)
 
 
 class RobotCompilerState(BaseModel):
@@ -52,7 +50,7 @@ class RobotCompilerState(BaseModel):
     package_dir: str
     joints: list[dict] = Field(default_factory=list)
     links: list[dict] = Field(default_factory=list)
-    root_link: Optional[str] = None
+    root_link: str | None = None
     edits: dict[str, JointEdit] = Field(default_factory=dict)
 
     def edit_for(self, joint_name: str) -> JointEdit:

--- a/sw2robot/editor/ui.py
+++ b/sw2robot/editor/ui.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import argparse
 import copy
+import itertools
 import math
 import os
 import threading
@@ -29,8 +30,7 @@ from pathlib import Path
 
 import numpy as np
 
-from . import autoinit
-from . import core
+from . import autoinit, core
 from .state import RobotCompilerState
 
 _PI = math.pi
@@ -95,7 +95,7 @@ def _rotation_arrow(color, radius=0.025, tube=0.0028, span_deg=290.0, n=36):
     pts = np.column_stack([radius * np.cos(angs), radius * np.sin(angs),
                            np.zeros_like(angs)])
     parts = [trimesh.creation.cylinder(radius=tube, segment=[a, b], sections=8)
-             for a, b in zip(pts[:-1], pts[1:])]
+             for a, b in itertools.pairwise(pts)]
     t = angs[-1]
     tangent = np.array([-np.sin(t), np.cos(t), 0.0])   # +theta direction at the tip
     cone = trimesh.creation.cone(radius=3.2 * tube, height=11.0 * tube, sections=12)
@@ -105,7 +105,7 @@ def _rotation_arrow(color, radius=0.025, tube=0.0028, span_deg=290.0, n=36):
     cone.apply_translation(pts[-1])
     parts.append(cone)
     arrow = trimesh.util.concatenate(parts)
-    arrow.visual = trimesh.visual.ColorVisuals(arrow, face_colors=list(color) + [255])
+    arrow.visual = trimesh.visual.ColorVisuals(arrow, face_colors=[*list(color), 255])
     return arrow
 
 
@@ -168,7 +168,7 @@ class RenderHandles:
         self._apply()
 
 
-def render_robot(server, robot) -> "tuple":
+def render_robot(server, robot) -> tuple:
     """Add each link's visual mesh (plus a hidden red copy) to the viser scene
     under a frame at the link's world pose.  Returns ``(refresh, handles)``;
     ``refresh()`` re-syncs the frames after an FK change."""
@@ -503,7 +503,7 @@ def build_gui(server, refresh, handles, watcher, robot,
     with joints_tab:
         server.gui.add_markdown("**Click a link in 3D** (or pick below) to edit it.")
         group_dd = server.gui.add_dropdown(
-            "chain", tuple(["(all)"] + group_names))
+            "chain", ("(all)", *group_names))
         select_dd = server.gui.add_dropdown("joint", tuple(orig_names))
         autoinit_btn = server.gui.add_button(
             "🪄 Auto-init limits (collision sweep)")
@@ -518,7 +518,7 @@ def build_gui(server, refresh, handles, watcher, robot,
         with server.gui.add_folder("🔗 bulk edit (selected joints)"):
             bulk_status = server.gui.add_markdown("_none selected_")
             bulk_mimic = server.gui.add_dropdown(
-                "mimic driver", tuple(["(none)"] + orig_names))
+                "mimic driver", ("(none)", *orig_names))
             bulk_mult = server.gui.add_number("mimic mult", initial_value=1.0)
             bulk_moff = server.gui.add_number("mimic offset", initial_value=0.0)
             bulk_mimic_btn = server.gui.add_button("apply mimic → selected")
@@ -526,7 +526,7 @@ def build_gui(server, refresh, handles, watcher, robot,
             bulk_hi = server.gui.add_number("upper", initial_value=0.0)
             bulk_lim_btn = server.gui.add_button("apply limits → selected")
             bulk_servo = server.gui.add_dropdown(
-                "servo model", ("(custom)",) + tuple(core.SERVO_PROFILES))
+                "servo model", ("(custom)", *tuple(core.SERVO_PROFILES)))
             bulk_servo_btn = server.gui.add_button("apply servo profile → selected")
             bulk_clear_btn = server.gui.add_button("clear selection")
         edit_status = server.gui.add_markdown("")
@@ -583,7 +583,7 @@ def build_gui(server, refresh, handles, watcher, robot,
                 velocity = server.gui.add_number("velocity (rad/s, 0=keep)", step=0.5,
                     initial_value=(e.velocity if e and e.velocity is not None else 0.0))
                 servo_model = server.gui.add_dropdown(
-                    "servo model", ("(custom)",) + tuple(core.SERVO_PROFILES),
+                    "servo model", ("(custom)", *tuple(core.SERVO_PROFILES)),
                     initial_value=(e.servo_model if e and e.servo_model in core.SERVO_PROFILES else "(custom)"))
                 servo_id = server.gui.add_number("servo_id (-1=none)", step=1,
                     initial_value=(e.servo_id if e and e.servo_id is not None else -1))
@@ -592,7 +592,7 @@ def build_gui(server, refresh, handles, watcher, robot,
                 offset = server.gui.add_number("angle_offset",
                     initial_value=(e.angle_offset if e else 0.0))
                 cands = [n for n in orig_names if n != jn]  # any movable joint
-                mimic = server.gui.add_dropdown("mimic", tuple(["(none)"] + cands),
+                mimic = server.gui.add_dropdown("mimic", ("(none)", *cands),
                     initial_value=(e.mimic_joint if e and e.mimic_joint in cands else "(none)"))
                 mult = server.gui.add_number("mimic mult",
                     initial_value=(e.mimic_multiplier if e else 1.0))
@@ -601,7 +601,7 @@ def build_gui(server, refresh, handles, watcher, robot,
                 flip = server.gui.add_checkbox("flip axis",
                     initial_value=bool(e and e.flip_axis))
                 reverse = server.gui.add_button("⇅ reverse direction (flip axis + swap limits)")
-                jtype = server.gui.add_dropdown("type", ("(keep)",) + core.JOINT_TYPES,
+                jtype = server.gui.add_dropdown("type", ("(keep)", *core.JOINT_TYPES),
                     initial_value=(e.jtype if e and e.jtype else "(keep)"))
         panel["handles"] = [angle, rename, lower, upper, set_lo, set_hi, autofit,
                             effort, velocity, servo_model,
@@ -609,10 +609,10 @@ def build_gui(server, refresh, handles, watcher, robot,
                             flip, reverse, jtype, fold]
         sliders[jn] = angle
         dbg["jn"] = jn
-        dbg["w"] = dict(angle=angle, rename=rename, lower=lower, upper=upper,
-                        set_lo=set_lo, set_hi=set_hi, servo_id=servo_id,
-                        direction=direction, offset=offset, mimic=mimic,
-                        mult=mult, moff=moff, flip=flip, reverse=reverse, jtype=jtype)
+        dbg["w"] = {"angle": angle, "rename": rename, "lower": lower, "upper": upper,
+                        "set_lo": set_lo, "set_hi": set_hi, "servo_id": servo_id,
+                        "direction": direction, "offset": offset, "mimic": mimic,
+                        "mult": mult, "moff": moff, "flip": flip, "reverse": reverse, "jtype": jtype}
 
         def on_angle(_):
             if _suppress["on"]:

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -23,17 +23,17 @@ localhost.  No third-party server deps; mesh conversion reuses trimesh which
 sw2robot.exporter already requires.
 """
 import argparse
+import http.server
 import io
 import json
 import os
 import posixpath
 import re
-import http.server
 import socket
 import socketserver
 import sys
-import threading
 import tempfile
+import threading
 import time
 import urllib.parse
 
@@ -470,8 +470,7 @@ def _export_zip(pkg_dir, robot_name, mesh_fmt="dae"):
     import io as _io
     import zipfile
 
-    from sw2robot.exporter.ros_export import (GLB_CTX_FMT,
-                                              build_ros_description)
+    from sw2robot.exporter.ros_export import GLB_CTX_FMT, build_ros_description
     kwargs = {"ctx_fmt": GLB_CTX_FMT} if mesh_fmt == "glb" else {}
     buf = _io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
@@ -865,6 +864,7 @@ def _build_collision(urdf_path, key):
         import numpy as np
         import trimesh
         from skrobot.models.urdf import RobotModelFromURDF
+
         from . import autoinit
         robot = RobotModelFromURDF(urdf_file=urdf_path)
         meshes = {}
@@ -1485,8 +1485,11 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                     return self._send_json(
                         {"error": "joints.yaml not found"}, 400)
                 import numpy as np
-                from sw2robot.exporter.geometry import (matrix_from_rpy,
-                                              matrix_to_xyz_rpy)
+
+                from sw2robot.exporter.geometry import (
+                    matrix_from_rpy,
+                    matrix_to_xyz_rpy,
+                )
                 with open(yml, encoding="utf-8") as f:
                     txt = f.read()
                 rpy0, xyz0, z0 = _read_root_pose(txt)

--- a/sw2robot/exporter/build.py
+++ b/sw2robot/exporter/build.py
@@ -3,7 +3,9 @@
     uv run python -m sw2robot.exporter.build <pkg_dir> [--config c.yaml] [--base S] [--exclude a,b] [--ros-pkg]
 """
 from __future__ import annotations
+
 import argparse
+
 from .export import build
 
 

--- a/sw2robot/exporter/export.py
+++ b/sw2robot/exporter/export.py
@@ -17,13 +17,19 @@ from __future__ import annotations
 import argparse
 import os
 
-from .swcom import SolidWorks, as_iface
-from .model import (extract_graph, extract_subgraphs, to_graph_state,
-                    capture_deep_worlds, build_model, safe_name)
-from .mesh import export_meshes, export_subgraph_meshes, _SAVE_OPTS
-from .state import GraphState
-from .urdf_writer import write_urdf, write_ros_package
 from . import jointcfg
+from .mesh import _SAVE_OPTS, export_meshes, export_subgraph_meshes
+from .model import (
+    build_model,
+    capture_deep_worlds,
+    extract_graph,
+    extract_subgraphs,
+    safe_name,
+    to_graph_state,
+)
+from .state import GraphState
+from .swcom import SolidWorks, as_iface
+from .urdf_writer import write_ros_package, write_urdf
 
 GRAPH_FILE = "graph.json"
 

--- a/sw2robot/exporter/extract.py
+++ b/sw2robot/exporter/extract.py
@@ -3,7 +3,9 @@
     uv run python -m sw2robot.exporter.extract <assembly.sldasm> [-o OUT] [-n NAME] [--visible]
 """
 from __future__ import annotations
+
 import argparse
+
 from .export import extract
 
 

--- a/sw2robot/exporter/jointcfg.py
+++ b/sw2robot/exporter/jointcfg.py
@@ -90,5 +90,5 @@ def write_template(model, path):
 
 
 def load(path):
-    with open(path, "r", encoding="utf-8") as f:
+    with open(path, encoding="utf-8") as f:
         return yaml.safe_load(f) or {}

--- a/sw2robot/exporter/mesh.py
+++ b/sw2robot/exporter/mesh.py
@@ -12,9 +12,16 @@ from __future__ import annotations
 
 import os
 
-from .swcom import (safe_prop, safe_call, as_iface, byref_long,
-                    doc_type_for, SW_OPEN_SILENT,
-                    SW_SAVEAS_SILENT, SW_SAVEAS_COPY)
+from .swcom import (
+    SW_OPEN_SILENT,
+    SW_SAVEAS_COPY,
+    SW_SAVEAS_SILENT,
+    as_iface,
+    byref_long,
+    doc_type_for,
+    safe_call,
+    safe_prop,
+)
 
 _SAVE_OPTS = SW_SAVEAS_SILENT | SW_SAVEAS_COPY  # 3
 # a 3DXML below this is just the empty-document envelope (no tessellation);

--- a/sw2robot/exporter/model.py
+++ b/sw2robot/exporter/model.py
@@ -23,11 +23,15 @@ from dataclasses import dataclass, field
 
 import numpy as np
 
-from .swcom import safe_prop, safe_call, as_iface
-from .geometry import (transform_to_matrix, matrix_to_xyz_rpy,
-                       relative_matrix, frame_at_point, transform_point_dir,
-                       matrix_from_rpy)
-from .state import GraphState, ComponentState, MateEdge, MateGeo, SubGraph
+from .geometry import (
+    frame_at_point,
+    matrix_from_rpy,
+    matrix_to_xyz_rpy,
+    relative_matrix,
+    transform_to_matrix,
+)
+from .state import ComponentState, GraphState, MateEdge, MateGeo, SubGraph
+from .swcom import as_iface, safe_call, safe_prop
 
 MATE_TYPES = {0: "COINCIDENT", 1: "CONCENTRIC", 2: "PERPENDICULAR",
               3: "PARALLEL", 4: "TANGENT", 5: "DISTANCE", 6: "ANGLE",
@@ -815,7 +819,7 @@ def _demote_coaxial_duplicates(edge, adjacency):
         return max(radii) if radii else 0.0
 
     groups = {}
-    for key, (jt, ax, note) in edge.items():
+    for key, (jt, ax, _note) in edge.items():
         if jt not in _MOVABLE_TYPES or ax is None:
             continue
         prefs = {prefix(n) for n in key}
@@ -823,7 +827,7 @@ def _demote_coaxial_duplicates(edge, adjacency):
             continue                      # only inside one expanded instance
         groups.setdefault(next(iter(prefs)), []).append(key)
 
-    for pref, keys in groups.items():
+    for _pref, keys in groups.items():
         keys.sort(key=lambda k: (-radius_of(k), sorted(k)))
         kept = []
         for key in keys:
@@ -924,7 +928,7 @@ def _auto_parent_map(comps, adjacency, base):
             tuple(-x for x in _edge_pref(cur, nb)), nb))
 
     while True:
-        bfs_within(0, [base.name] + sorted(parent_of))
+        bfs_within(0, [base.name, *sorted(parent_of)])
         # attach ONE component over the lowest-tier edge available --
         # picking the BEST such edge (instance affinity, mate richness),
         # then resume rigid expansion from it
@@ -1258,7 +1262,7 @@ def _warn_unsolved_mates(comps, adjacency):
                 if top not in per or off < per[top][0]:
                     per[top] = (off, p, d)
     flagged = {}
-    for sig, per in pattern.items():
+    for _sig, per in pattern.items():
         if len(per) < 2:               # needs at least two DISTINCT instances
             continue
         best = min(off for off, _, _ in per.values())
@@ -1457,7 +1461,7 @@ def from_graph(graph, exclude=None, expand=None, no_expand=None):
         if e.a not in names or e.b not in names:
             continue
         adjacency[frozenset((e.a, e.b))] = _edge_rec(e)
-    ground = set(g for g in graph.ground if g in names)
+    ground = {g for g in graph.ground if g in names}
     _snap_unsolved_mates(comps, adjacency)
     return _expand_subassemblies(graph, comps, adjacency, ground,
                                  expand=expand, no_expand=no_expand)

--- a/sw2robot/exporter/ros_export.py
+++ b/sw2robot/exporter/ros_export.py
@@ -168,7 +168,7 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
             return
         try:
             data = _CONVERT[fmt](src)
-        except Exception as e:             # noqa: BLE001 -- report, don't die
+        except Exception as e:
             errors.append(f"{base}: {fmt} convert failed ({e!r})")
             return
         arc = f"{pkg}/meshes/{base}.{fmt}"

--- a/sw2robot/exporter/state.py
+++ b/sw2robot/exporter/state.py
@@ -93,5 +93,5 @@ class GraphState(BaseModel):
 
     @classmethod
     def load(cls, path):
-        with open(path, "r", encoding="utf-8") as f:
+        with open(path, encoding="utf-8") as f:
             return cls.model_validate_json(f.read())

--- a/sw2robot/exporter/swcom.py
+++ b/sw2robot/exporter/swcom.py
@@ -80,6 +80,7 @@ def _load_modules():
 def _makepy_solidworks():
     """Locate sldworks.tlb (+swconst/swpublished) and run makepy on them."""
     import glob
+
     from win32com.client import makepy
     roots = [r"C:\Program Files\SOLIDWORKS Corp",
              r"C:\Program Files (x86)\SOLIDWORKS Corp"]

--- a/sw2robot/exporter/urdf_writer.py
+++ b/sw2robot/exporter/urdf_writer.py
@@ -79,7 +79,7 @@ def _report_inertia(methods):
 def _link_xml(comp, ros_pkg=None, rn=lambda n: n, mesh_dir=None, density=None):
     lines = [f'  <link name="{rn(comp.link_name)}">']
     if comp.mesh_file:
-        mesh_ref = ("package://%s/%s" % (ros_pkg, comp.mesh_file.replace("\\", "/"))
+        mesh_ref = ("package://{}/{}".format(ros_pkg, comp.mesh_file.replace("\\", "/"))
                     if ros_pkg else "../" + comp.mesh_file.replace("\\", "/"))
         vorigin = (f'      <origin xyz="{_fmt(comp.visual_xyz)}" '
                    f'rpy="{_fmt(comp.visual_rpy)}"/>')
@@ -198,7 +198,7 @@ def write_urdf(model, urdf_path, ros_pkg=None, density=_inertia.DEFAULT_DENSITY,
     # urdf lives at <pkg>/urdf/<name>.urdf -> the package root is two levels up.
     mesh_dir = os.path.dirname(os.path.dirname(os.path.abspath(urdf_path)))
 
-    parts = [f'<?xml version="1.0"?>', f'<robot name="{model.name}">']
+    parts = ['<?xml version="1.0"?>', f'<robot name="{model.name}">']
     methods = {}
     for comp in model.components:
         xml, method = _link_xml(comp, ros_pkg, rn, mesh_dir=mesh_dir,

--- a/sw2robot/exporter/viewer.py
+++ b/sw2robot/exporter/viewer.py
@@ -72,9 +72,9 @@ def _wxyz_to_mat(q):
 def view(urdf_path, open_browser=True, labels=True, gizmos=True,
          gizmo_scale=0.05, axis_viz=True, axis_length=0.05):
     import skrobot
-    from skrobot.models.urdf import RobotModelFromURDF
-    from skrobot.model import Axis, Cylinder
     from skrobot.coordinates import Coordinates
+    from skrobot.model import Axis, Cylinder
+    from skrobot.models.urdf import RobotModelFromURDF
 
     print(f"loading URDF: {urdf_path}")
     robot = RobotModelFromURDF(urdf_file=urdf_path)

--- a/tests/test_autoinit.py
+++ b/tests/test_autoinit.py
@@ -53,7 +53,7 @@ def test_build_emits_real_inertia(built_pkg):
             off_com += 1
 
     # not the old uniform 0.1 kg placeholder: masses must vary and be plausible
-    assert len(set(round(m, 6) for m in masses)) > 1, "masses look like placeholders"
+    assert len({round(m, 6) for m in masses}) > 1, "masses look like placeholders"
     assert 0.01 < sum(masses) < 50.0, f"total mass {sum(masses)} kg implausible"
     assert off_com > 0, "no link has an off-origin centre of mass"
 
@@ -121,7 +121,7 @@ def test_sweep_limits_finds_limits_and_restores_pose(built_pkg):
     res = autoinit.sweep_limits(robot, meshes, step_deg=6, max_deg=120)
 
     assert res, "no revolute joints swept"
-    for jn, v in res.items():
+    for _jn, v in res.items():
         assert v["lower"] <= v["upper"]
         # a non-continuous joint that hit a collision must be a finite sub-range
         if v["hit_upper"] is not None:

--- a/tests/test_cad2rc_e2e.py
+++ b/tests/test_cad2rc_e2e.py
@@ -25,8 +25,12 @@ CACHE = REPO_ROOT / "output" / "feetech_hand"
 
 def _rc_config_available() -> bool:
     try:
-        from sw2robot.editor._vendor.rc_config.export import export_all_configs  # noqa: F401
-        from sw2robot.editor._vendor.rc_config.urdf_parser import parse_urdf_content  # noqa: F401
+        from sw2robot.editor._vendor.rc_config.export import (
+            export_all_configs,  # noqa: F401
+        )
+        from sw2robot.editor._vendor.rc_config.urdf_parser import (
+            parse_urdf_content,  # noqa: F401
+        )
     except Exception:
         return False
     return True

--- a/tests/test_classify_geo.py
+++ b/tests/test_classify_geo.py
@@ -5,7 +5,7 @@ Each case is a list of MateGeo-shaped dicts as build_mate_graph records them
 import numpy as np
 import pytest
 
-from sw2robot.exporter.model import classify_edge_geo, classify_edge_auto
+from sw2robot.exporter.model import classify_edge_auto, classify_edge_geo
 
 Z = [0.0, 0.0, 1.0]
 X = [1.0, 0.0, 0.0]

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -4,12 +4,16 @@ base plate.  Expansion must splice the children in, keep the internal
 revolute, and re-attach the mounting mate to the owning child."""
 import numpy as np
 import pytest
+from test_classify_geo import O, Z, coinc_planes, conc, dup
 
-from sw2robot.exporter.model import from_graph, build_model
-from sw2robot.exporter.state import (GraphState, SubGraph, ComponentState, MateEdge,
-                           MateGeo)
-
-from test_classify_geo import mate, dup, conc, coinc_planes, PLANE, CYL, Z, O
+from sw2robot.exporter.model import build_model, from_graph
+from sw2robot.exporter.state import (
+    ComponentState,
+    GraphState,
+    MateEdge,
+    MateGeo,
+    SubGraph,
+)
 
 
 def _comp(name, link, xyz=(0, 0, 0), sub=False, path=None):
@@ -225,8 +229,9 @@ def test_hidden_components_excluded():
 def test_snap_not_fooled_by_multi_mate_single_instance():
     # ONE cover mated to two boards: hole A on its origin axis (0mm), hole B
     # 20mm away -- legitimate design, must NOT be "corrected"
-    from sw2robot.exporter.model import _warn_unsolved_mates, Component
     import numpy as np
+
+    from sw2robot.exporter.model import Component, _warn_unsolved_mates
     def comp(name, path, xyz):
         w = np.eye(4); w[:3, 3] = xyz
         return Component(name=name, link_name=name.replace("-", "_"),
@@ -249,8 +254,9 @@ def test_snap_not_fooled_by_multi_mate_single_instance():
 
 
 def test_snap_still_fires_for_true_stale_sibling():
-    from sw2robot.exporter.model import _warn_unsolved_mates, Component
     import numpy as np
+
+    from sw2robot.exporter.model import Component, _warn_unsolved_mates
     def comp(name, path, xyz):
         w = np.eye(4); w[:3, 3] = xyz
         return Component(name=name, link_name=name.replace("-", "_"),
@@ -281,8 +287,9 @@ def _adj_rec(mates_):
 def test_loop_locked_hinge_demoted():
     # A-B looks like a hinge, but A-C and B-C are HARD fixed -> the loop
     # locks the hinge (what SolidWorks drag shows)
-    from sw2robot.exporter.model import _auto_parent_map, Component
     import numpy as np
+
+    from sw2robot.exporter.model import Component, _auto_parent_map
     def comp(name, xyz):
         w = np.eye(4); w[:3, 3] = xyz
         return Component(name=name, link_name=name, part_path=None,
@@ -310,8 +317,9 @@ def test_loop_with_offset_fastener_also_locks():
     # the loop edge is a single small fastener on a DIFFERENT axis: two
     # non-collinear axes on one part -> SolidWorks drag cannot rotate it,
     # so the global solve demotes the hinge too
-    from sw2robot.exporter.model import _auto_parent_map, Component
     import numpy as np
+
+    from sw2robot.exporter.model import Component, _auto_parent_map
     def comp(name, xyz):
         w = np.eye(4); w[:3, 3] = xyz
         return Component(name=name, link_name=name, part_path=None,
@@ -337,8 +345,9 @@ def test_loop_with_offset_fastener_also_locks():
 
 def test_isolated_hinge_survives_global_solve():
     # a hinge with NO other path stays movable under the global solve
-    from sw2robot.exporter.model import _auto_parent_map, Component
     import numpy as np
+
+    from sw2robot.exporter.model import Component, _auto_parent_map
     def comp(name, xyz):
         w = np.eye(4); w[:3, 3] = xyz
         return Component(name=name, link_name=name, part_path=None,

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -1,6 +1,5 @@
 """Rename overlay: write_urdf applies link/joint name overrides (refs follow,
 names sanitised) and the webserver's joints.yaml helpers round-trip."""
-import os
 import xml.etree.ElementTree as ET
 
 import numpy as np

--- a/tests/test_ros_export.py
+++ b/tests/test_ros_export.py
@@ -35,6 +35,7 @@ def test_mesh_to_dae_scale_and_loadable():
     if not os.path.exists(_SAMPLE_MESH):
         pytest.skip("sample .3dxml mesh not present")
     import trimesh
+
     from sw2robot.exporter.ros_export import _mesh_to_dae_bytes
 
     src = trimesh.load(_SAMPLE_MESH)
@@ -60,6 +61,7 @@ def test_mesh_to_dae_scale_and_loadable():
 
 def test_build_ros_description_layout(tmp_path):
     import trimesh
+
     from sw2robot.exporter.ros_export import build_ros_description
 
     pkg_dir = _make_pkg(tmp_path, robot="fing")
@@ -96,9 +98,11 @@ def test_build_ros_description_layout(tmp_path):
 
 def test_glb_ctx_exports_uniform_glb(tmp_path):
     import io
-    import trimesh
     import xml.etree.ElementTree as ET
-    from sw2robot.exporter.ros_export import build_ros_description, GLB_CTX_FMT
+
+    import trimesh
+
+    from sw2robot.exporter.ros_export import GLB_CTX_FMT, build_ros_description
 
     pkg_dir = _make_pkg(tmp_path, robot="g")
     files = dict(build_ros_description(pkg_dir, "g", ctx_fmt=GLB_CTX_FMT))
@@ -134,9 +138,10 @@ def test_working_package_is_not_modified(tmp_path):
 def test_texture_glb_colours_become_collada_materials(tmp_path):
     import numpy as np
     pytest.importorskip("PIL")
-    from PIL import Image
     import trimesh
+    from PIL import Image
     from trimesh.visual.texture import TextureVisuals
+
     from sw2robot.exporter.ros_export import _mesh_to_dae_bytes
 
     mesh = trimesh.creation.box(extents=(1, 1, 1))

--- a/tests/test_sanitize_names.py
+++ b/tests/test_sanitize_names.py
@@ -29,8 +29,8 @@ def test_safe_name_strips_unsafe_chars():
 
 
 def test_exporter_sanitizes_root_and_port(tmp_path):
-    from sw2robot.exporter.model import Component, Joint, Port, RobotModel
     from sw2robot.exporter import urdf_writer
+    from sw2robot.exporter.model import Component, Joint, Port, RobotModel
 
     comps = [
         Component(name="Base-1", link_name="base_link", part_path=None,


### PR DESCRIPTION
## What

Adopt **ruff** as the linter, tuned for an AI-coding workflow: high signal on real bugs, low style noise.

### Config (`[tool.ruff]` in pyproject.toml)
- **select**: `F` (pyflakes), `B` (bugbear) — real bugs; `UP` (pyupgrade), `I` (isort) — modern + tidy; plus `E/W`, `C4`, `PIE`, `RUF`.
- **ignore**: stylistic rules that fight this codebase's compact one-liners (`E501/E701/E702/E731/E741`) and noisy/false-positive ones (`B023` immediate-call closures, `RUF059` intentional tuple unpacking). `B905` left as a TODO.

### Fixes
All current findings fixed so `ruff check` is green — safe + reviewed unsafe autofixes (import sorting, `Optional[...]` → `X | None`, printf → f-string, list-concat → spread, unused removals). Tests unaffected: **53 passed / 7 skipped**.

Notable real bug caught: `editor/core.py` annotated params with `Optional[...]` but never imported `Optional` → switched to PEP 604 `X | None`.

### CI
New `lint` job runs ruff (pinned `0.15.17`) on every PR, alongside test / build-check / e2e.