### PR TITLE
docs: add project CLAUDE.md for AI coding agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,35 @@
+# CLAUDE.md
+
+## Project
+sw2robot: a SolidWorks assembly -> URDF exporter with a browser-based editor
+(joint types, limits, root frame, ROS/glb export). The SolidWorks extract step
+is Windows-only (pywin32 COM); view / edit / build / export run on any OS from a
+cached `graph.json`.
+
+## Read first when touching ...
+- web editor UI  -> `sw2robot/editor/web/index.html` is one self-contained
+  HTML+JS file; every user-facing string goes through the i18n `t()` layer.
+- freeze / release -> `build_exe.py` and `.github/workflows/`.
+
+## Commands
+- Fast check (run after each change, <20s): `uv run --extra ui --with pytest pytest -q`
+- Lint: `uvx ruff@0.15.17 check .`  (config in `pyproject.toml` `[tool.ruff]`)
+- Run the editor: `uv run python -m sw2robot.editor.webserver <pkg_dir> --port 8090`
+- Build the .exe (Windows): `python build_exe.py --editor-ui`
+- Use Python 3.12. Don't run on 3.14: its argparse rejects the webserver's
+  `%TEMP%` help string and the server won't start.
+
+## Rules
+- Don't translate filesystem paths, package names, or the Google "shared drives"
+  mount name in the web UI. Instead translate display strings only, because those
+  names carry real on-disk SolidWorks paths resolved server-side.
+- Don't disable or fake an assertion to make a check pass. Instead write the real
+  check or flag the gap, because green-but-fake tests hide regressions.
+- Don't add a fallback that makes broken functionality look like it works.
+  Instead surface the failure.
+- Don't read, edit, commit, or transmit any `.env` or secret file.
+
+## Conventions
+- CI runs on PRs only (lint / test / build-check / e2e); a push to main is an
+  already-tested merge. Releases are tag-driven: push a `vX.Y.Z` tag.
+- A `feat`/`fix` change ships with its test in the same PR.


### PR DESCRIPTION
## What

Add a concise, project-level `CLAUDE.md` (35 lines) so AI coding agents (Claude Code, Cursor, Codex, …) have the repo context and guardrails up front instead of inferring them.

## Design (high signal, low bloat)
- **Project context** in the first lines.
- **Commands** an agent can't guess: fast test (`pytest -q`, <20s), lint (`ruff`), run the editor, build the .exe — plus the Python 3.12 constraint (3.14 breaks the webserver's argparse).
- **Guardrails as "don't X, instead Y, because Z"**: display-only i18n (never translate real paths / the shared-drive name), no faked/disabled assertions, no failure-masking fallbacks, never touch `.env`.
- **Conventions**: PR-only CI, tag-driven release, feat/fix ships with its test.

No identity language, no `IMPORTANT`/`MUST` padding, no template placeholders; well under the size where agent tools start truncating.

> Note: the `ruff` command references config added in the parallel lint PR; both are intended to land.