### PR TITLE
docs: fix README title (sw2robot + tagline)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# solidworks_urdf_exporter2
+# sw2robot
 
-Turn a SolidWorks assembly into a URDF, then clean it up in the browser.
+**SolidWorks → robot (URDF) converter.** Turn a SolidWorks assembly into a
+URDF, then clean it up in the browser.
 
 One import package, with two subpackages:
 


### PR DESCRIPTION
The README H1 was `# solidworks_urdf_exporter2` — it didn't match the package name (`sw2robot`) and read like a leftover.

Change it to the actual name as the title plus a one-line tagline that matches the GitHub repo description:

```
# sw2robot

**SolidWorks → robot (URDF) converter.** Turn a SolidWorks assembly into a
URDF, then clean it up in the browser.
```

Uses correct casing (SolidWorks / URDF). No other content changed.