### PR TITLE
editor: dedup refactors, faster joint-limit sweep + live progress

### DIFF
--- a/sw2robot/editor/_autolimits_cli.py
+++ b/sw2robot/editor/_autolimits_cli.py
@@ -51,7 +51,6 @@ def _fast_urdf(urdf):
 
 def main():
     urdf, step_deg, max_deg = sys.argv[1], float(sys.argv[2]), float(sys.argv[3])
-    import trimesh
     from skrobot.models.urdf import RobotModelFromURDF
 
     from sw2robot.editor import autoinit
@@ -65,15 +64,7 @@ def main():
                 os.remove(load_urdf)
             except OSError:
                 pass
-    meshes = {}
-    for l in robot.link_list:
-        vm = getattr(l, "visual_mesh", None)
-        ms = (vm if isinstance(vm, (list, tuple)) else [vm]) \
-            if vm is not None else []
-        ms = [m for m in ms if hasattr(m, "vertices") and len(m.vertices)]
-        if ms:
-            meshes[l.name] = (trimesh.util.concatenate(ms)
-                              if len(ms) > 1 else ms[0])
+    meshes = autoinit.link_meshes(robot)
 
     results = autoinit.sweep_limits(
         robot, meshes, step_deg=step_deg, max_deg=max_deg, margin_deg=2.0,

--- a/sw2robot/editor/_autolimits_cli.py
+++ b/sw2robot/editor/_autolimits_cli.py
@@ -49,12 +49,21 @@ def _fast_urdf(urdf):
     return tmp, True
 
 
+def _emit(**ev):
+    """One progress event as a JSON line on STDERR (stdout is reserved for the
+    final results JSON the caller parses).  The webserver reads these live to
+    drive the UI's per-joint progress bar."""
+    sys.stderr.write(json.dumps(ev) + "\n")
+    sys.stderr.flush()
+
+
 def main():
     urdf, step_deg, max_deg = sys.argv[1], float(sys.argv[2]), float(sys.argv[3])
     from skrobot.models.urdf import RobotModelFromURDF
 
     from sw2robot.editor import autoinit
 
+    _emit(event="loading")                    # model load is the slow first ~2 s
     load_urdf, is_tmp = _fast_urdf(urdf)
     try:
         robot = RobotModelFromURDF(urdf_file=load_urdf)
@@ -66,9 +75,18 @@ def main():
                 pass
     meshes = autoinit.link_meshes(robot)
 
+    total = sum(1 for j in robot.joint_list
+                if type(j).__name__ == "RotationalJoint")
+    _emit(event="start", total=total)
+    done = [0]
+
+    def progress(name, _res):
+        done[0] += 1
+        _emit(event="joint", i=done[0], total=total, joint=name)
+
     results = autoinit.sweep_limits(
         robot, meshes, step_deg=step_deg, max_deg=max_deg, margin_deg=2.0,
-        refine=True)
+        refine=True, progress=progress)
     out = [{"child": v["child"], "lower": v["lower"], "upper": v["upper"],
             "continuous": v["continuous"]}
            for v in results.values() if v.get("child")]

--- a/sw2robot/editor/_vendor/rc_config/urdf_parser.py
+++ b/sw2robot/editor/_vendor/rc_config/urdf_parser.py
@@ -50,20 +50,26 @@ def parse_urdf_content(urdf_content: str) -> dict[str, Any]:
         link_info = _parse_link(link_elem)
         links.append(link_info)
 
-    # Find root link (link that is not a child of any joint)
+    # Find root link (link that is not a child of any joint).  Keep DOCUMENT
+    # ORDER throughout -- a set.pop() here is non-deterministic across runs,
+    # which would make root detection (and the editor's rename/root handling
+    # built on it) flip arbitrarily on a multi-root / disconnected URDF.
     child_links = {j["childLink"] for j in joints}
-    link_names = {link["name"] for link in links}
-    root_links = link_names - child_links
+    root_candidates = [link["name"] for link in links
+                       if link["name"] not in child_links]
 
     root_link = None
-    if len(root_links) == 1:
-        root_link = root_links.pop()
-    elif len(root_links) > 1:
-        # If multiple root candidates, pick the one that's a parent
+    if len(root_candidates) == 1:
+        root_link = root_candidates[0]
+    elif len(root_candidates) > 1:
+        # multiple roots (disconnected / imported URDF): prefer the first
+        # candidate that actually drives a joint (a real kinematic root) over a
+        # stray link with no joints, else just the first -- both in document
+        # order so the choice is stable and identical for every caller
+        # (core.load_module and the webserver's root detection).
         parent_links = {j["parentLink"] for j in joints}
-        candidates = root_links & parent_links
-        if candidates:
-            root_link = candidates.pop()
+        root_link = next((c for c in root_candidates if c in parent_links),
+                         root_candidates[0])
 
     return {
         "joints": joints,

--- a/sw2robot/editor/autoinit.py
+++ b/sw2robot/editor/autoinit.py
@@ -202,6 +202,16 @@ def sweep_limits(robot, meshes, step_deg=6.0, max_deg=180.0, margin_deg=2.0,
         # (convex hulls touch at rest and mask real collisions -> limits too
         # wide).  Callers that already built a hull `sc` (the live UI) pass it.
         sc = SelfCollision(robot, meshes, margin=margin_m, hull=hull)
+    # Hull PRE-FILTER world.  A convex hull CONTAINS its mesh, so if two hulls
+    # do not collide the meshes inside them cannot either: a hull-clear angle is
+    # provably mesh-clear.  The coarse scan runs on these cheap hulls and only
+    # escalates to the exact mesh where a hull flags a possible collision, so a
+    # free joint (the common, expensive case -- it scans the whole range finding
+    # nothing) costs only hull queries.  Result-identical to the pure-mesh scan;
+    # see `_hull_clear`.  (When the caller already asked for a hull `sc`, reuse
+    # it rather than build a redundant second hull world.)
+    sc_hull = sc if hull else SelfCollision(robot, meshes, margin=margin_m,
+                                            hull=True)
 
     step = np.radians(step_deg)
     nmax = max(1, int(np.radians(max_deg) / step))
@@ -210,19 +220,25 @@ def sweep_limits(robot, meshes, step_deg=6.0, max_deg=180.0, margin_deg=2.0,
 
     import fcl
 
+    _req = fcl.CollisionRequest(num_max_contacts=1000, enable_contact=True)
+
     # Reuse the fcl objects SelfCollision already built (their BVH is built
     # ONCE here).  Per joint we register the prebuilt objects into throwaway
     # broadphase managers -- registerObjects does NOT rebuild the BVH, so a
     # query is ~1 ms even on the real (non-hull) meshes; rebuilding a manager
     # via trimesh.add_object instead cost ~2 s/joint (the whole sweep was 55 s).
-    objs = {n: sc.cm._objs[n]["obj"] for n in sc.names}
-    geom2name = {id(sc.cm._objs[n]["geom"]): n for n in sc.names}
-    _req = fcl.CollisionRequest(num_max_contacts=1000, enable_contact=True)
+    def _world(world):
+        objs = {n: world.cm._objs[n]["obj"] for n in world.names}
+        geom2name = {id(world.cm._objs[n]["geom"]): n for n in world.names}
 
-    def _set_obj_T(n):
-        T = sc._link[n].worldcoords().T()
-        objs[n].setTranslation(np.ascontiguousarray(T[:3, 3]))
-        objs[n].setRotation(np.ascontiguousarray(T[:3, :3]))
+        def set_T(n):
+            T = world._link[n].worldcoords().T()
+            objs[n].setTranslation(np.ascontiguousarray(T[:3, 3]))
+            objs[n].setRotation(np.ascontiguousarray(T[:3, :3]))
+        return objs, geom2name, set_T
+
+    raw_objs, raw_g2n, raw_set_T = _world(sc)
+    hull_objs, hull_g2n, hull_set_T = _world(sc_hull)
 
     def _moving_set(J):
         # Which links ACTUALLY move when only J rotates?  Determined by probing
@@ -255,51 +271,81 @@ def sweep_limits(robot, meshes, step_deg=6.0, max_deg=180.0, margin_deg=2.0,
                     progress(J.name, out[J.name])
                 continue
             # static links don't move while J sweeps -> set their transforms
-            # once; only the moving set updates per angle.
-            st_mgr = fcl.DynamicAABBTreeCollisionManager()
-            st_mgr.registerObjects([objs[n] for n in static])
-            for n in static:
-                _set_obj_T(n)
-            st_mgr.setup()
-            mv_mgr = fcl.DynamicAABBTreeCollisionManager()
-            mv_mgr.registerObjects([objs[n] for n in moving])
-            mv_mgr.setup()
+            # once; only the moving set updates per angle.  Build the same
+            # throwaway broadphase managers for BOTH the exact-mesh world and
+            # the hull pre-filter world, over the same moving/static split.
+            def _make_pairs(objs, geom2name, set_T, margin):
+                st_mgr = fcl.DynamicAABBTreeCollisionManager()
+                st_mgr.registerObjects([objs[n] for n in static])
+                for n in static:
+                    set_T(n)
+                st_mgr.setup()
+                mv_mgr = fcl.DynamicAABBTreeCollisionManager()
+                mv_mgr.registerObjects([objs[n] for n in moving])
+                mv_mgr.setup()
 
-            def _pairs(mag, direction):
-                J.joint_angle(direction * mag)
-                for n in moving:
-                    _set_obj_T(n)
-                mv_mgr.update()          # refresh AABBs after the move
-                cdata = fcl.CollisionData(request=_req)
-                mv_mgr.collide(st_mgr, cdata, fcl.defaultCollisionCallback)
-                depth = {}
-                for c in cdata.result.contacts:
-                    a = geom2name.get(id(c.o1))
-                    b = geom2name.get(id(c.o2))
-                    if a and b:
-                        k = frozenset((a, b))
-                        depth[k] = max(depth.get(k, 0.0),
-                                       abs(c.penetration_depth))
-                return {k for k, v in depth.items() if v > sc.margin}
+                def _pairs(mag, direction):
+                    J.joint_angle(direction * mag)
+                    for n in moving:
+                        set_T(n)
+                    mv_mgr.update()          # refresh AABBs after the move
+                    cdata = fcl.CollisionData(request=_req)
+                    mv_mgr.collide(st_mgr, cdata, fcl.defaultCollisionCallback)
+                    depth = {}
+                    for c in cdata.result.contacts:
+                        a = geom2name.get(id(c.o1))
+                        b = geom2name.get(id(c.o2))
+                        if a and b:
+                            k = frozenset((a, b))
+                            depth[k] = max(depth.get(k, 0.0),
+                                           abs(c.penetration_depth))
+                    return {k for k, v in depth.items() if v > margin}
+                return _pairs
 
-            # baseline: moving-vs-static pairs already in contact at HOME
-            ignore = _pairs(0.0, 1) | sc.baseline
+            raw_pairs = _make_pairs(raw_objs, raw_g2n, raw_set_T, sc.margin)
+            hull_pairs = _make_pairs(hull_objs, hull_g2n, hull_set_T,
+                                     sc_hull.margin)
+
+            # baseline: moving-vs-static pairs already in contact at HOME (mesh)
+            ignore = raw_pairs(0.0, 1) | sc.baseline
 
             def _collides(mag, direction):
-                new = _pairs(mag, direction) - ignore
+                new = raw_pairs(mag, direction) - ignore
                 return (tuple(sorted(next(iter(new)))) if new else None)
+
+            def _hull_clear(mag, direction):
+                # Hull CONTAINS the mesh, so no hull collision => no mesh
+                # collision: this angle is skipped without an exact-mesh query.
+                # Subtract the MESH `ignore` (not a hull baseline) so a pair that
+                # only the hull touches at rest is never absorbed into the
+                # baseline and so can never mask a real mesh collision -- this is
+                # what keeps the pre-filter result-identical to a pure-mesh scan.
+                return not (hull_pairs(mag, direction) - ignore)
 
             lim = {}
             hit = {}
             for direction in (+1, -1):
                 clear_mag, hit_mag, hit_pair = 0.0, None, None
+                # The hull pre-filter pays off only while the hulls actually
+                # separate as J turns.  Some links have fat hulls that overlap a
+                # static link at rest and never separate (a non-adjacent pair the
+                # mesh never touches); for them every step would escalate, so the
+                # hull query is pure overhead.  Treat the hull as "innocent until
+                # useless": the first time it flags a step that the mesh finds
+                # clear (a persistent false positive), stop consulting it for the
+                # rest of this direction and scan the mesh directly.
+                use_hull = True
                 for k in range(1, nmax + 1):
                     mag = k * step
-                    pair = _collides(mag, direction)
+                    if use_hull and _hull_clear(mag, direction):
+                        clear_mag = mag          # hull clear => mesh clear
+                        continue
+                    pair = _collides(mag, direction)  # hull flagged: check mesh
                     if pair:
                         hit_mag, hit_pair = mag, pair
                         break
-                    clear_mag = mag
+                    clear_mag = mag              # hull false positive; mesh clear
+                    use_hull = False             # hull is useless here; drop it
                 # bisect [clear_mag, hit_mag] to the precise boundary
                 if refine and hit_mag is not None:
                     a, b = clear_mag, hit_mag

--- a/sw2robot/editor/autoinit.py
+++ b/sw2robot/editor/autoinit.py
@@ -57,6 +57,34 @@ def _descendants(root, children):
     return out
 
 
+def link_visual_mesh(link):
+    """A single local-frame trimesh for a skrobot link's visual geometry, or
+    None.  ``visual_mesh`` is a single mesh, a list, or None depending on the
+    URDF; empty meshes are dropped and a multi-mesh link is concatenated."""
+    import trimesh
+    vm = getattr(link, "visual_mesh", None)
+    ms = (vm if isinstance(vm, (list, tuple)) else [vm]) \
+        if vm is not None else []
+    ms = [m for m in ms
+          if m is not None and hasattr(m, "vertices") and len(m.vertices)]
+    if not ms:
+        return None
+    return trimesh.util.concatenate(ms) if len(ms) > 1 else ms[0]
+
+
+def link_meshes(robot):
+    """``{link name -> local-frame trimesh}`` for every link that has visual
+    geometry -- the per-link mesh map both :class:`SelfCollision` and
+    :func:`sweep_limits` take.  One place so the webserver, the autolimits
+    subprocess and the viser UI build it identically."""
+    out = {}
+    for l in robot.link_list:
+        m = link_visual_mesh(l)
+        if m is not None:
+            out[l.name] = m
+    return out
+
+
 class SelfCollision:
     """Convex-hull self-collision model over a skrobot robot.
 
@@ -105,6 +133,16 @@ class SelfCollision:
         """Colliding link pairs (beyond the rest baseline) at the current pose."""
         self._sync()
         return self._pairs(self.margin) - self.baseline
+
+    def offenders(self):
+        """``(new_pairs, offending_link_names)`` at the current pose -- the live
+        drag highlight wants the flat set of links to tint as well as the
+        pairs."""
+        new = self.new_pairs()
+        links = set()
+        for p in new:
+            links |= set(p)
+        return new, links
 
     def min_distance(self):
         """``(distance_m, (link_a, link_b))`` of the closest non-adjacent pair,

--- a/sw2robot/editor/ui.py
+++ b/sw2robot/editor/ui.py
@@ -116,20 +116,6 @@ def _slider_range(j: dict) -> tuple[float, float]:
     return (lo, hi)
 
 
-def _link_mesh(link):
-    """A single trimesh for a link's visual geometry (local frame), or None."""
-    import trimesh
-    vm = getattr(link, "visual_mesh", None)
-    if vm is None:
-        return None
-    if isinstance(vm, (list, tuple)):
-        vm = [m for m in vm if m is not None]
-        if not vm:
-            return None
-        return trimesh.util.concatenate(vm) if len(vm) > 1 else vm[0]
-    return vm
-
-
 def _pose(link):
     """(position xyz, quaternion wxyz) of a link in world coords."""
     c = link.worldcoords()
@@ -176,7 +162,7 @@ def render_robot(server, robot) -> tuple:
 
     h = RenderHandles()
     for link in robot.link_list:
-        mesh = _link_mesh(link)
+        mesh = autoinit.link_visual_mesh(link)
         if mesh is None:
             continue
         pos, wxyz = _pose(link)
@@ -206,81 +192,6 @@ def render_robot(server, robot) -> tuple:
                 fr.position, fr.wxyz = _pose(link)
 
     return refresh, h
-
-
-def _collision_mesh(mesh):
-    """A cheap proxy for fcl: the convex hull (built-in, ~100x faster than the
-    raw CAD mesh -- base_link alone is 117k faces).  Since the baseline is
-    computed with the SAME proxies, hull-induced static overlaps are absorbed
-    into the baseline and never show as a new collision."""
-    try:
-        hull = mesh.convex_hull
-        if hull is not None and len(hull.faces):
-            return hull
-    except Exception:
-        pass
-    return mesh
-
-
-class CollisionWatcher:
-    """Self-collision detector. Pairs touching at the REST pose, plus
-    parent/child adjacency, are the allowed baseline; any NEW colliding pair is
-    reported so the offending links can be highlighted (the user's request).
-
-    Collision geometry is the per-link convex hull, not the full CAD mesh, so a
-    query is ~2 ms instead of ~200 ms (the FK slider stays interactive)."""
-
-    def __init__(self, robot, meshes: dict, margin: float = 0.002):
-        from trimesh.collision import CollisionManager
-        self.robot = robot
-        self.names = list(meshes)
-        self._link = {l.name: l for l in robot.link_list}
-        self.margin = margin            # penetration (m) before a pair counts
-        self.cm = CollisionManager()
-        for name in self.names:
-            self.cm.add_object(name, _collision_mesh(meshes[name]),
-                               transform=self._link[name].worldcoords().T())
-        # Baseline = EVERY pair touching at rest (margin 0), plus parent/child
-        # adjacency.  A "new" collision must penetrate past ``margin``, so the
-        # depth~0 grazing contacts that flicker on fcl's boundary never trigger.
-        self.baseline = self._pairs(0.0)
-        for j in robot.joint_list:
-            if j.parent_link and j.child_link:
-                self.baseline.add(frozenset((j.parent_link.name, j.child_link.name)))
-
-    def _pairs(self, margin) -> set:
-        """Colliding link pairs whose max penetration depth exceeds ``margin``."""
-        _, names, data = self.cm.in_collision_internal(return_names=True,
-                                                        return_data=True)
-        if margin <= 0:
-            return {frozenset(p) for p in names}
-        depth = {}
-        for d in data:
-            k = frozenset(d.names)
-            depth[k] = max(depth.get(k, 0.0), abs(d.depth))
-        return {k for k, v in depth.items() if v > margin}
-
-    def offenders(self):
-        """(new_pairs, offending_link_names) at the robot's current pose."""
-        for name in self.names:
-            self.cm.set_transform(name, self._link[name].worldcoords().T())
-        new = self._pairs(self.margin) - self.baseline
-        links = set()
-        for p in new:
-            links |= set(p)
-        return new, links
-
-    def min_distance(self):
-        """``(distance_m, (link_a, link_b))`` for the closest separated pair, or
-        ``(inf, None)`` if nothing is near.  fcl skips pairs already in contact,
-        so a touching/penetrating pair shows up via ``offenders`` instead."""
-        for name in self.names:
-            self.cm.set_transform(name, self._link[name].worldcoords().T())
-        try:
-            d, names = self.cm.min_distance_internal(return_names=True)
-        except Exception:
-            return float("inf"), None
-        return float(d), (tuple(sorted(names)) if names else None)
 
 
 def build_gui(server, refresh, handles, watcher, robot,
@@ -994,7 +905,7 @@ def mount_module(server, state: RobotCompilerState, export_dir: Path):
 
     robot = RobotModelFromURDF(urdf_file=state.urdf_path)
     refresh, handles = render_robot(server, robot)
-    watcher = CollisionWatcher(robot, handles.meshes)
+    watcher = autoinit.SelfCollision(robot, handles.meshes)
     build_gui(server, refresh, handles, watcher, robot, state, export_dir)
     print(f"[sw2robot.ui] mounted '{state.robot_name}': {len(state.joints)} joints "
           f"({len(state.movable_joints())} movable), root={state.root_link}")

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -582,6 +582,9 @@ skrobot / native-mesh consumers (not RViz-loadable)">⬇ glb</button></a>
     'auto.sweepStart': { en: 'self-collision limit sweep (coarse scan + binary search) — this takes a few seconds …',
                          ja: '自己干渉リミット探索（粗スキャン + 二分探索）— 数秒かかります …' },
     'auto.sweepBar': { en: 'searching joint limits …', ja: '関節リミットを探索中 …' },
+    'auto.sweepLoading': { en: 'loading model …', ja: 'モデルを読み込み中 …' },
+    'auto.sweepProg': { en: a => `joint ${a.n}/${a.total}${a.j ? ' — ' + a.j : ''}`,
+                        ja: a => `関節 ${a.n}/${a.total}${a.j ? ' — ' + a.j : ''}` },
     'auto.sweepDone': { en: a => `sweep done: ${a.l} joint(s) get limits, ${a.c} stay continuous — applying …`,
                         ja: a => `探索完了: ${a.l} 関節にリミット、${a.c} 関節は連続回転のまま — 適用中 …` },
     'auto.noRot': { en: 'no rotational joints to limit', ja: 'リミット対象の回転関節がありません' },
@@ -2399,14 +2402,29 @@ autolimitsBtn.addEventListener('click', async () => {
   autolimitsBtn.disabled = true;
   op('autoLimits', {});
   log(t('auto.sweepStart'));
-  // ONE blocking request, no progress polling: polling during the CPU-bound
-  // sweep thrashes the server's GIL and balloons it ~20x (8s -> 200s).
+  // Start ASYNC, then poll /api/auto_limits/status for per-joint progress.
+  // (Safe now: the sweep runs in a child process, so polling no longer steals
+  // its GIL the way the old in-process sweep did.)
   showLoadbar(t('auto.sweepBar'), { indet: true });
   try {
     const resp0 = await fetch('/api/auto_limits');
     const data = await resp0.json();
     if (!resp0.ok || data.error) { throw new Error(data.error ?? resp0.status); }
-    const results = data.results || [];
+    let st = {};
+    while (true) {
+      await new Promise(r => setTimeout(r, 400));
+      try { st = await (await fetch('/api/auto_limits/status')).json(); }
+      catch { continue; }                       // transient: keep polling
+      if (st.total) {
+        updateLoadbar(st.n / st.total,
+                      t('auto.sweepProg', { n: st.n, total: st.total, j: st.joint }));
+      } else if (st.phase === 'loading') {
+        updateLoadbar(null, null, t('auto.sweepLoading'));
+      }
+      if (st.done) { break; }
+    }
+    if (st.error) { throw new Error(st.error); }
+    const results = st.results || [];
     const limited = results.filter(r => !r.continuous);
     const cont = results.filter(r => r.continuous);
     log(t('auto.sweepDone', { l: limited.length, c: cont.length }), 'ok');

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -638,30 +638,32 @@ def _zdir_to_rpy(zdir):
     return list(rpy)
 
 
+def _parse_urdf(pkg_dir, urdf_rel):
+    """Parse the served URDF via the editor's one canonical parser
+    (``parse_urdf_content``) -- the same code path ``core.load_module`` uses --
+    so link/joint listing and root-link detection don't drift between the
+    server and the rest of the editor.  Returns the parsed dict or None."""
+    from ._vendor.rc_config.urdf_parser import parse_urdf_content
+    try:
+        with open(os.path.join(pkg_dir, urdf_rel), encoding="utf-8") as f:
+            return parse_urdf_content(f.read())
+    except Exception:
+        return None
+
+
 def _urdf_names(pkg_dir, urdf_rel, tag):
     """Current ``<link>``/``<joint>`` names in the served URDF (the source of
     truth for what's on screen), for the rename collision check + root detect."""
-    import xml.etree.ElementTree as ET
-    try:
-        root = ET.parse(os.path.join(pkg_dir, urdf_rel)).getroot()
-    except Exception:
+    parsed = _parse_urdf(pkg_dir, urdf_rel)
+    if parsed is None:
         return []
-    return [e.get("name") for e in root.findall(tag) if e.get("name")]
+    return [e["name"] for e in parsed["links" if tag == "link" else "joints"]]
 
 
 def _urdf_root_link(pkg_dir, urdf_rel):
     """The root link name (the link that is never a joint's child)."""
-    import xml.etree.ElementTree as ET
-    try:
-        root = ET.parse(os.path.join(pkg_dir, urdf_rel)).getroot()
-    except Exception:
-        return None
-    children = {j.find("child").get("link") for j in root.findall("joint")
-                if j.find("child") is not None}
-    for ln in root.findall("link"):
-        if ln.get("name") not in children:
-            return ln.get("name")
-    return None
+    parsed = _parse_urdf(pkg_dir, urdf_rel)
+    return parsed["root_link"] if parsed else None
 
 
 def _list_packages(root):

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -864,21 +864,11 @@ _coll = {"key": None, "ctx": None, "building": False, "error": None}
 def _build_collision(urdf_path, key):
     try:
         import numpy as np
-        import trimesh
         from skrobot.models.urdf import RobotModelFromURDF
 
         from . import autoinit
         robot = RobotModelFromURDF(urdf_file=urdf_path)
-        meshes = {}
-        for l in robot.link_list:
-            vm = getattr(l, "visual_mesh", None)
-            ms = (vm if isinstance(vm, (list, tuple)) else [vm]) \
-                if vm is not None else []
-            ms = [m for m in ms
-                  if hasattr(m, "vertices") and len(m.vertices)]
-            if ms:
-                meshes[l.name] = (trimesh.util.concatenate(ms)
-                                  if len(ms) > 1 else ms[0])
+        meshes = autoinit.link_meshes(robot)
         sc = autoinit.SelfCollision(robot, meshes)
         joints = {}
         for j in robot.joint_list:

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1258,7 +1258,10 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                                    phase="loading")
                 pkg, rel = cls.pkg_dir, cls.urdf_rel
 
-                def _job():
+                # NB: must NOT be named `_job` -- that shadows the module-global
+                # `_job` (the extraction job) across this whole method and breaks
+                # the /api/extract* handlers with an UnboundLocalError.
+                def _sweep_job():
                     try:
                         results, err = _run_auto_limits(pkg, rel, step, mx)
                     except Exception as e:           # never leave it "running"
@@ -1267,7 +1270,7 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                         _limjob.update(results=results, error=err,
                                        running=False)
 
-                threading.Thread(target=_job, daemon=True).start()
+                threading.Thread(target=_sweep_job, daemon=True).start()
                 return self._send_json({"started": True})
             if path == "/api/auto_limits/status":
                 with _limjob_lock:

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -898,7 +898,7 @@ def _build_collision(urdf_path, key):
 # collision lock while it sweeps (it mutates joint angles), so the live drag
 # check pauses for its duration.
 _limjob = {"running": False, "log": [], "error": None, "results": None,
-           "n": 0, "total": 0}
+           "n": 0, "total": 0, "joint": None, "phase": None}
 _limjob_lock = threading.Lock()
 
 
@@ -934,16 +934,67 @@ def _run_auto_limits(pkg_dir, urdf_rel, step_deg, max_deg):
         cwd = PROJECT_ROOT
     cmd += [urdf, str(step_deg), str(max_deg)]
     _t0 = time.time()
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE, text=True, cwd=cwd)
+
+    # Drain stderr LIVE in a thread: the CLI emits per-joint progress there as
+    # JSON lines (stdout carries only the final results JSON).  Reading it as it
+    # flows both feeds the UI progress bar via _limjob and keeps the pipe from
+    # filling.  Polling is GIL-safe now -- the sweep runs in this child process,
+    # not in a server thread (the whole reason it is a subprocess).
+    def _pump():
+        for line in proc.stderr:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                ev = json.loads(line)
+            except Exception:
+                with _limjob_lock:        # non-JSON (skrobot warnings): keep a tail
+                    _limjob["log"].append(line)
+                    del _limjob["log"][:-50]
+                continue
+            with _limjob_lock:
+                kind = ev.get("event")
+                if kind == "loading":
+                    _limjob["phase"] = "loading"
+                elif kind == "start":
+                    _limjob.update(phase="sweeping", total=ev.get("total", 0),
+                                   n=0)
+                elif kind == "joint":
+                    _limjob.update(n=ev.get("i", 0),
+                                   total=ev.get("total", _limjob["total"]),
+                                   joint=ev.get("joint"))
+
+    pump = threading.Thread(target=_pump, daemon=True)
+    pump.start()
+    # Drain stdout in THIS thread while the pump drains stderr -- both pipes are
+    # read concurrently, so neither can fill and deadlock the child.  A watchdog
+    # enforces the timeout by killing the child (which gives stdout.read() its
+    # EOF); we then always wait() to reap it and join the pump after its stderr
+    # hits EOF, so a stale pump can never bleed into the next job's _limjob.
+    timed_out = {"v": False}
+
+    def _watchdog():
+        timed_out["v"] = True
+        proc.kill()
+
+    timer = threading.Timer(900, _watchdog)
+    timer.start()
     try:
-        p = subprocess.run(cmd, capture_output=True, text=True, timeout=900,
-                           cwd=cwd)
-    except subprocess.TimeoutExpired:
+        out_txt = proc.stdout.read()
+    finally:
+        timer.cancel()
+        proc.wait()
+        pump.join(timeout=2)
+    if timed_out["v"]:
         return None, "sweep timed out"
-    if p.returncode != 0:
-        tail = (p.stderr or "").strip().splitlines()[-3:]
+    if proc.returncode != 0:
+        with _limjob_lock:
+            tail = _limjob["log"][-3:]
         return None, "sweep failed: " + " | ".join(tail)
     try:
-        out = json.loads(p.stdout)["results"]
+        out = json.loads(out_txt)["results"]
     except Exception as e:
         return None, f"bad sweep output: {e}"
     print(f"[sw2robot.web] auto_limits sweep: {time.time() - _t0:.1f}s "
@@ -1185,25 +1236,47 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                         "baseline": (len(_coll["ctx"]["sc"].baseline)
                                      if ready else None)})
             if path == "/api/auto_limits":
-                # SUBPROCESS sweep (avoids the GIL convoy; see
-                # _run_auto_limits).  One job at a time; blocks ~10 s.
+                # SUBPROCESS sweep (avoids the GIL convoy; see _run_auto_limits).
+                # Started ASYNC so the page can poll /api/auto_limits/status for
+                # per-joint progress while it runs (the sweep is in the child
+                # process, so polling no longer thrashes its GIL).  One at a time.
                 if not cls.pkg_dir:
                     return self._send_json({"error": "no package open"}, 400)
+                # parse BEFORE claiming the job, so a bad step/max can't wedge
+                # the "running" flag (no worker would start to clear it)
+                try:
+                    step = float((query.get("step") or ["10"])[0])
+                    mx = float((query.get("max") or ["360"])[0])  # ±2π
+                except ValueError:
+                    return self._send_json({"error": "bad step/max"}, 400)
                 with _limjob_lock:
                     if _limjob["running"]:
                         return self._send_json(
                             {"error": "a limit sweep is already running"}, 409)
-                    _limjob["running"] = True
-                try:
-                    step = float((query.get("step") or ["10"])[0])
-                    mx = float((query.get("max") or ["360"])[0])  # ±2π
-                    results, err = _run_auto_limits(
-                        cls.pkg_dir, cls.urdf_rel, step, mx)
-                finally:
-                    _limjob["running"] = False
-                if err:
-                    return self._send_json({"error": err}, 409)
-                return self._send_json({"results": results})
+                    _limjob.update(running=True, log=[], error=None,
+                                   results=None, n=0, total=0, joint=None,
+                                   phase="loading")
+                pkg, rel = cls.pkg_dir, cls.urdf_rel
+
+                def _job():
+                    try:
+                        results, err = _run_auto_limits(pkg, rel, step, mx)
+                    except Exception as e:           # never leave it "running"
+                        results, err = None, f"{type(e).__name__}: {e}"
+                    with _limjob_lock:
+                        _limjob.update(results=results, error=err,
+                                       running=False)
+
+                threading.Thread(target=_job, daemon=True).start()
+                return self._send_json({"started": True})
+            if path == "/api/auto_limits/status":
+                with _limjob_lock:
+                    return self._send_json(
+                        {"running": _limjob["running"], "n": _limjob["n"],
+                         "total": _limjob["total"], "joint": _limjob["joint"],
+                         "phase": _limjob["phase"], "error": _limjob["error"],
+                         "results": _limjob["results"],
+                         "done": not _limjob["running"]})
             if path == "/api/extract":
                 target = (query.get("path") or [""])[0]
                 target = os.path.abspath(os.path.expanduser(


### PR DESCRIPTION
Editor improvements + cleanup, on top of the browser auto-open already merged in #10. Each commit is self-contained and reviewable independently.

## What's in here

**Refactor — dedup URDF parsing** (`6a82783`)
The webserver re-implemented link/joint listing and root-link detection with its own ElementTree walk. Both now delegate to `parse_urdf_content` (the parser `core.load_module` already uses) so the server and the rest of the editor can't drift. Also made that parser's root selection deterministic (it used an arbitrary `set.pop()` for multi-root URDFs).

**Refactor — dedup self-collision + per-link mesh extraction** (`575614c`)
Three call sites each had their own copy of the skrobot `visual_mesh -> {link: trimesh}` loop → folded into `autoinit.link_visual_mesh` / `link_meshes`. `ui.CollisionWatcher` was a near-verbatim second copy of `autoinit.SelfCollision` → deleted; the UI now uses `SelfCollision` (new `offenders()` helper). Net −70 lines, no behavior change.

**Perf — convex-hull pre-filter for the joint-limit sweep** (`f97e181`)
The self-collision limit sweep scanned each joint on the exact meshes, so a free joint paid a full mesh query at every coarse step. A convex hull is a superset of its mesh, so when the hulls don't collide the meshes can't either → that angle is marked clear without an exact-mesh query (escalation + bisection stay on the exact mesh). Subtracts the **raw** baseline so it's result-identical to the pure-mesh scan; a `use_hull` guard drops the hull where fat hulls overlap at rest. **Verified result-identical limits; Panda sweep 1.51s → 1.22s.**

**Feature — live per-joint progress for the sweep** (`030ef5e`)
The sweep was one blocking request with an indeterminate spinner; on a 22-joint robot (~8s) the user had no idea how far along it was. `_autolimits_cli` now emits per-joint JSON progress on stderr; `_run_auto_limits` drains it live into `_limjob`; `/api/auto_limits` is async with a new `/api/auto_limits/status` the page polls for a determinate "joint i/N — name" bar. Polling is GIL-safe now that the sweep runs in a child process.

**Bugfix** (`55a5deb`)
The progress commit named its worker closure `def _job():`, which shadowed the module-global `_job` (the extraction job) across `do_GET` and broke `/api/extract*` with an UnboundLocalError (HTTP 500) — SolidWorks extraction appeared to "load forever". Renamed to `_sweep_job`.

## Testing
- `ruff` clean on every commit.
- `pytest`: editor suite green (the 3 `test_ros_export` failures only appear in a throwaway env without `pycollada`; unrelated to these changes).
- Sweep speedup + result-equivalence verified on Panda and on real extracted packages (mini_quadrotor 22 joints, vial_gripper 14 joints).
- Progress + the extraction-endpoint fix verified end-to-end over HTTP.
- Concurrency / subprocess pipe + timeout handling and the refactors' behavior-equivalence were reviewed with codex.

Not run locally: the puppeteer e2e suite (needs Chrome + a running server) — CI covers it.