### PR TITLE
editor: make the live self-collision highlight exact-mesh accurate

### DIFF
--- a/sw2robot/editor/autoinit.py
+++ b/sw2robot/editor/autoinit.py
@@ -91,23 +91,40 @@ class SelfCollision:
     ``meshes`` maps link name -> local-frame trimesh (the UI already has these).
     """
 
-    def __init__(self, robot, meshes, margin=REST_MARGIN, hull=True):
+    def __init__(self, robot, meshes, margin=REST_MARGIN, hull=True,
+                 confirm=False):
         from trimesh.collision import CollisionManager
 
         self.robot = robot
         self.margin = float(margin)
+        self.confirm = bool(confirm)
         self._link = {l.name: l for l in robot.link_list}
         self.names = [n for n in meshes if n in self._link]
         # hull=True: convex-hull proxies (fast, ~2 ms/query) for the live drag
         # check.  hull=False: the ACTUAL meshes -- slower but exact, for the
         # limit sweep (hulls touch at rest and mask collisions that only the
         # real concave geometry develops, giving limits that are too wide).
-        self._hulls = {n: (_hull(meshes[n]) if hull else meshes[n])
+        #
+        # confirm=True: hulls for the cheap BROADPHASE, but every candidate pair
+        # is then verified on the EXACT mesh below -- so the live highlight
+        # reports the same collisions as the exact-mesh limit sweep, instead of
+        # the fatter hulls lighting up red well before the joint reaches its
+        # (mesh-derived) limit.
+        use_hull = hull or self.confirm
+        self._hulls = {n: (_hull(meshes[n]) if use_hull else meshes[n])
                        for n in self.names}
         self.cm = CollisionManager()
         for n in self.names:
             self.cm.add_object(n, self._hulls[n],
                                transform=self._link[n].worldcoords().T())
+        # second manager over the exact meshes, queried pairwise (not as a
+        # broadphase) only on the candidates the hull broadphase flags.
+        self._raw = None
+        if self.confirm:
+            self._raw = CollisionManager()
+            for n in self.names:
+                self._raw.add_object(
+                    n, meshes[n], transform=self._link[n].worldcoords().T())
         self.baseline = self._pairs(0.0)
         for j in robot.joint_list:
             if j.parent_link and j.child_link:
@@ -117,6 +134,24 @@ class SelfCollision:
     def _pairs(self, margin) -> set:
         _, names, data = self.cm.in_collision_internal(
             return_names=True, return_data=True)
+        if self.confirm:
+            # Candidates must be EVERY overlapping hull pair (boolean), not the
+            # depth-thresholded set: the hull penetration depth is NOT a sound
+            # upper bound on the mesh depth (deeply interlocking concave parts
+            # can have only shallow-touching hulls), so filtering candidates by
+            # hull depth would drop real collisions.  Boolean containment (mesh
+            # overlap => hull overlap) is what makes the candidate set complete;
+            # each is then verified on the exact mesh at the real margin.
+            cand = {frozenset(p) for p in names}
+            # new_pairs() subtracts the rest baseline anyway, so don't spend an
+            # exact-mesh query on the dozens of links that touch at rest -- drop
+            # them from the candidates first.  (During __init__, before the
+            # baseline exists, getattr returns None so every pair is verified,
+            # which is exactly what building the baseline needs.)
+            base = getattr(self, "baseline", None)
+            if base:
+                cand = cand - base
+            return self._confirm(cand, margin) if cand else cand
         if margin <= 0:
             return {frozenset(p) for p in names}
         depth = {}
@@ -124,6 +159,32 @@ class SelfCollision:
             k = frozenset(d.names)
             depth[k] = max(depth.get(k, 0.0), abs(d.depth))
         return {k for k, v in depth.items() if v > margin}
+
+    def _confirm(self, cand, margin) -> set:
+        """Keep only the candidate pairs whose EXACT meshes actually collide.  A
+        convex hull is a superset of its mesh, so the hull broadphase never
+        misses a real pair -- it only over-reports, and this verifies that away
+        with one pairwise exact-mesh query per candidate (candidates are few:
+        just the links whose hulls overlap right now)."""
+        import fcl
+        # enough contacts that the true max penetration depth isn't truncated
+        req = fcl.CollisionRequest(num_max_contacts=1000, enable_contact=True)
+        objs = self._raw._objs
+        for n in {n for p in cand for n in p}:        # sync only candidate links
+            self._raw.set_transform(n, self._link[n].worldcoords().T())
+        out = set()
+        for pair in cand:
+            a, b = tuple(pair)
+            res = fcl.CollisionResult()
+            fcl.collide(objs[a]["obj"], objs[b]["obj"], req, res)
+            if margin > 0:
+                hit = max((abs(c.penetration_depth) for c in res.contacts),
+                          default=0.0) > margin
+            else:
+                hit = len(res.contacts) > 0
+            if hit:
+                out.add(pair)
+        return out
 
     def _sync(self):
         for n in self.names:

--- a/sw2robot/editor/ui.py
+++ b/sw2robot/editor/ui.py
@@ -905,7 +905,7 @@ def mount_module(server, state: RobotCompilerState, export_dir: Path):
 
     robot = RobotModelFromURDF(urdf_file=state.urdf_path)
     refresh, handles = render_robot(server, robot)
-    watcher = autoinit.SelfCollision(robot, handles.meshes)
+    watcher = autoinit.SelfCollision(robot, handles.meshes, confirm=True)
     build_gui(server, refresh, handles, watcher, robot, state, export_dir)
     print(f"[sw2robot.ui] mounted '{state.robot_name}': {len(state.joints)} joints "
           f"({len(state.movable_joints())} movable), root={state.root_link}")

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -869,7 +869,10 @@ def _build_collision(urdf_path, key):
         from . import autoinit
         robot = RobotModelFromURDF(urdf_file=urdf_path)
         meshes = autoinit.link_meshes(robot)
-        sc = autoinit.SelfCollision(robot, meshes)
+        # confirm=True: hull broadphase + exact-mesh verification, so the live
+        # red highlight matches the exact-mesh joint-limit sweep (fat hulls
+        # would otherwise light up red before the joint reaches its limit).
+        sc = autoinit.SelfCollision(robot, meshes, confirm=True)
         joints = {}
         for j in robot.joint_list:
             if type(j).__name__ in ("RotationalJoint", "LinearJoint"):


### PR DESCRIPTION
Follow-up to #11.

**Problem reported:** while dragging a joint, the link turns **red before** it reaches the joint limit. The collision judgment wasn't wrong — the **live highlight used convex hulls** (fast) while the **auto joint-limit sweep uses the exact meshes**. A convex hull is fatter than its mesh, so it collides at a smaller angle → red appears before the (mesh-derived) limit.

**Fix:** add a `confirm=True` mode to `autoinit.SelfCollision`. Hulls still do the cheap broadphase, but every candidate pair is then verified on the **exact mesh**, so the live `new_pairs()` reports the same collisions as the sweep. The web editor (`_build_collision`) and the viser GUI both opt in.

### Soundness
Rests on **boolean** hull containment (mesh overlap ⟹ hull overlap), **not** on hull penetration depth — deeply interlocking concave parts can have only shallow-touching hulls, so the candidate set is *every* overlapping hull pair (not depth-filtered). Rest-baseline pairs are dropped before verification (`new_pairs` subtracts them anyway) to keep it interactive.

### Verification
- `confirm == exact-mesh` over **350 poses** on `vial_gripper` (14 joints × 25 angles): **0 mismatches**; the old hull path over-reported in **51** of them (exactly the "red too early" cases).
- An earlier, depth-filtered candidate set was caught under-reporting vs the exact mesh by this same scan — fixed to the boolean candidate set.

### Cost
The live query is ~2× the hull-only path (e.g. `mini_quadrotor` 120 links: ~54ms → ~100ms; `vial_gripper`: 29ms → 72–175ms depending on how deep the collision is). Still interactive, and the red now matches the limit. If it feels sluggish on very large robots we can make it a toggle or add motion-cached verification.

ruff clean; pytest editor suite green (the 3 `test_ros_export` failures are a missing-`pycollada` env issue, unrelated).