### PR TITLE
exporter: portable ROS 2 (ament_cmake) export + package-validity tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,9 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          pip install ".[ui]" pytest
+          # ui -> skrobot (loads the exported URDF + resolves package:// meshes),
+          # test -> catkin_pkg (validates the exported package.xml)
+          pip install ".[ui,test]" pytest
 
       - name: Run tests
         run: pytest -q
@@ -143,3 +145,106 @@ jobs:
       - name: Server log (on failure)
         if: failure()
         run: cat server.log
+
+  # ----- the exported ROS packages must BUILD as real catkin / colcon packages,
+  # not just have the right files.  sw2robot needs Python >=3.12 but the ROS
+  # images ship 3.8 (Noetic) / 3.10 (Humble), so we split: generate the
+  # description packages here (3.12), then build each under its ROS toolchain.
+  ros-pkg-generate:
+    name: generate ROS description packages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install . pycollada    # pycollada: the .dae visual-mesh writer
+
+      - name: Build ROS 1 + ROS 2 <name>_description packages from the example
+        run: |
+          set -e
+          for ver in 1 2; do
+            rm -rf work && cp -r examples/fingertip work
+            flag=$([ "$ver" = 2 ] && echo --ros2 || echo --ros-pkg)
+            python -m sw2robot.exporter.build work \
+              --config work/fingertip.joints.yaml "$flag"
+            # build() writes <name>_description next to the package dir (here ./)
+            mkdir -p artifacts/ros$ver
+            mv fingertip_description artifacts/ros$ver/fingertip_description
+          done
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ros-desc-packages
+          path: artifacts/
+
+  ros1-build:
+    name: catkin build (ROS 1 Noetic)
+    needs: ros-pkg-generate
+    runs-on: ubuntu-latest
+    container: ros:noetic-ros-base
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: ros-desc-packages
+          path: artifacts
+
+      - name: Install catkin_tools + urdf checker
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            python3-catkin-tools liburdfdom-tools
+
+      - name: catkin build + install + check_urdf
+        shell: bash
+        run: |
+          set -e
+          source /opt/ros/noetic/setup.bash
+          mkdir -p ws/src
+          cp -r artifacts/ros1/fingertip_description ws/src/
+          cd ws
+          catkin build --install --no-status     # configures + runs install rules
+          source install/setup.bash
+          # the URDF must parse with ROS's own urdfdom parser
+          check_urdf install/share/fingertip_description/urdf/fingertip.urdf
+          # the install rules must place the package's runtime files
+          test -d install/share/fingertip_description/meshes
+
+  ros2-build:
+    name: colcon build (ROS 2 Humble)
+    needs: ros-pkg-generate
+    runs-on: ubuntu-latest
+    container: ros:humble-ros-base
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: ros-desc-packages
+          path: artifacts
+
+      - name: Install colcon + urdf checker
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            python3-colcon-common-extensions liburdfdom-tools
+
+      - name: colcon build + check_urdf + launch files installed
+        shell: bash
+        run: |
+          set -e
+          source /opt/ros/humble/setup.bash
+          mkdir -p ws/src
+          cp -r artifacts/ros2/fingertip_description ws/src/
+          cd ws
+          colcon build
+          source install/setup.bash
+          check_urdf src/fingertip_description/urdf/fingertip.urdf
+          share=install/fingertip_description/share/fingertip_description
+          test -f "$share/urdf/fingertip.urdf"
+          test -f "$share/launch/display.launch.py"
+          test -f "$share/rviz/fingertip.rviz"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,8 @@ jobs:
           mkdir -p ws/src
           cp -r artifacts/ros1/fingertip_description ws/src/
           cd ws
-          catkin build --install --no-status     # configures + runs install rules
+          catkin config --install     # run the install rules into install/
+          catkin build --no-status
           source install/setup.bash
           # the URDF must parse with ROS's own urdfdom parser
           check_urdf install/share/fingertip_description/urdf/fingertip.urdf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,9 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          pip install . pycollada    # pycollada: the .dae visual-mesh writer
+          # pycollada: the .dae visual-mesh writer; scipy/networkx: trimesh's
+          # mesh-processing deps the converter needs (mirrors build-check)
+          pip install . pycollada scipy networkx
 
       - name: Build ROS 1 + ROS 2 <name>_description packages from the example
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,12 @@ ui = [
     "python-fcl>=0.7",
     "viser",
 ]
+# extra deps the test suite uses to validate exported ROS packages without a ROS
+# install: catkin_pkg parses/validates package.xml the way catkin/colcon do
+# (skrobot, used to load the exported URDF + resolve package:// meshes, is in ui).
+test = [
+    "catkin_pkg",
+]
 
 [project.scripts]
 sw2urdf = "sw2robot.exporter.export:main"     # extract + build (needs SolidWorks)

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -452,12 +452,18 @@
       <div style="color:#8fd99f;font-size:11px;margin-bottom:4px">
         📦 Export</div>
       <div style="display:flex;gap:4px;flex-wrap:wrap;align-items:center">
-        <a id="expdae" href="/api/export/zip?meshes=dae" download>
+        <a id="expdae" href="/api/export/zip?meshes=dae&ros=1" download>
           <button data-i18n="ui.expdae" data-i18n-title="t.expdae"
-                  title="portable ROS package (<name>_description): package://
+                  title="portable ROS 1 (catkin) package (<name>_description): package://
 URLs, visual = colour COLLADA .dae, collision = .stl (loads in RViz/Gazebo)">
-            ⬇ ROS package</button></a>
-        <a id="expglb" href="/api/export/zip?meshes=glb" download>
+            ⬇ ROS1 package</button></a>
+        <a id="expros2" href="/api/export/zip?meshes=dae&ros=2" download>
+          <button data-i18n="ui.expros2" data-i18n-title="t.expros2"
+                  title="portable ROS 2 (ament_cmake) package (<name>_description):
+package:// URLs, .dae/.stl meshes, plus launch/display.launch.py + rviz config
+(run: ros2 launch <name>_description display.launch.py)">
+            ⬇ ROS2 package</button></a>
+        <a id="expglb" href="/api/export/zip?meshes=glb&ros=1" download>
           <button data-i18n-title="t.expglb" title="uniform .glb meshes (colour kept) for three.js /
 skrobot / native-mesh consumers (not RViz-loadable)">⬇ glb</button></a>
       </div>
@@ -876,9 +882,12 @@ skrobot / native-mesh consumers (not RViz-loadable)">⬇ glb</button></a>
     't.selall': { en: 'select all', ja: 'すべて選択' },
     'ui.selectedArrow': { en: 'selected →', ja: '選択 →' },
     'ui.set': { en: 'Set', ja: '適用' },
-    't.expdae': { en: 'portable ROS package (<name>_description): package:// URLs, visual = colour COLLADA .dae, collision = .stl (loads in RViz/Gazebo)',
-                  ja: 'ポータブルな ROS パッケージ (<name>_description): package:// URL、visual = カラー COLLADA .dae、collision = .stl（RViz/Gazebo で読込可）' },
-    'ui.expdae': { en: '⬇ ROS package', ja: '⬇ ROS パッケージ' },
+    't.expdae': { en: 'portable ROS 1 (catkin) package (<name>_description): package:// URLs, visual = colour COLLADA .dae, collision = .stl (loads in RViz/Gazebo)',
+                  ja: 'ポータブルな ROS 1 (catkin) パッケージ (<name>_description): package:// URL、visual = カラー COLLADA .dae、collision = .stl（RViz/Gazebo で読込可）' },
+    'ui.expdae': { en: '⬇ ROS1 package', ja: '⬇ ROS1 パッケージ' },
+    't.expros2': { en: 'portable ROS 2 (ament_cmake) package (<name>_description): package:// URLs, .dae/.stl meshes, plus launch/display.launch.py + rviz config (run: ros2 launch <name>_description display.launch.py)',
+                  ja: 'ポータブルな ROS 2 (ament_cmake) パッケージ (<name>_description): package:// URL、.dae/.stl メッシュ、launch/display.launch.py + rviz 設定付き（実行: ros2 launch <name>_description display.launch.py）' },
+    'ui.expros2': { en: '⬇ ROS2 package', ja: '⬇ ROS2 パッケージ' },
     't.expglb': { en: 'uniform .glb meshes (colour kept) for three.js / skrobot / native-mesh consumers (not RViz-loadable)',
                   ja: '均一な .glb メッシュ（色は保持）three.js / skrobot / ネイティブメッシュ向け（RVizでは読込不可）' },
     'ui.hint': { en: 'left-drag: orbit · right-drag: pan · wheel: zoom · click to select a link · move joints with the panel sliders (🖐 pose ON lets you drag a link to move its joint)',

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -457,13 +457,15 @@ def _read_root_pose(txt):
             float(m.group(1)) if m else 0.0)
 
 
-def _export_zip(pkg_dir, robot_name, mesh_fmt="dae"):
+def _export_zip(pkg_dir, robot_name, mesh_fmt="dae", ros_version=1):
     """ZIP a portable ``<robot_name>_description`` package (package:// URLs).
 
     ``mesh_fmt='dae'`` (default): ``<visual>`` as colour COLLADA ``.dae`` +
     ``<collision>`` as plain ``.stl`` -- the RViz/Gazebo-ready variant.
     ``mesh_fmt='glb'``: a uniform ``.glb`` package (colour kept) for three.js /
-    skrobot / native-mesh consumers (not RViz-loadable)."""
+    skrobot / native-mesh consumers (not RViz-loadable).
+
+    ``ros_version`` (1 = catkin, 2 = ament_cmake) selects the build files."""
     if mesh_fmt not in ("dae", "glb"):
         raise ValueError(f"unsupported mesh format: {mesh_fmt}")
 
@@ -474,7 +476,9 @@ def _export_zip(pkg_dir, robot_name, mesh_fmt="dae"):
     kwargs = {"ctx_fmt": GLB_CTX_FMT} if mesh_fmt == "glb" else {}
     buf = _io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
-        for arc, data in build_ros_description(pkg_dir, robot_name, **kwargs):
+        for arc, data in build_ros_description(pkg_dir, robot_name,
+                                               ros_version=ros_version,
+                                               **kwargs):
             z.writestr(arc, data)
     return buf.getvalue()
 
@@ -1322,7 +1326,13 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 if fmt not in ("dae", "glb"):
                     return self._send_json(
                         {"error": f"unsupported mesh format: {fmt}"}, 400)
-                data = _export_zip(cls.pkg_dir, cls.robot_name, fmt)
+                ros = (query.get("ros") or ["1"])[0]
+                if ros not in ("1", "2"):
+                    return self._send_json(
+                        {"error": f"unsupported ros version: {ros}"}, 400)
+                ros_version = int(ros)
+                data = _export_zip(cls.pkg_dir, cls.robot_name, fmt,
+                                   ros_version=ros_version)
                 fname = (f"{cls.robot_name}_glb.zip" if fmt == "glb"
                          else f"{cls.robot_name}_description.zip")
                 self.send_response(200)

--- a/sw2robot/exporter/build.py
+++ b/sw2robot/exporter/build.py
@@ -1,6 +1,6 @@
 """CLI: build URDF from a cached graph.json (fast, no SolidWorks).
 
-    uv run python -m sw2robot.exporter.build <pkg_dir> [--config c.yaml] [--base S] [--exclude a,b] [--ros-pkg]
+    uv run python -m sw2robot.exporter.build <pkg_dir> [--config c.yaml] [--base S] [--exclude a,b] [--ros-pkg] [--ros2]
 """
 from __future__ import annotations
 
@@ -16,10 +16,14 @@ def main():
     ap.add_argument("--base", default=None)
     ap.add_argument("--exclude", default=None)
     ap.add_argument("--ros-pkg", action="store_true")
+    ap.add_argument("--ros2", action="store_true",
+                    help="make --ros-pkg an ament_cmake (ROS 2) package with "
+                         "launch/ + rviz/ instead of catkin; implies --ros-pkg")
     args = ap.parse_args()
     exclude = [x.strip() for x in args.exclude.split(",")] if args.exclude else None
     build(args.pkg_dir, config_path=args.config, base_hint=args.base,
-          exclude=exclude, ros_pkg=args.ros_pkg)
+          exclude=exclude, ros_pkg=args.ros_pkg or args.ros2,
+          ros_version=2 if args.ros2 else 1)
 
 
 if __name__ == "__main__":

--- a/sw2robot/exporter/export.py
+++ b/sw2robot/exporter/export.py
@@ -140,7 +140,7 @@ def extract(assembly_path, out_dir=None, robot_name=None, visible=False,
 
 # ---------------------------------------------------------------- build
 def build(pkg_dir, config_path=None, base_hint=None, exclude=None,
-          ros_pkg=False, density=None):
+          ros_pkg=False, density=None, ros_version=1):
     graph = GraphState.load(os.path.join(pkg_dir, GRAPH_FILE))
     robot_name = graph.robot_name
     urdf_path = os.path.join(pkg_dir, "urdf", robot_name + ".urdf")
@@ -171,15 +171,17 @@ def build(pkg_dir, config_path=None, base_hint=None, exclude=None,
     desc_dir = None
     if ros_pkg:
         # a standalone <robot_name>_description package next to pkg_dir:
-        # package:// URLs + COLLADA .dae meshes (RViz/Gazebo-ready)
+        # package:// URLs + COLLADA .dae meshes (RViz/Gazebo-ready).
+        # ros_version 2 also bundles launch/ + rviz/ for `ros2 launch`.
         from .ros_export import write_ros_description_package
         desc_dir = write_ros_description_package(
-            pkg_dir, robot_name, os.path.dirname(os.path.abspath(pkg_dir)))
+            pkg_dir, robot_name, os.path.dirname(os.path.abspath(pkg_dir)),
+            ros_version=ros_version)
 
     print(f"\nDONE. Package: {pkg_dir}")
     print(f"  URDF:   {urdf_path}")
     if desc_dir:
-        print(f"  ROS pkg: {desc_dir}  (package:// + .dae)")
+        print(f"  ROS pkg: {desc_dir}  (ROS {ros_version}, package:// + .dae)")
     if not config_path:
         print(f"  Config: {tmpl}  (edit, re-run: "
               "python -m sw2robot.exporter.build with --config)")
@@ -189,10 +191,11 @@ def build(pkg_dir, config_path=None, base_hint=None, exclude=None,
 
 # ---------------------------------------------------------------- export
 def export(assembly_path, out_dir=None, robot_name=None, visible=False,
-           config_path=None, base_hint=None, exclude=None, ros_pkg=False):
+           config_path=None, base_hint=None, exclude=None, ros_pkg=False,
+           ros_version=1):
     pkg_dir = extract(assembly_path, out_dir, robot_name, visible)
     return build(pkg_dir, config_path=config_path, base_hint=base_hint,
-                 exclude=exclude, ros_pkg=ros_pkg)
+                 exclude=exclude, ros_pkg=ros_pkg, ros_version=ros_version)
 
 
 def _exclude_list(s):
@@ -212,10 +215,16 @@ def main():
                     help="also write a portable <name>_description package "
                          "(package:// URLs + COLLADA .dae meshes) next to the "
                          "output; the working URDF stays mesh-relative")
+    ap.add_argument("--ros2", action="store_true",
+                    help="make the --ros-pkg an ament_cmake (ROS 2) package "
+                         "with launch/ + rviz/ instead of catkin (ROS 1); "
+                         "implies --ros-pkg")
     args = ap.parse_args()
     export(args.assembly, args.out, args.name, args.visible,
            config_path=args.config, base_hint=args.base,
-           exclude=_exclude_list(args.exclude), ros_pkg=args.ros_pkg)
+           exclude=_exclude_list(args.exclude),
+           ros_pkg=args.ros_pkg or args.ros2,
+           ros_version=2 if args.ros2 else 1)
 
 
 if __name__ == "__main__":

--- a/sw2robot/exporter/ros_export.py
+++ b/sw2robot/exporter/ros_export.py
@@ -24,7 +24,14 @@ from __future__ import annotations
 import os
 import xml.etree.ElementTree as ET
 
-from .urdf_writer import CMAKELISTS, PACKAGE_XML
+from .urdf_writer import (
+    CMAKELISTS,
+    CMAKELISTS_ROS2,
+    DISPLAY_LAUNCH_ROS2,
+    PACKAGE_XML,
+    PACKAGE_XML_ROS2,
+    RVIZ_CONFIG_ROS2,
+)
 
 # extensions we convert; anything else (already .dae/.stl, abs URLs) is left alone
 _CONVERTIBLE = (".3dxml", ".glb")
@@ -144,7 +151,7 @@ def _resolve_mesh(pkg_dir, ref):
 
 
 def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
-                          ctx_fmt=_CTX_FMT):
+                          ctx_fmt=_CTX_FMT, ros_version=1):
     """``pkg_dir`` (a built package) -> ``[(arcname, bytes), ...]`` for a portable
     ``<robot_name>_description`` ROS package, all behind ``package://`` URLs.
 
@@ -152,9 +159,17 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
     ``<visual>`` as colour ``.dae`` and ``<collision>`` as plain ``.stl`` (the
     usual ROS split).  Pass :data:`GLB_CTX_FMT` for a uniform ``.glb`` package.
 
+    ``ros_version`` picks the build system: ``1`` (default) writes a catkin
+    ``package.xml`` (format 2) + ``CMakeLists.txt``; ``2`` writes an ament_cmake
+    ``package.xml`` (format 3) + ``CMakeLists.txt`` and bundles a
+    ``launch/display.launch.py`` + ``rviz/<name>.rviz`` so the package runs with
+    ``ros2 launch <name> display.launch.py``.
+
     Reads the on-disk ``urdf/<robot_name>.urdf`` (which already carries the
     editor's applied edits).  A missing/unconvertible mesh aborts the export
     before any entries are emitted, so a half-rewritten package never ships."""
+    if ros_version not in (1, 2):
+        raise ValueError(f"unsupported ros_version: {ros_version}")
     pkg = f"{robot_name}_description"
     urdf_path = os.path.join(pkg_dir, "urdf", robot_name + ".urdf")
     root = ET.parse(urdf_path).getroot()
@@ -196,18 +211,38 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
     if not new_urdf.endswith("\n"):
         new_urdf += "\n"
     files.append((f"{pkg}/urdf/{robot_name}.urdf", new_urdf.encode("utf-8")))
-    files.append((f"{pkg}/package.xml",
-                  PACKAGE_XML.format(name=pkg, email=email).encode("utf-8")))
-    files.append((f"{pkg}/CMakeLists.txt",
-                  CMAKELISTS.format(name=pkg).encode("utf-8")))
+
+    if ros_version == 2:
+        # the root (first) link is the natural RViz fixed frame
+        first_link = root.find("link")
+        fixed_frame = (first_link.get("name") if first_link is not None
+                       else "base_link") or "base_link"
+        files.append((f"{pkg}/package.xml",
+                      PACKAGE_XML_ROS2.format(name=pkg, email=email)
+                      .encode("utf-8")))
+        files.append((f"{pkg}/CMakeLists.txt",
+                      CMAKELISTS_ROS2.format(name=pkg).encode("utf-8")))
+        files.append((f"{pkg}/launch/display.launch.py",
+                      DISPLAY_LAUNCH_ROS2.format(name=pkg, robot=robot_name)
+                      .encode("utf-8")))
+        files.append((f"{pkg}/rviz/{robot_name}.rviz",
+                      RVIZ_CONFIG_ROS2.format(fixed_frame=fixed_frame)
+                      .encode("utf-8")))
+    else:
+        files.append((f"{pkg}/package.xml",
+                      PACKAGE_XML.format(name=pkg, email=email).encode("utf-8")))
+        files.append((f"{pkg}/CMakeLists.txt",
+                      CMAKELISTS.format(name=pkg).encode("utf-8")))
     return files
 
 
 def write_ros_description_package(pkg_dir, robot_name, dest_dir,
-                                  email="auto@example.com"):
+                                  email="auto@example.com", ros_version=1):
     """Write the ``<robot_name>_description`` package under ``dest_dir`` and return
-    its directory path."""
-    files = build_ros_description(pkg_dir, robot_name, email=email)
+    its directory path.  ``ros_version`` (1 = catkin, 2 = ament_cmake) is passed
+    through to :func:`build_ros_description`."""
+    files = build_ros_description(pkg_dir, robot_name, email=email,
+                                  ros_version=ros_version)
     root = os.path.abspath(dest_dir)
     for arc, data in files:
         dst = os.path.join(root, *arc.split("/"))

--- a/sw2robot/exporter/urdf_writer.py
+++ b/sw2robot/exporter/urdf_writer.py
@@ -242,6 +242,104 @@ install(DIRECTORY urdf meshes
   DESTINATION ${{CATKIN_PACKAGE_SHARE_DESTINATION}})
 """
 
+# --- ROS 2 (ament_cmake) variants -------------------------------------------
+# Same description-package layout, but a format-3 manifest + ament_cmake build,
+# plus a ready-to-run display launch file and an RViz config so the package is
+# usable straight away: `ros2 launch <name> display.launch.py`.
+PACKAGE_XML_ROS2 = """<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>{name}</name>
+  <version>0.0.1</version>
+  <description>URDF generated from SolidWorks assembly {name}</description>
+  <maintainer email="{email}">auto</maintainer>
+  <license>TODO</license>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
+  <exec_depend>rviz2</exec_depend>
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>
+"""
+
+CMAKELISTS_ROS2 = """cmake_minimum_required(VERSION 3.8)
+project({name})
+find_package(ament_cmake REQUIRED)
+install(DIRECTORY urdf meshes launch rviz
+  DESTINATION share/${{PROJECT_NAME}})
+ament_package()
+"""
+
+# {name} = package name, {robot} = urdf file stem.  Reads the plain URDF (not
+# xacro) and brings up robot_state_publisher + joint_state_publisher_gui + RViz.
+DISPLAY_LAUNCH_ROS2 = '''import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    pkg = get_package_share_directory("{name}")
+    urdf = os.path.join(pkg, "urdf", "{robot}.urdf")
+    with open(urdf) as f:
+        robot_description = f.read()
+    rviz = os.path.join(pkg, "rviz", "{robot}.rviz")
+    return LaunchDescription([
+        Node(
+            package="robot_state_publisher",
+            executable="robot_state_publisher",
+            output="screen",
+            parameters=[{{"robot_description": robot_description}}],
+        ),
+        Node(
+            package="joint_state_publisher_gui",
+            executable="joint_state_publisher_gui",
+            output="screen",
+        ),
+        Node(
+            package="rviz2",
+            executable="rviz2",
+            output="screen",
+            arguments=["-d", rviz],
+        ),
+    ])
+'''
+
+# A minimal RViz2 config so the robot shows up immediately (RobotModel from the
+# /robot_description topic, TF, grid).  {fixed_frame} = the root link name.
+RVIZ_CONFIG_ROS2 = """Panels:
+  - Class: rviz_common/Displays
+    Name: Displays
+Visualization Manager:
+  Displays:
+    - Class: rviz_default_plugins/Grid
+      Enabled: true
+      Name: Grid
+    - Class: rviz_default_plugins/RobotModel
+      Enabled: true
+      Name: RobotModel
+      Description Topic:
+        Value: /robot_description
+    - Class: rviz_default_plugins/TF
+      Enabled: true
+      Name: TF
+  Global Options:
+    Fixed Frame: {fixed_frame}
+    Frame Rate: 30
+  Tools:
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/Select
+  Views:
+    Current:
+      Class: rviz_default_plugins/Orbit
+      Name: Current View
+"""
+
 
 def write_ros_package(model, pkg_dir, email="auto@example.com"):
     with open(os.path.join(pkg_dir, "package.xml"), "w", encoding="utf-8") as f:

--- a/tests/test_ros_export.py
+++ b/tests/test_ros_export.py
@@ -96,6 +96,57 @@ def test_build_ros_description_layout(tmp_path):
             assert len(m.faces) > 0
 
 
+def test_build_ros2_description_layout(tmp_path):
+    """ros_version=2 emits an ament_cmake manifest + launch + rviz, on top of
+    the same package:// URDF and converted meshes."""
+    from sw2robot.exporter.ros_export import build_ros_description
+
+    pkg_dir = _make_pkg(tmp_path, robot="fing")
+    files = dict(build_ros_description(pkg_dir, "fing", ros_version=2))
+    arcs = set(files)
+
+    # same description payload as ROS 1
+    assert "fing_description/urdf/fing.urdf" in arcs
+    assert "fing_description/meshes/part.dae" in arcs
+    assert "fing_description/meshes/part.stl" in arcs
+    urdf = files["fing_description/urdf/fing.urdf"].decode()
+    assert "package://fing_description/meshes/part.dae" in urdf
+
+    # ROS 2 specific files
+    assert "fing_description/launch/display.launch.py" in arcs
+    assert "fing_description/rviz/fing.rviz" in arcs
+
+    pxml = files["fing_description/package.xml"].decode()
+    assert 'format="3"' in pxml
+    assert "<buildtool_depend>ament_cmake</buildtool_depend>" in pxml
+    assert "<build_type>ament_cmake</build_type>" in pxml
+
+    cmake = files["fing_description/CMakeLists.txt"].decode()
+    assert "find_package(ament_cmake REQUIRED)" in cmake
+    assert "ament_package()" in cmake
+    assert "launch rviz" in cmake
+
+    launch = files["fing_description/launch/display.launch.py"].decode()
+    assert "robot_state_publisher" in launch
+    assert 'get_package_share_directory("fing_description")' in launch
+    # the launch python must be syntactically valid
+    compile(launch, "display.launch.py", "exec")
+
+    rviz = files["fing_description/rviz/fing.rviz"].decode()
+    assert "RobotModel" in rviz
+    assert "Fixed Frame: base_link" in rviz   # the urdf's first link
+
+
+def test_invalid_ros_version_rejected(tmp_path):
+    import pytest
+
+    from sw2robot.exporter.ros_export import build_ros_description
+
+    pkg_dir = _make_pkg(tmp_path, robot="r")
+    with pytest.raises(ValueError, match="ros_version"):
+        build_ros_description(pkg_dir, "r", ros_version=3)
+
+
 def test_glb_ctx_exports_uniform_glb(tmp_path):
     import io
     import xml.etree.ElementTree as ET
@@ -170,6 +221,58 @@ def test_texture_glb_colours_become_collada_materials(tmp_path):
     dae = trimesh.load(io.BytesIO(data), file_type="dae")
     assert isinstance(dae, trimesh.Scene)
     assert len(dae.geometry) > 1
+
+
+def _write_desc(tmp_path, robot="fing", ros_version=1):
+    """Write a real ``<robot>_description`` package to disk (the on-disk form ROS
+    tooling sees) and return its directory."""
+    from sw2robot.exporter.ros_export import write_ros_description_package
+
+    src = tmp_path / "src"
+    src.mkdir()
+    pkg_dir = _make_pkg(src, robot=robot)
+    return write_ros_description_package(pkg_dir, robot, str(tmp_path / "out"),
+                                         ros_version=ros_version)
+
+
+@pytest.mark.parametrize("ros_version, fmt, build_type",
+                         [(1, 2, "catkin"), (2, 3, "ament_cmake")])
+def test_package_xml_is_a_valid_ros_manifest(tmp_path, ros_version, fmt,
+                                             build_type):
+    """The manifest parses + validates under ``catkin_pkg`` -- the same parser
+    catkin / colcon use -- not just a string match.  ``parse_package`` validates
+    on read, so a malformed package.xml (bad format/build_type, illegal name or
+    email, missing required tag) raises ``InvalidPackage`` and fails the test."""
+    cp = pytest.importorskip("catkin_pkg.package")
+
+    desc = _write_desc(tmp_path, "fing", ros_version)
+    pkg = cp.parse_package(os.path.join(desc, "package.xml"))   # validates here
+
+    assert pkg.name == "fing_description"
+    assert pkg.package_format == fmt
+    assert pkg.get_build_type() == build_type
+    exec_deps = {d.name for d in pkg.exec_depends}
+    assert "robot_state_publisher" in exec_deps
+
+
+@pytest.mark.parametrize("ros_version", [1, 2])
+def test_urdf_loads_in_skrobot_with_package_meshes_resolved(tmp_path,
+                                                            ros_version):
+    """The package loads as a real robot: skrobot parses the URDF into a link
+    tree and resolves every ``package://`` mesh to a file with geometry.  No ROS
+    environment is needed -- skrobot walks up from the urdf dir to find the
+    sibling package -- so this guards URDF validity + mesh wiring in plain CI."""
+    pytest.importorskip("skrobot")
+    from skrobot.models.urdf import RobotModelFromURDF
+
+    desc = _write_desc(tmp_path, "fing", ros_version)
+    robot = RobotModelFromURDF(urdf_file=os.path.join(desc, "urdf", "fing.urdf"))
+
+    assert "base_link" in [link.name for link in robot.link_list]
+    vms = robot.link_list[0].visual_mesh
+    vms = vms if isinstance(vms, (list, tuple)) else [vms]
+    faces = sum(len(m.faces) for m in vms if hasattr(m, "faces"))
+    assert faces > 0, "package:// visual mesh did not resolve to real geometry"
 
 
 def test_missing_mesh_aborts_instead_of_half_broken_package(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,22 @@ wheels = [
 ]
 
 [[package]]
+name = "catkin-pkg"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "packaging" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/7a/dcd7ba56dc82d88b3059a6770828388fc2e136ca4c5d79003f9febf33087/catkin_pkg-1.1.0.tar.gz", hash = "sha256:df1cb6879a3a772e770a100a6613ce8fc508b4855e5b2790106ddad4a8beb43c", size = 65547, upload-time = "2025-09-10T17:34:36.911Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/1b/50316bd6f95c50686b35799abebb6168d90ee18b7c03e3065f587f010f7c/catkin_pkg-1.1.0-py3-none-any.whl", hash = "sha256:7f5486b4f5681b5f043316ce10fc638c8d0ba8127146e797c85f4024e4356027", size = 76369, upload-time = "2025-09-10T17:34:35.639Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.5.20"
 source = { registry = "https://pypi.org/simple" }
@@ -139,6 +155,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/82/71/8b528247e42ee63cbe1c1d53805d30b28663fa782c88da4a9b69a1a412dd/cython-3.2.5-cp39-abi3-win32.whl", hash = "sha256:0bc29c7f870b09efdb1f583fbec9592b33af81a7ce273b89c8f5163d7572d5c1", size = 2440395, upload-time = "2026-05-23T19:35:33.082Z" },
     { url = "https://files.pythonhosted.org/packages/50/4d/81c91d3279d156ee2c9ead7ed9eaa862e498066d759e92fb83d0d842c5a7/cython-3.2.5-cp39-abi3-win_arm64.whl", hash = "sha256:85b2944c3eddfc230f9082720195a2e9f869908e5a8b3185be1be832755ee7fc", size = 2446963, upload-time = "2026-05-23T19:35:35.267Z" },
     { url = "https://files.pythonhosted.org/packages/d4/5c/9cd909e6a8bb178e4e0f9a2a9227c8201a2be38abe45ada4a4c3e9154277/cython-3.2.5-py3-none-any.whl", hash = "sha256:dc1c8cebb7df5bce37f5f8dc1e5bf04313272a5973d50a55c0ec76c83812911b", size = 1257622, upload-time = "2026-05-23T19:34:05.163Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.23"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/a4/5180d9afc57e8fca05601dd652bdff19604c218814037fe90ffc7625a50a/docutils-0.23.tar.gz", hash = "sha256:746f5060322511280a1e50eb76846ed6bf2342984b2ac04dc42caa1a8d78799e", size = 2303823, upload-time = "2026-05-27T17:41:06.934Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/91/30151a39f7570f448ed84529390628a651d7f27c87d73c9b887f8189695e/docutils-0.23-py3-none-any.whl", hash = "sha256:25d013af9bf23bc1c7b2b093dff4208166c53a94786c9e447808335ef1185fea", size = 634701, upload-time = "2026-05-27T17:40:58.442Z" },
 ]
 
 [[package]]
@@ -665,6 +690,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
 name = "pysdfgen"
 version = "0.2.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1013,6 +1047,15 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1023,7 +1066,7 @@ wheels = [
 
 [[package]]
 name = "sw2robot"
-version = "0.1.0"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "lxml" },
@@ -1035,6 +1078,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+test = [
+    { name = "catkin-pkg" },
+]
 ui = [
     { name = "python-fcl" },
     { name = "scikit-robot" },
@@ -1043,6 +1089,7 @@ ui = [
 
 [package.metadata]
 requires-dist = [
+    { name = "catkin-pkg", marker = "extra == 'test'" },
     { name = "lxml" },
     { name = "numpy", specifier = ">=2" },
     { name = "pydantic", specifier = ">=2" },
@@ -1053,7 +1100,7 @@ requires-dist = [
     { name = "trimesh", specifier = ">=3.9" },
     { name = "viser", marker = "extra == 'ui'" },
 ]
-provides-extras = ["ui"]
+provides-extras = ["ui", "test"]
 
 [[package]]
 name = "threadpoolctl"


### PR DESCRIPTION
## What

Adds a **ROS 2 (ament_cmake)** variant of the `<name>_description` export next to
the existing catkin one, and — the main ask — makes CI prove the exported
packages actually **function as ROS packages**, not just that the files exist.

### ROS 2 export
- `package.xml` (format 3) + ament_cmake `CMakeLists.txt`
- `launch/display.launch.py` + `rviz/<name>.rviz`, so it runs straight away:
  `ros2 launch <name>_description display.launch.py`
- same `package://` URDF + `.dae`/`.stl` mesh split as ROS 1
- exposed everywhere the ROS 1 export is: editor **⬇ ROS2 package** download
  (`/api/export/zip?ros=2`), CLI `--ros2`, and
  `build()` / `write_ros_description_package(ros_version=2)`

### Tests — "does it work as a package?"
Two tiers:

**Tier 1 — pure Python, runs in the normal pytest/CI (no ROS needed)**
- `package.xml` parses + validates under `catkin_pkg` (the same parser
  catkin/colcon use) — a malformed manifest raises and fails the test.
- the exported URDF loads in **skrobot** with every `package://` mesh resolved
  to real geometry (skrobot walks up from the urdf dir, so no ROS env required).

**Tier 2 — real build in ROS Docker images**
- generate the `<name>_description` packages (Python 3.12) and build them for
  real: `catkin build` on **Noetic**, `colcon build` on **Humble**.
- each followed by `check_urdf` (ROS's own urdfdom parser) and an
  install-layout check (`share/<pkg>/{urdf,meshes,launch,rviz}`).

A description package compiles nothing, so the ROS jobs are seconds of CMake
configure + file install; the wall-clock is mostly image pull + apt.

## Why
These export paths are easy to break silently while iterating. Tier 1 catches
manifest/URDF/mesh-wiring regressions on every PR; Tier 2 guarantees the result
still builds under the actual ROS toolchains.
