### PR TITLE
exporter/editor: fix CO_E_OBJNOTCONNECTED (create SolidWorks on the use thread)

### DIFF
--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -779,13 +779,15 @@ _sw = {"sess": None}
 def _warm_sw(progress):
     sess = _sw["sess"]
     if sess is not None:
-        from sw2robot.exporter.swcom import safe_prop
         progress("checking the warm SolidWorks session (an idle session "
                  "can take a moment to respond) ...")
         t0 = time.time()
         for attempt in (1, 2, 3):    # transient RPC-busy is not death
-            alive = sess.app is not None \
-                and safe_prop(sess.app, "Visible") is not None
+            # _responds() makes a REAL call, so it catches a disconnected proxy
+            # (CO_E_OBJNOTCONNECTED) -- e.g. a session whose creating thread has
+            # ended -- which a bare Visible read can miss.  A dead one is dropped
+            # and the caller starts a fresh instance on the current thread.
+            alive = sess.app is not None and sess._responds()
             if alive:
                 progress(f"warm session is alive ✓ (responded in "
                          f"{time.time() - t0:.1f}s)")
@@ -801,35 +803,6 @@ def _warm_sw(progress):
     return None
 
 
-def _start_sw_session(progress, timeout=300):
-    """Start a fresh hidden SolidWorks, but never hang forever: if the launch
-    has not finished within ``timeout`` s -- the classic symptom of an
-    unreachable license server, where SolidWorks sits waiting on a license it
-    cannot get -- stop with a clear warning instead of blocking the job
-    indefinitely.  A timed-out launch thread is left to die on its own; the
-    next extraction starts clean (no session is cached)."""
-    from sw2robot.exporter.swcom import SolidWorks, SolidWorksUnavailable
-    box = {}
-
-    def work():
-        try:
-            box["sw"] = SolidWorks(visible=False)
-        except BaseException as e:       # carry the failure to the caller
-            box["err"] = e
-
-    th = threading.Thread(target=work, daemon=True)
-    th.start()
-    th.join(timeout)
-    if th.is_alive():
-        raise SolidWorksUnavailable(
-            f"SolidWorks did not start within {timeout}s -- the license "
-            f"server is almost certainly unreachable. Stopping. Restart the "
-            f"extraction once SolidWorks can acquire a license.")
-    if "err" in box:
-        raise box["err"]
-    return box["sw"]
-
-
 def _keepalive_loop():
     """Ping the warm session once a minute while idle, so Windows doesn't
     page it out and the next extraction starts instantly.
@@ -839,7 +812,6 @@ def _keepalive_loop():
     full relaunch on the next extraction (~20 s) and leaves the old
     process behind as a zombie.  Declare death only after 3 consecutive
     failures, and then try to shut the process down for real."""
-    from sw2robot.exporter.swcom import safe_prop
     fails = 0
     while True:
         time.sleep(60)
@@ -849,8 +821,7 @@ def _keepalive_loop():
             continue
         alive = False
         try:
-            alive = sess.app is not None \
-                and safe_prop(sess.app, "Visible") is not None
+            alive = sess.app is not None and sess._responds()
         except Exception:
             alive = False
         if alive:
@@ -927,9 +898,14 @@ def _run_extract(sldasm):
                  f"(the original is never modified)")
         sw = _warm_sw(progress)
         if sw is None:
+            from sw2robot.exporter.swcom import SolidWorks
             progress("starting SolidWorks (this can take a minute; later "
                      "extractions reuse this session) ...")
-            sw = _start_sw_session(progress)   # bounded; warns if it can't start
+            # Create the COM object in THIS thread.  SolidWorks is STA-bound:
+            # an instance built on another thread (e.g. a timeout worker) loses
+            # its apartment when that thread ends, so OpenDoc6 then fails with
+            # CO_E_OBJNOTCONNECTED ("object not connected to server").
+            sw = SolidWorks(visible=False)
             _sw["sess"] = sw
         state = core.extract_and_import(
             sldasm, out_dir=_Handler.root_dir, progress=progress, sw=sw)

--- a/sw2robot/exporter/swcom.py
+++ b/sw2robot/exporter/swcom.py
@@ -274,18 +274,26 @@ class SolidWorks:
         try:
             self.app = win32com.client.gencache.EnsureDispatch(
                 "SldWorks.Application")
-        except Exception as e:
-            print(f"  [swcom] EnsureDispatch (early binding) failed: {e!r}")
+        except Exception:
+            # benign here: with the typelib loaded (ensure_typelibs) the dynamic
+            # object still resolves OpenDoc6 et al.  Only the frozen build, where
+            # makepy can't generate, ends up genuinely late-bound -- handled next.
             self.app = win32com.client.Dispatch("SldWorks.Application")
-        # A LATE-bound object (the EnsureDispatch fallback, common in a frozen
-        # build) cannot reach typelib-only methods like OpenDoc6.  Upgrade the
-        # live object to an early-bound wrapper now that gencache is writable.
+        # A LATE-bound object that lacks OpenDoc6 cannot reach typelib-only
+        # methods (the frozen-exe failure).  Force-generate the wrapper now that
+        # gencache is writable and upgrade the live object to early binding.
         if not hasattr(self.app, "OpenDoc6"):
+            print("  [swcom] dispatch is late-bound (no OpenDoc6); generating "
+                  "the typelib wrapper ...")
             try:
                 _prepare_gencache()
                 self.app = win32com.client.gencache.EnsureDispatch(self.app)
             except Exception as e:
                 print(f"  [swcom] could not upgrade to early binding: {e!r}")
+            if not hasattr(self.app, "OpenDoc6"):
+                print("  [swcom] WARNING: OpenDoc6 still unavailable -- makepy "
+                      "could not generate the typelib wrapper (frozen build "
+                      "with no writable gen_py?)")
         try:
             self.app.Visible = visible
         except Exception:

--- a/tests/test_sw_unavailable.py
+++ b/tests/test_sw_unavailable.py
@@ -1,19 +1,12 @@
-"""SolidWorks connection robustness: warn + stop instead of hanging or wedging.
+"""SolidWorks connection robustness.
 
-When SolidWorks cannot be reached -- not running, or (most often) launched but
-unable to check out a license because the license server is down -- the
-extractor must surface a clear ``SolidWorksUnavailable`` and never cache a dead
-instance, so retries recover the moment the license is back.  The webserver's
-launch is also time-bounded so an unreachable license server stops the job with
-a warning rather than blocking forever.
+A dead/unresponsive SolidWorks COM proxy (an instance that can't check out a
+license, or a warm session whose creating thread has ended ->
+CO_E_OBJNOTCONNECTED) must be detected via a REAL call and dropped, never
+reused, so the next extraction starts a fresh instance and recovers.
 """
 
-import time
-
-import pytest
-
-from sw2robot.exporter import swcom
-from sw2robot.exporter.swcom import SolidWorks, SolidWorksUnavailable
+from sw2robot.exporter.swcom import SolidWorks
 
 
 class _AliveApp:
@@ -44,29 +37,14 @@ def test_responds_false_for_a_dead_app():
     assert _bare(None)._responds() is False
 
 
-def test_start_session_times_out_with_a_warning(monkeypatch):
-    """A launch that never returns (license server hung) must stop promptly
-    with SolidWorksUnavailable, not wait out the whole hang."""
+def test_warm_session_dropped_when_proxy_is_disconnected(monkeypatch):
+    """A warm session whose COM proxy is disconnected (e.g. its creating thread
+    ended -> CO_E_OBJNOTCONNECTED) must be detected as NOT alive, so the server
+    starts a fresh instance instead of reusing a dead one."""
     from sw2robot.editor import webserver
 
-    class _Hang:
-        def __init__(self, *a, **k):
-            time.sleep(30)
-
-    monkeypatch.setattr(swcom, "SolidWorks", _Hang)
-    t0 = time.time()
-    with pytest.raises(SolidWorksUnavailable):
-        webserver._start_sw_session(lambda _m: None, timeout=1)
-    assert time.time() - t0 < 5, "did not stop promptly on a hung launch"
-
-
-def test_start_session_propagates_launch_failure(monkeypatch):
-    from sw2robot.editor import webserver
-
-    class _Fail:
-        def __init__(self, *a, **k):
-            raise SolidWorksUnavailable("no license")
-
-    monkeypatch.setattr(swcom, "SolidWorks", _Fail)
-    with pytest.raises(SolidWorksUnavailable):
-        webserver._start_sw_session(lambda _m: None, timeout=5)
+    monkeypatch.setattr(webserver.time, "sleep", lambda *_: None)  # no retry wait
+    monkeypatch.setitem(webserver._sw, "sess", _bare(_DeadApp()))
+    got = webserver._warm_sw(lambda _m: None)
+    assert got is None, "a disconnected warm session must not be reused"
+    assert webserver._sw["sess"] is None


### PR DESCRIPTION
Hotfix: the STA-threading fix (`b6a933c`) was orphaned when PR #21 auto-merged on the first commit before this was pushed. It must land before the 0.1.6 release.

Extraction failed with `com_error -2147220995` (object not connected to server) at OpenDoc6: the earlier change started SolidWorks on a short-lived timeout worker thread and handed it to the extract thread; SolidWorks COM is STA-bound, so the proxy disconnected when the worker ended. Now the instance is created inline on the extract thread (verified: OpenDoc6 succeeds), the worker-thread launcher is removed, and warm/keepalive liveness uses a real call so a disconnected proxy is dropped, not reused.