### PR TITLE
Real link inertials + simpler, portable open flow

### DIFF
--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -266,7 +266,7 @@
 </script>
 </head>
 <body>
-<div id="droptip" data-i18n="ui.droptip">drop a module folder or a .sldasm here</div>
+<div id="droptip" data-i18n="ui.droptip">drop a package folder here (for a .sldasm use 🗄)</div>
 <div id="app">
   <div id="viewwrap">
     <urdf-manipulator id="viewer" up="Z" highlight-color="#ffb86b">
@@ -330,11 +330,19 @@
          flex-direction:column">
       <div style="display:flex;gap:6px;align-items:center;margin-bottom:6px">
         <button id="fsup">⬆</button>
-        <span id="fspath" style="flex:1;font-size:11px;color:#8a93a3;
-              overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
-              direction:rtl;text-align:left"></span>
+        <input id="fspath" data-i18n-ph="t.fspathPh"
+               placeholder="フルパスを貼り付け / 編集して Enter"
+               style="flex:1;font-size:11px;color:#cdd;background:#0e1216;
+               border:1px solid #345;border-radius:4px;padding:4px 6px;
+               min-width:0">
+        <button id="fsgo" data-i18n-title="t.fsgo" title="このパスを開く / 移動">↵</button>
         <button id="fsclose">✕</button>
       </div>
+      <input id="fsfilter" data-i18n-ph="t.fsfilterPh"
+             placeholder="このフォルダ内を絞り込み…"
+             style="font-size:11px;color:#cdd;background:#0e1216;
+             border:1px solid #345;border-radius:4px;padding:4px 6px;
+             margin-bottom:6px">
       <div id="fslist" style="overflow-y:auto;font-size:12.5px"></div>
     </div>
     <div id="loadbackdrop" style="position:absolute;inset:0;z-index:6;
@@ -401,20 +409,13 @@
         🎯 Extract the assembly open in SolidWorks</button>
       <div id="swstat" style="font-size:11px;color:#8a93a3"></div>
       <div style="display:flex;gap:4px">
-        <button id="openfile" style="flex:1" data-i18n="ui.openfile"
-                data-i18n-title="t.openfile"
-                title="OSのファイルダイアログ (.sldasm / .urdf)">
-          📄 ファイルを開く…</button>
-        <button id="openfolder" style="flex:1" data-i18n="ui.openfolder"
-                data-i18n-title="t.openfolder"
-                title="OSのフォルダダイアログ (パッケージフォルダ)">
-          📁 フォルダ…</button>
-        <button id="fsbrowse" data-i18n-title="t.fsbrowse"
-                title="サーバー側のファイルブラウザ (ダイアログで見つからない時)">
-          🗄</button>
+        <button id="fsbrowse" style="flex:1" data-i18n-title="t.fsbrowse"
+                title="サーバー側のファイルブラウザ（最近のファイル＋フルパス貼り付け）">
+          🗄 開く…</button>
       </div>
-      <input id="openfileinput" type="file" accept=".sldasm,.SLDASM,.urdf"
-             style="display:none">
+      <!-- folder-upload kept for later (no visible button): a package folder
+           can still be dropped onto the page; this hidden directory picker is
+           wired to handleDrop so a button can re-enable dialog upload anytime -->
       <input id="openfolderinput" type="file" webkitdirectory directory
              multiple style="display:none">
     </div>
@@ -857,8 +858,9 @@ skrobot / native-mesh consumers (not RViz-loadable)">⬇ glb</button></a>
     'extract.phaseRunning': { en: a => `${a.phase} …`, ja: a => `${a.phase} …` },
     // file browser
     'fs.error': { en: a => `📁 ${a.e}`, ja: a => `📁 ${a.e}` },
-    'fs.driveSelect': { en: '(select a drive)', ja: '(ドライブ選択)' },
     'fs.packageHint': { en: '(package — click to open)', ja: '(パッケージ — クリックで開く)' },
+    'fs.recentHint': { en: '(recent — click to extract)', ja: '(最近のファイル — クリックで抽出)' },
+    'fs.pkgRecentHint': { en: '(built package — click to open)', ja: '(抽出済みパッケージ — クリックで開く)' },
     'fs.empty': { en: '(empty, or no matching files)', ja: '(空、または対象ファイルなし)' },
     // drag & drop
     'drop.count': { en: a => `dropped ${a.n} files`, ja: a => `${a.n} 個のファイルをドロップ` },
@@ -868,22 +870,8 @@ skrobot / native-mesh consumers (not RViz-loadable)">⬇ glb</button></a>
     'drop.convertOk': { en: a => `3DXML conversions done ✓ (${a.n} files ready)`, ja: a => `3DXML 変換完了 ✓（${a.n} ファイル）` },
     'drop.suffix': { en: ' (dropped)', ja: '（ドロップ）' },
     'drop.fail': { en: a => `drop failed: ${a.e}`, ja: a => `ドロップに失敗: ${a.e}` },
-    // locate .sldasm
-    'locate.start': { en: a => `locating "${a.name}" (${a.size} B) on disk …`, ja: a => `「${a.name}」(${a.size} B) をディスク上で検索中 …` },
-    'locate.bar': { en: a => `searching for "${a.name}" on disk …`, ja: a => `「${a.name}」をディスク上で検索中 …` },
-    'locate.fail': { en: a => `locate failed: ${a.e}`, ja: a => `検索に失敗: ${a.e}` },
-    'locate.found': { en: a => `found on disk: ${a.path}`, ja: a => `ディスク上で発見: ${a.path}` },
-    'locate.building': { en: 'file index is still building (first run walks the CAD shares, a few minutes) — try the drop again shortly, or use 🗄',
-                         ja: 'ファイル索引を構築中です（初回は CAD 共有を走査、数分）— 少し待って再ドロップするか 🗄 を使ってください' },
-    'locate.notFound': { en: 'not found in the CAD shares or local Desktop/Downloads/Documents — open it via the 🗄 server browser instead',
-                         ja: 'CAD 共有やローカルの Desktop/Downloads/Documents に見つかりません — 🗄 サーバーブラウザから開いてください' },
-    'locate.candidates': { en: a => `${a.n} candidate file(s) — pick one`, ja: a => `${a.n} 件の候補 — 1つ選んでください` },
-    'locate.multiTitle': { en: a => `multiple matches for "${a.name}"`, ja: a => `「${a.name}」が複数見つかりました` },
-    'locate.multiHelp': { en: 'pick the file to load (≡ = same size as the one you dropped)',
-                          ja: '読み込むファイルを選んでください(≡ = ドロップしたものと同じサイズ)' },
-    'locate.sameSize': { en: 'same size', ja: '同じサイズ' },
-    'locate.diffSize': { en: 'same name, different size (older?)', ja: '同名・別サイズ(旧版?)' },
-    'locate.prepBar': { en: a => `preparing to extract "${a.name}" …`, ja: a => `「${a.name}」を抽出準備中 …` },
+    'drop.sldasmUsePath': { en: 'a dropped .sldasm has no real path — open 🗄 and pick a recent file or paste its full path',
+                            ja: 'ドロップした .sldasm は実パスが取れません — 🗄 を開いて最近のファイルを選ぶかフルパスを貼り付けてください' },
     // SolidWorks status
     'sw.unsaved': { en: '⚠️ unsaved changes — press Ctrl+S in SolidWorks first; ', ja: '⚠️ 未保存の変更 — まず SolidWorks で Ctrl+S を押してください; ' },
     'sw.open': { en: a => `open: ${a.name}`, ja: a => `開いています: ${a.name}` },
@@ -897,11 +885,11 @@ skrobot / native-mesh consumers (not RViz-loadable)">⬇ glb</button></a>
     'bug.sent': { en: '🐞 diagnostic report sent (server: _client_report.json)', ja: '🐞 診断レポートを送信しました（サーバー: _client_report.json）' },
     'bug.fail': { en: a => `🐞 report failed: ${a.e}`, ja: a => `🐞 レポート送信に失敗: ${a.e}` },
     'start.pick': { en: 'pick a package (or drag&drop)', ja: 'パッケージを選択（またはドラッグ&ドロップ）' },
-    'start.noPkg': { en: 'no package open yet — open via 📄/📁/🗄 or drop a folder/.sldasm',
-                     ja: 'まだパッケージが開かれていません — 📄/📁/🗄 で開くかフォルダ/.sldasm をドロップ' },
+    'start.noPkg': { en: 'no package open yet — drop a package folder, or open a .sldasm via 🗄 (recent files + paste a full path)',
+                     ja: 'まだパッケージが開かれていません — パッケージフォルダをドロップ、または .sldasm を 🗄（最近のファイル＋フルパス貼り付け）で開く' },
     // ---- static HTML (data-i18n / data-i18n-title) ----
     'ui.title': { en: 'sw2robot viewer', ja: 'sw2robot ビューア' },
-    'ui.droptip': { en: 'drop a module folder or a .sldasm here', ja: 'モジュールフォルダか .sldasm をここにドロップ' },
+    'ui.droptip': { en: 'drop a package folder here (for a .sldasm use 🗄)', ja: 'パッケージフォルダをここにドロップ（.sldasm は 🗄 で）' },
     't.iso': { en: 'isometric', ja: '等角投影' },
     't.axes': { en: 'joint axes', ja: '関節軸' },
     't.origin': { en: 'root origin triad', ja: 'ルート原点の座標軸' },
@@ -919,10 +907,10 @@ skrobot / native-mesh consumers (not RViz-loadable)">⬇ glb</button></a>
     't.gridcap': { en: 'grid pitch', ja: 'グリッド間隔' },
     't.keycast': { en: 'demo recording: show pressed keys / mouse in the bottom-left',
                    ja: 'デモ録画用: 押したキー/マウス操作を画面左下に表示' },
-    'ui.emptyDrop': { en: 'Drag & Drop a .sldasm / package folder here',
-                      ja: 'ここに .sldasm / パッケージフォルダを Drag & Drop' },
-    'ui.emptyPick': { en: 'or use “📄 Open file…” / “📁 Folder…” on the right',
-                      ja: 'または右の「📄 ファイルを開く…」「📁 フォルダ…」から選択' },
+    'ui.emptyDrop': { en: 'Drag & Drop a package folder here',
+                      ja: 'ここにパッケージフォルダを Drag & Drop' },
+    'ui.emptyPick': { en: 'or open via 🗄 on the right (recent files / paste a full path)',
+                      ja: 'または右の 🗄 から開く（最近のファイル / フルパス貼り付け）' },
     't.selexclude': { en: 'exclude from the URDF (adds to yaml exclude:, Ctrl+Z to undo)',
                       ja: 'URDFから除外する (yaml exclude: に追加、Ctrl+Zで戻る)' },
     'ui.selroot': { en: '⌂ make root', ja: '⌂ ルート化' },
@@ -932,12 +920,11 @@ skrobot / native-mesh consumers (not RViz-loadable)">⬇ glb</button></a>
     'ui.btContinuous': { en: 'continuous', ja: '連続回転' },
     'ui.btPrismatic': { en: 'prismatic', ja: '直動' },
     'ui.useactive': { en: '🎯 Extract the assembly open in SolidWorks', ja: '🎯 SolidWorksで開いているアセンブリを抽出' },
-    't.openfile': { en: 'OS file dialog (.sldasm / .urdf)', ja: 'OSのファイルダイアログ (.sldasm / .urdf)' },
-    'ui.openfile': { en: '📄 Open file…', ja: '📄 ファイルを開く…' },
-    't.openfolder': { en: 'OS folder dialog (package folder)', ja: 'OSのフォルダダイアログ (パッケージフォルダ)' },
-    'ui.openfolder': { en: '📁 Folder…', ja: '📁 フォルダ…' },
-    't.fsbrowse': { en: 'server-side file browser (when the dialog can’t find it)',
-                    ja: 'サーバー側のファイルブラウザ (ダイアログで見つからない時)' },
+    't.fsbrowse': { en: 'server-side file browser: recent files + paste a full path',
+                    ja: 'サーバー側ファイルブラウザ：最近のファイル＋フルパス貼り付け' },
+    't.fspathPh': { en: 'paste / edit a full path, then Enter', ja: 'フルパスを貼り付け / 編集して Enter' },
+    't.fsgo': { en: 'open / go to this path', ja: 'このパスを開く / 移動' },
+    't.fsfilterPh': { en: 'filter this folder…', ja: 'このフォルダ内を絞り込み…' },
     'ui.reset': { en: 'Reset pose (0)', ja: '姿勢リセット (0)' },
     'ui.resetview': { en: '↺ Reset view', ja: '↺ リセット' },
     't.resetview': { en: 'back to the just-loaded state: neutral pose, default camera, nothing selected, all tools closed (c)',
@@ -999,6 +986,9 @@ skrobot / native-mesh consumers (not RViz-loadable)">⬇ glb</button></a>
     });
     r.querySelectorAll('[data-i18n-title]').forEach(el => {
       el.title = t(el.dataset.i18nTitle);
+    });
+    r.querySelectorAll('[data-i18n-ph]').forEach(el => {
+      el.placeholder = t(el.dataset.i18nPh);
     });
   }
   window.applyStaticI18n = applyStaticI18n;
@@ -4342,19 +4332,24 @@ function openAny(p) {
 const fsmodal = document.getElementById('fsmodal');
 let fsCur = '';
 
+const FS_LAST_DIR_KEY = 'sw2robot.fsdir';
+
 async function fsShow(path) {
   const r = await (await fetch(
     '/api/fs?path=' + encodeURIComponent(path ?? ''))).json();
   if (r.error) { log(t('fs.error', { e: r.error }), 'err'); return; }
   fsCur = r.path;
-  document.getElementById('fspath').textContent = r.path || t('fs.driveSelect');
+  try { localStorage.setItem(FS_LAST_DIR_KEY, r.path || ''); } catch { /**/ }
+  document.getElementById('fspath').value = r.path || '';
   document.getElementById('fsup').disabled = !r.parent && !r.path;
   document.getElementById('fsup').dataset.parent = r.parent ?? '';
+  document.getElementById('fsfilter').value = '';
   const list = document.getElementById('fslist');
   list.innerHTML = '';
   const row = (icon, name, cb, hint) => {
     const d = document.createElement('div');
     d.textContent = `${icon} ${name}${hint ? '   ' + hint : ''}`;
+    d.dataset.fsname = String(name).toLowerCase();
     d.style.cssText = 'padding:3px 6px;border-radius:3px;cursor:pointer;' +
                       'white-space:nowrap;overflow:hidden;' +
                       'text-overflow:ellipsis';
@@ -4363,6 +4358,21 @@ async function fsShow(path) {
     d.addEventListener('click', cb);
     list.appendChild(d);
   };
+  if (!r.path) {           // root view: recent SolidWorks files + built packages
+    const [recent, pkgs] = await Promise.all([
+      fetch('/api/recent').then(x => x.json()).catch(() => []),
+      fetch('/api/list').then(x => x.json()).catch(() => [])]);
+    for (const p of (recent || []).slice(0, 10)) {
+      const nm = p.split(/[\\/]/).pop();
+      row('⭐', nm, () => { fsmodal.style.display = 'none'; openAny(p); },
+          t('fs.recentHint'));
+    }
+    for (const pk of (pkgs || []).slice(0, 10)) {
+      row('⭐📦', pk.name, () => { fsmodal.style.display = 'none';
+                                  openServerPath(pk.path); },
+          t('fs.pkgRecentHint'));
+    }
+  }
   for (const dir of r.dirs) {
     if (dir.package) {
       row('📦', dir.name, () => { fsmodal.style.display = 'none';
@@ -4381,25 +4391,50 @@ async function fsShow(path) {
   }
   fsmodal.style.display = 'flex';
 }
-document.getElementById('fsbrowse').addEventListener('click',
-  () => fsShow(fsCur || ''));
 
-// ---- OS-native open dialogs (hidden file inputs, robot-compiler style).
-// The browser hides real paths, so picked files go through the SAME flow
-// as drag&drop: .sldasm -> fingerprint locate, package folder -> blob URLs.
-const openFileInput = document.getElementById('openfileinput');
+// type-to-narrow the current listing (hide non-matching rows)
+function fsFilter() {
+  const q = document.getElementById('fsfilter').value.trim().toLowerCase();
+  for (const d of document.querySelectorAll('#fslist > div')) {
+    d.style.display = (!q || (d.dataset.fsname || '').includes(q)) ? '' : 'none';
+  }
+}
+
+// the path bar IS the old 📋: paste/edit a full path + Enter -> a .sldasm/.urdf
+// is opened/extracted, anything else is treated as a directory to navigate to.
+// Windows "Copy as path" wraps the path in quotes -- strip them.
+function fsGo() {
+  const p = document.getElementById('fspath').value.trim().replace(/^"+|"+$/g, '');
+  if (!p) { return; }
+  if (/\.(sldasm|urdf)$/i.test(p)) { fsmodal.style.display = 'none'; openAny(p); }
+  else { fsShow(p); }
+}
+
+document.getElementById('fsbrowse').addEventListener('click', () => {
+  let start = fsCur;
+  try { start = start || localStorage.getItem(FS_LAST_DIR_KEY) || ''; }
+  catch { /**/ }
+  fsShow(start);
+  setTimeout(() => document.getElementById('fspath').focus(), 50);
+});
+document.getElementById('fsgo').addEventListener('click', fsGo);
+document.getElementById('fspath').addEventListener('keydown', e => {
+  if (e.key === 'Enter') { e.preventDefault(); fsGo(); }
+});
+document.getElementById('fsfilter').addEventListener('input', fsFilter);
+document.getElementById('fsfilter').addEventListener('keydown', e => {
+  if (e.key !== 'Enter') { return; }     // Enter on a lone match activates it
+  const vis = [...document.querySelectorAll('#fslist > div')]
+    .filter(d => d.style.display !== 'none');
+  if (vis.length === 1) { vis[0].click(); }
+});
+
+// Folder-upload (view a package without a server path) is kept for later but
+// has no visible button: this hidden directory picker stays wired to handleDrop
+// (browsers hide real paths, so uploaded files load via blob URLs), and a
+// package folder can still be drag&dropped onto the page.  Re-adding a button
+// that calls openFolderInput.click() re-enables dialog upload.
 const openFolderInput = document.getElementById('openfolderinput');
-document.getElementById('openfile').addEventListener('click', () => {
-  openFileInput.value = ''; openFileInput.click();
-});
-document.getElementById('openfolder').addEventListener('click', () => {
-  openFolderInput.value = ''; openFolderInput.click();
-});
-openFileInput.addEventListener('change', () => {
-  const files = {};
-  [...openFileInput.files].forEach(f => { files['/' + f.name] = f; });
-  if (Object.keys(files).length) { handleDrop(files); }
-});
 openFolderInput.addEventListener('change', () => {
   const files = {};
   [...openFolderInput.files].forEach(
@@ -4450,9 +4485,11 @@ async function handleDrop(files) {
   log(t('drop.count', { n: names.length }));
   const urdfPath = names.find(n => n.toLowerCase().endsWith('.urdf'));
   if (!urdfPath) {
+    // A dropped .sldasm can't be extracted from its uploaded bytes -- SolidWorks
+    // needs the file in its folder (referenced parts resolve relative to it) and
+    // the browser hides the real path.  Point the user at the path-aware entries.
     const sld = names.find(n => n.toLowerCase().endsWith('.sldasm'));
-    if (sld) { return locateAndExtract(sld, files[sld]); }
-    log(t('drop.noUrdf'), 'err');
+    log(t(sld ? 'drop.sldasmUsePath' : 'drop.noUrdf'), sld ? 'wrn' : 'err');
     return;
   }
   const blobs = new Map();
@@ -4495,79 +4532,6 @@ function showLoadOverlay(text) {
 function hideLoadOverlay() {
   loadBackdrop.style.display = 'none';
   hideLoadbar();
-}
-
-// dropped .sldasm: fingerprint (basename+size) -> server finds the real path
-async function locateAndExtract(droppedPath, file) {
-  const name = droppedPath.split('/').pop();
-  log(t('locate.start', { name, size: file.size }));
-  showLoadOverlay(t('locate.bar', { name }));
-  let r;
-  try {
-    const resp = await fetch(`/api/locate?name=${encodeURIComponent(name)}` +
-                             `&size=${file.size}`);
-    r = await resp.json();
-    if (!resp.ok || r.error) { throw new Error(r.error ?? resp.status); }
-  } catch (e) {
-    hideLoadOverlay();
-    log(t('locate.fail', { e: e.message ?? e }), 'err');
-    return;
-  }
-  const hits = r.hits ?? [];
-  const exact = hits.filter(h => h.size_match);
-  // auto-proceed when there's only one sensible choice: a single exact-size
-  // match, or just a single candidate overall (no picker for one option)
-  const auto = exact.length === 1 ? exact[0]
-             : hits.length === 1 ? hits[0] : null;
-  if (auto) {
-    log(t('locate.found', { path: auto.path }), 'ok');
-    extractFlow(auto.path);                // keeps the overlay; shows progress
-    return;
-  }
-  if (hits.length === 0) {
-    hideLoadOverlay();
-    log(r.building ? t('locate.building') : t('locate.notFound'), 'wrn');
-    return;
-  }
-  // multiple candidates: a prominent centered picker (the dim stays behind it)
-  log(t('locate.candidates', { n: hits.length }), 'wrn');
-  hideLoadbar();                           // pause the spinner while we wait
-  showCandidatePicker(name, hits);
-}
-
-function showCandidatePicker(name, hits) {
-  const ov = document.createElement('div');
-  ov.style.cssText = 'position:absolute;inset:0;z-index:9;display:flex;' +
-    'align-items:center;justify-content:center';
-  const card = document.createElement('div');
-  card.style.cssText = 'background:#1c2228;border:1px solid #456;' +
-    'border-radius:8px;padding:16px 18px;max-width:82%;color:#dde;' +
-    'box-shadow:0 8px 30px #000a';
-  card.innerHTML =
-    `<div style="font-size:14px;margin-bottom:3px">${t('locate.multiTitle', { name })}</div>` +
-    `<div style="font-size:11px;color:#8a93a3;margin-bottom:10px">` +
-    `${t('locate.multiHelp')}</div>`;
-  for (const h of hits) {
-    const b = document.createElement('button');
-    b.style.cssText = 'display:block;width:100%;margin:3px 0;text-align:left;' +
-      'font-size:12px;padding:7px 9px';
-    b.textContent = (h.size_match ? '≡ ' : '≠ ') + h.path +
-                    (h.size_match ? '' : `  (${h.size} B)`);
-    b.title = h.size_match ? t('locate.sameSize') : t('locate.diffSize');
-    b.addEventListener('click', () => {
-      ov.remove();
-      showLoadbar(t('locate.prepBar', { name }), { indet: true });
-      extractFlow(h.path);
-    });
-    card.appendChild(b);
-  }
-  const cancel = document.createElement('button');
-  cancel.textContent = t('common.cancel');
-  cancel.style.cssText = 'margin-top:10px;font-size:11px';
-  cancel.addEventListener('click', () => { ov.remove(); hideLoadOverlay(); });
-  card.appendChild(cancel);
-  ov.appendChild(card);
-  loadBackdrop.parentElement.appendChild(ov);
 }
 
 let dragDepth = 0;
@@ -4665,7 +4629,6 @@ window.sw2robot = {
   dump: sw2robotDump,
   collision: () => ({ ready: colReady, links: [...collisionLinks] }),
   extractFlow: p => extractFlow(p),     // for E2E (fetch is mocked there)
-  locateAndExtract: (p, sz) => locateAndExtract(p, { size: sz }),
   boxSelect: rect => selectLinksInBox(rect ??
     { l: -1e9, t: -1e9, r: 1e9, b: 1e9 }),   // no rect => everything on screen
   boxSelected: () => [...boxSelected],

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -266,6 +266,13 @@
 </script>
 </head>
 <body>
+<div id="backendDown" style="position:fixed;top:0;left:0;right:0;z-index:1000;
+     display:none;background:#7a1d1d;color:#fff;padding:8px 14px;font-size:13px;
+     text-align:center;box-shadow:0 2px 10px #0009">
+  <span id="backendDownMsg"></span>
+  <button id="backendReload" data-i18n="backend.reload"
+          style="margin-left:12px">⟳ reload</button>
+</div>
 <div id="droptip" data-i18n="ui.droptip">drop a package folder here (for a .sldasm use 🗄)</div>
 <div id="app">
   <div id="viewwrap">
@@ -529,6 +536,9 @@ skrobot / native-mesh consumers (not RViz-loadable)">⬇ glb</button></a>
                       ja: a => `JSエラー: ${a.msg} (${a.file}:${a.line})` },
     'boot.promiseRejected': { en: a => `promise rejected: ${a.reason}`,
                               ja: a => `Promise が拒否されました: ${a.reason}` },
+    'backend.down': { en: '⚠ Lost connection to the sw2robot server — it may have stopped. Restart it in the terminal, then reload.',
+                      ja: '⚠ sw2robot サーバーに接続できません — 停止した可能性があります。ターミナルで再起動してから再読み込みしてください。' },
+    'backend.reload': { en: '⟳ reload', ja: '⟳ 再読み込み' },
     'load.ok': { en: 'three.js + urdf-loader loaded ✓', ja: 'three.js + urdf-loader を読み込みました ✓' },
     'load.fail': { en: a => `CDN import failed: ${a.e}`, ja: a => `CDN の読み込みに失敗: ${a.e}` },
     'load.failHint': { en: '→ check internet access / proxy for unpkg.com, then reload',
@@ -1019,11 +1029,45 @@ skrobot / native-mesh consumers (not RViz-loadable)">⬇ glb</button></a>
     if (cls === 'err') { statusEl.textContent = '❌ ' + msg; }
   }
   window.log = log;
+
+  // Backend-down banner: when the local server stops (or the network drops),
+  // every fetch throws `TypeError: Failed to fetch` -- cryptic on its own.
+  // Wrap fetch so ANY failed request raises a clear, persistent banner, and any
+  // successful response clears it (auto-recovers when the server is back).
+  function setBackendDown(down) {
+    const el = document.getElementById('backendDown');
+    if (!el) { return; }
+    if (down && el.style.display === 'none') {
+      document.getElementById('backendDownMsg').textContent = t('backend.down');
+    }
+    el.style.display = down ? 'block' : 'none';
+  }
+  window.setBackendDown = setBackendDown;
+  const isNetErr = r => (r instanceof TypeError)
+    && /fetch|network|load failed/i.test(r.message || '');
+  const _origFetch = window.fetch.bind(window);
+  window.fetch = async (...args) => {
+    try {
+      const r = await _origFetch(...args);
+      setBackendDown(false);            // got a response -> server is alive
+      return r;
+    } catch (e) {
+      if (isNetErr(e)) { setBackendDown(true); }
+      throw e;                          // keep existing error handling working
+    }
+  };
+  const reloadBtn = document.getElementById('backendReload');
+  if (reloadBtn) { reloadBtn.addEventListener('click', () => location.reload()); }
+
   window.addEventListener('error', e =>
     log(t('boot.jsError', { msg: e.message,
         file: (e.filename || '?').split('/').pop(), line: e.lineno }), 'err'));
-  window.addEventListener('unhandledrejection', e =>
-    log(t('boot.promiseRejected', { reason: e.reason }), 'err'));
+  window.addEventListener('unhandledrejection', e => {
+    // a dead backend surfaces here as "Failed to fetch" -- the banner already
+    // explains it clearly, so don't also dump the raw TypeError on the user
+    if (isNetErr(e.reason)) { setBackendDown(true); e.preventDefault(); return; }
+    log(t('boot.promiseRejected', { reason: e.reason }), 'err');
+  });
   // translate the static chrome + reflect the active language button now
   applyStaticI18n();
   // #title / #status are dynamic (set from JS), so localize their placeholders

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -44,8 +44,8 @@ WEB_DIR = os.path.join(HERE, "web")
 
 
 def _app_data_dir():
-    """Writable base for runtime side-files (the drive index, the default
-    package root, the client report).  A PyInstaller-frozen exe's PROJECT_ROOT
+    """Writable base for runtime side-files (the default package root, the
+    client report).  A PyInstaller-frozen exe's PROJECT_ROOT
     lives INSIDE the read-only bundle, so fall back to a stable Windows temp
     dir there; a source checkout keeps using the repo root, so the dev workflow
     is unchanged."""
@@ -164,284 +164,13 @@ def _resolve_package(path):
     raise ValueError(f"not a package dir or .urdf file: {path}")
 
 
-# --- .sldasm basename index (NO SolidWorks needed: plain os.walk) ---------
-# Google Drive for Desktop localises the "Shared drives" mount folder by the
-# app's display LANGUAGE -- it is 共有ドライブ in Japanese, "Shared drives" in
-# English, "Unidades compartidas" in Spanish, and so on.  Hardcoding one name
-# silently breaks the index (and every absolute part reference) the moment the
-# language is switched, so resolve the live name at runtime instead.
-_GDRIVE_LETTER = "G:"
-_SHARED_DRIVE_NAMES = ["共有ドライブ", "Shared drives", "Unidades compartidas",
-                       "Geteilte Ablagen", "Drive partagés", "공유 드라이브",
-                       "共享云端硬盘", "Gedeelde drives"]
-# CAD roots as paths RELATIVE to the shared-drives mount folder
-_CAD_ROOT_RELS = [
-    r"KXR\kxr-design",
-    r"Designs\Mechanical Design",
-]
-
-
-def _shared_drives_base():
-    """The Google Drive 'Shared drives' mount folder under G:, by whatever
-    localised name it currently carries; None if G: isn't mounted."""
-    drive = _GDRIVE_LETTER + "\\"
-    for name in _SHARED_DRIVE_NAMES:               # known localisations first
-        p = os.path.join(drive, name)
-        if os.path.isdir(p):
-            return p
-    # unknown locale: pick any G:\<dir> that actually holds our CAD drives
-    firsts = {rel.split("\\", 1)[0].lower() for rel in _CAD_ROOT_RELS}
-    try:
-        for name in os.listdir(drive):
-            p = os.path.join(drive, name)
-            if os.path.isdir(p) and any(
-                    os.path.isdir(os.path.join(p, d)) for d in
-                    os.listdir(p) if d.lower() in firsts):
-                return p
-    except OSError:
-        pass
-    return None
-
-
-def _default_cad_roots():
-    """The configured CAD roots, resolved against the live shared-drives mount
-    name; empty when G: isn't available (the index then simply finds nothing
-    instead of walking dead Japanese-named paths)."""
-    base = _shared_drives_base()
-    if not base:
-        return []
-    return [os.path.join(base, rel) for rel in _CAD_ROOT_RELS]
-
-
-def _remap_share(path, base=None):
-    """Rewrite ``G:\\<old shared-drives name>\\...`` to the CURRENT mount name.
-
-    When Google Drive's display language is switched the only thing that moves
-    is the localised top folder (共有ドライブ <-> Shared drives <-> ...); the
-    sub-tree is identical.  So a stale cached path is fixed by swapping just
-    that one segment -- no need to re-walk the share (minutes over streaming).
-    Leaves non-G:, already-current, and unrecognised paths untouched."""
-    base = base or _shared_drives_base()
-    drive = _GDRIVE_LETTER + "\\"
-    if not base or not path.startswith(drive):
-        return path
-    oldname, _, tail = path[len(drive):].partition("\\")
-    cur = os.path.basename(base)
-    if tail and oldname != cur and oldname in _SHARED_DRIVE_NAMES:
-        return os.path.join(base, tail)
-    return path
-
-
-_SKIP_DIRS = {"backup", "backups", "old", "_old", "bak", "trash", ".git",
-              "sandbox"}
-_INDEX_FILE = os.path.join(_DATA_DIR, "_sldasm_index.json")
-_INDEX_MAX_AGE_S = 24 * 3600
-_index = {"byname": {}, "building": False, "count": 0}
-
-
-def _build_index(roots):
-    _index["building"] = True
-    byname, n = {}, 0
-    try:
-        for root in roots:
-            if not os.path.isdir(root):
-                print(f"[sw2robot.web] index: skipping missing root {root}")
-                continue
-            print(f"[sw2robot.web] index: walking {root} ...")
-            for dirpath, dirnames, filenames in os.walk(root):
-                dirnames[:] = [d for d in dirnames
-                               if d.lower() not in _SKIP_DIRS
-                               and not d.lower().endswith("_backups")]
-                for f in filenames:
-                    if f.lower().endswith(".sldasm") \
-                            and not f.startswith("~$"):
-                        byname.setdefault(f.lower(), []).append(
-                            os.path.join(dirpath, f))
-                        n += 1
-        _index["byname"], _index["count"] = byname, n
-        with open(_INDEX_FILE, "w", encoding="utf-8") as f:
-            json.dump({"roots": list(roots), "byname": byname}, f)
-        print(f"[sw2robot.web] index: {n} .sldasm files indexed")
-    except Exception as e:
-        print(f"[sw2robot.web] index build failed: {e!r}")
-    finally:
-        _index["building"] = False
-
-
-def _ensure_index(roots):
-    if _index["byname"] or _index["building"]:
-        return
-    if os.path.exists(_INDEX_FILE) \
-            and time.time() - os.path.getmtime(_INDEX_FILE) \
-            < _INDEX_MAX_AGE_S:
-        try:
-            with open(_INDEX_FILE, encoding="utf-8") as f:
-                cached = json.load(f)
-            # accept both the new {"roots","byname"} and the old plain-{byname}
-            byname = cached["byname"] if isinstance(cached, dict) \
-                and "byname" in cached else cached
-            # the shared-drives mount may have been RENAMED (locale switch)
-            # since the cache was written -- repoint the stored paths to the
-            # live name in memory instead of re-walking the share (a walk over
-            # Google Drive streaming costs minutes for ~20k files).
-            base = _shared_drives_base()
-            n_remap = 0
-            for k, paths in byname.items():
-                fixed = [_remap_share(p, base) for p in paths]
-                n_remap += sum(a != b for a, b in zip(paths, fixed))
-                byname[k] = fixed
-            _index["byname"] = byname
-            _index["count"] = sum(len(v) for v in byname.values())
-            note = (f" ({n_remap} repointed to '{os.path.basename(base)}')"
-                    if n_remap and base else "")
-            print(f"[sw2robot.web] index: {_index['count']} entries loaded "
-                  f"from cache{note}")
-            return
-        except Exception:
-            pass
-    threading.Thread(target=_build_index, args=(roots,),
-                     daemon=True).start()
-
-
-def _shell_folder_roots():
-    """Desktop / Downloads / Documents as Windows ACTUALLY has them, read from
-    the per-user 'User Shell Folders' registry.  This is the only reliable way
-    when OneDrive's Known-Folder-Move has redirected them away from the plain
-    ``~\\Desktop`` path (a guess that then silently doesn't exist)."""
-    if os.name != "nt":
-        return []
-    keys = {"Desktop": "Desktop",
-            "Personal": "Documents",                       # Documents
-            "{374DE290-123F-4565-9164-39C4925E467B}": "Downloads"}
-    out = []
-    try:
-        import winreg
-        with winreg.OpenKey(
-                winreg.HKEY_CURRENT_USER,
-                r"Software\Microsoft\Windows\CurrentVersion\Explorer"
-                r"\User Shell Folders") as k:
-            for val in keys:
-                try:
-                    raw, _ = winreg.QueryValueEx(k, val)
-                except OSError:
-                    continue
-                out.append(os.path.expandvars(raw))   # %USERPROFILE% etc.
-    except Exception:
-        pass
-    return out
-
-
-def _local_search_roots():
-    """Likely local spots for a hand-dropped .sldasm that lives OUTSIDE the
-    indexed CAD shares -- Desktop / Downloads / Documents under the user
-    profile (and their OneDrive mirrors).  A GUI .exe user typically drops a
-    working copy from one of these, which the drive index never walks."""
-    cands = list(_shell_folder_roots())          # registry truth first
-    bases = [os.path.expanduser("~")]
-    for var in ("OneDrive", "OneDriveConsumer", "OneDriveCommercial"):
-        if os.environ.get(var):
-            bases.append(os.environ[var])
-    for b in bases:                              # plain-path fallback guesses
-        for sub in ("Desktop", "Downloads", "Documents"):
-            cands.append(os.path.join(b, sub))
-    seen, out = set(), []
-    for c in cands:
-        c = os.path.normpath(c)
-        if c.lower() not in seen and os.path.isdir(c):
-            seen.add(c.lower())
-            out.append(c)
-    return out
-
-
-def _deep_find_basename(roots, base, time_budget_s=6.0):
-    """Bounded on-demand walk of ``roots`` for a file whose lowercased basename
-    is ``base``.  Stops at ``time_budget_s`` so a huge Downloads tree can't hang
-    the /api/locate request; skips the same junk dirs as the index build."""
-    hits = []
-    deadline = time.time() + time_budget_s
-    for root in roots:
-        for dirpath, dirnames, filenames in os.walk(root):
-            if time.time() > deadline:
-                return hits, True            # timed out -- partial result
-            dirnames[:] = [d for d in dirnames
-                           if d.lower() not in _SKIP_DIRS
-                           and not d.lower().endswith("_backups")]
-            for f in filenames:
-                if f.lower() == base and not f.startswith("~$"):
-                    hits.append(os.path.join(dirpath, f))
-    return hits, False
-
-
-def _locate_sldasm(name, size=None):
-    """Find the real on-disk path(s) of a drag&dropped .sldasm by fingerprint.
-
-    Browsers hide real file paths on drop, but basename (+size as a
-    preference, not a hard filter) identifies the file well enough to look
-    it up in: the SolidWorks MRU, the source_assembly of every extracted
-    package under output/, the drive index _sldasm_index.json (built by
-    plain os.walk -- no SolidWorks), and _find_roots_sw.py's cache."""
-    base = os.path.basename(str(name)).lower()
-    seen, out = set(), []
-
-    def consider(p):
-        p = os.path.normpath(str(p))
-        k = p.lower()
-        if k in seen or os.path.basename(k) != base:
-            return
-        seen.add(k)
-        try:
-            st = os.stat(p)
-        except OSError:
-            return
-        out.append({"path": p, "size": st.st_size,
-                    "mtime": int(st.st_mtime),
-                    "size_match": bool(size)
-                    and st.st_size == int(size)})
-
-    try:
-        from . import core
-        for p in core.sw_recent_assemblies(50):
-            consider(p)
-    except Exception:
-        pass
-    root = _DATA_DIR
-    out_dir = os.path.join(root, "output")
-    if os.path.isdir(out_dir):                  # extracted packages know
-        for d in os.listdir(out_dir):           # their own source path
-            g = os.path.join(out_dir, d, "graph.json")
-            if os.path.exists(g):
-                try:
-                    from sw2robot.exporter.state import GraphState
-                    consider(GraphState.load(g).source_assembly or "")
-                except Exception:
-                    pass
-    for p in _index["byname"].get(base, []):
-        consider(p)
-    cache = os.path.join(root, "_roots_cache.jsonl")
-    if os.path.exists(cache):
-        with open(cache, encoding="utf-8") as f:
-            for line in f:
-                try:
-                    key = json.loads(line).get("key", "")
-                except Exception:
-                    continue
-                p = key.rsplit("|", 1)[0]
-                if os.path.basename(p).lower() == base:
-                    consider(p)
-    # last resort: the indexed sources (MRU / output / drive index / roots
-    # cache) all cover the CAD shares, not local folders.  A GUI .exe user
-    # usually drops a working copy from Desktop/Downloads/Documents, so walk
-    # those on demand before giving up.
-    if not out:
-        local, timed_out = _deep_find_basename(_local_search_roots(), base)
-        for p in local:
-            consider(p)
-        if timed_out:
-            print(f"[sw2robot.web] local search for {base} hit its time "
-                  f"budget; results may be incomplete")
-    # exact-size hits first, then newest
-    out.sort(key=lambda h: (not h["size_match"], -h["mtime"]))
-    return out
+# Opening an assembly needs its REAL on-disk path (SolidWorks resolves the
+# referenced parts relative to it), but a browser never reveals the path of a
+# drag&dropped / file-dialog file -- only its name+size+bytes.  Rather than
+# guess the path by walking the disk (slow, and the guessed locations are
+# environment-specific), the editor opens by an actual path: the 🗄 server-side
+# file browser (which lists SolidWorks' recent files for one-click access), or
+# 📋 paste-a-full-path.  Both hand the server a real path; no indexing, no walk.
 
 
 def _read_root_pose(txt):
@@ -1238,9 +967,9 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                     for d in string.ascii_uppercase:
                         if os.path.exists(f"{d}:\\"):
                             roots.append(f"{d}:\\")
-                    for r in [_Handler.root_dir, *_default_cad_roots()]:
-                        if r and os.path.isdir(r) and r not in roots:
-                            roots.append(r)
+                    if _Handler.root_dir and os.path.isdir(_Handler.root_dir) \
+                            and _Handler.root_dir not in roots:
+                        roots.append(_Handler.root_dir)
                     return self._send_json(
                         {"path": "", "parent": None,
                          "dirs": [{"name": r, "path": r, "package": False}
@@ -1285,19 +1014,6 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 had = _sw.get("sess") is not None
                 _shutdown_sw()
                 return self._send_json({"released": had})
-            if path == "/api/locate":
-                name = (query.get("name") or [""])[0]
-                size = (query.get("size") or [None])[0]
-                if not name.lower().endswith(".sldasm"):
-                    return self._send_json({"error": "need a .sldasm name"},
-                                           400)
-                hits = _locate_sldasm(name, size)
-                print(f"[sw2robot.web] locate {name} ({size}B): "
-                      f"{len(hits)} hit(s)"
-                      + (" [index still building]"
-                         if _index["building"] else ""))
-                return self._send_json({"hits": hits,
-                                        "building": _index["building"]})
             if path == "/api/collision/init":
                 if not cls.pkg_dir:
                     return self._send_json({"error": "no package open"}, 400)
@@ -2137,13 +1853,11 @@ class _Handler(http.server.BaseHTTPRequestHandler):
         pass
 
 
-def serve(package_dir=None, root_dir=None, port=8090, cad_roots=None,
-          open_browser=True):
+def serve(package_dir=None, root_dir=None, port=8090, open_browser=True):
     import atexit
     atexit.register(_shutdown_sw)     # close the warm session on exit
     threading.Thread(target=_keepalive_loop, daemon=True).start()
     _Handler.root_dir = os.path.abspath(root_dir or _default_root())
-    _ensure_index(cad_roots or _default_cad_roots())
     if package_dir:
         pkg, rel = _resolve_package(package_dir)
         _Handler.pkg_dir, _Handler.urdf_rel = pkg, rel
@@ -2181,15 +1895,12 @@ def main():
                          "source checkout, %TEMP%\\sw2robot\\output for the "
                          "frozen .exe)")
     ap.add_argument("--port", type=int, default=8090)
-    ap.add_argument("--cad-roots", nargs="*", default=None,
-                    help="directories indexed for drag&drop .sldasm lookup "
-                         "(default: KXR + Mechanical Design shares)")
     ap.add_argument("--no-browser", action="store_true",
                     help="do not open the editor in the default browser on "
                          "startup")
     args = ap.parse_args()
     serve(args.package_dir, root_dir=args.root, port=args.port,
-          cad_roots=args.cad_roots, open_browser=not args.no_browser)
+          open_browser=not args.no_browser)
 
 
 if __name__ == "__main__":

--- a/sw2robot/exporter/inertia.py
+++ b/sw2robot/exporter/inertia.py
@@ -100,6 +100,49 @@ def link_inertial(mesh_path, visual_xyz, visual_rpy,
     }
 
 
+def link_inertial_from_sw(mass, com_local, inertia6_local,
+                          visual_xyz, visual_rpy):
+    """Inertial in the LINK frame from SolidWorks-native mass properties.
+
+    ``mass``/``com_local``/``inertia6_local`` come straight from the part's
+    ``IMassProperty`` (see ``model._sw_mass_props``): SI units already (kg,
+    metres, kg.m^2) and expressed in the part's OWN coordinate frame -- the
+    very frame the mesh is exported in -- so the visual origin maps them into
+    the link frame exactly as the mesh path does, with NO extra scaling.
+
+    ``inertia6_local`` is ``(ixx, ixy, ixz, iyy, iyz, izz)`` of the tensor
+    about the centre of mass.  Returns the same dict shape as
+    :func:`link_inertial` (``method="solidworks"``), or ``None`` if the values
+    are missing / non-finite so the caller can fall back to the mesh."""
+    if mass is None or com_local is None or inertia6_local is None:
+        return None
+    try:
+        m = float(mass)
+        com_l = np.asarray(com_local, dtype=float)
+        ixx, ixy, ixz, iyy, iyz, izz = (float(x) for x in inertia6_local)
+    except (TypeError, ValueError):
+        return None
+    I_l = np.array([[ixx, ixy, ixz],
+                    [ixy, iyy, iyz],
+                    [ixz, iyz, izz]], dtype=float)
+    if not (np.isfinite(m) and m > 0 and com_l.shape == (3,)
+            and np.all(np.isfinite(com_l)) and np.all(np.isfinite(I_l))):
+        return None
+    # mesh-frame -> link-frame, identical transform to link_inertial: the
+    # rotation rotates the tensor about the (unchanged) com, the translation
+    # moves the com.
+    R = _rpy_matrix(visual_rpy)[:3, :3]
+    com = R @ com_l + np.asarray(visual_xyz, dtype=float)
+    I = R @ I_l @ R.T
+    return {
+        "mass": m,
+        "com": [float(c) for c in com],
+        "inertia": (float(I[0, 0]), float(I[0, 1]), float(I[0, 2]),
+                    float(I[1, 1]), float(I[1, 2]), float(I[2, 2])),
+        "method": "solidworks",
+    }
+
+
 _PROPS_CACHE = {}
 
 

--- a/sw2robot/exporter/model.py
+++ b/sw2robot/exporter/model.py
@@ -51,6 +51,56 @@ def safe_name(raw):
     return s
 
 
+def _sw_mass_props(mp):
+    """(mass, com3, inertia6) of a part from its SolidWorks ``IMassProperty``.
+
+    The inertia tensor is taken ABOUT THE CENTRE OF MASS, in the part's own
+    coordinate axes (the frame the mesh is exported in), in SI units (kg, m,
+    kg.m^2).  We reconstruct it from the principal moments + principal axes,
+    both of which the classic ``IMassProperty`` exposes::
+
+        I_part = R^T @ diag(Px, Py, Pz) @ R
+
+    where ``R``'s rows are the three principal-axis unit vectors expressed in
+    the part frame (SolidWorks returns them as three consecutive triples).
+    Returns ``(None, None, None)`` if the values are unavailable / degenerate
+    so the caller falls back to the mesh estimate."""
+    # Force SI output if this build's interface exposes the toggle
+    # (IMassProperty2); the classic IMassProperty is already SI, so the
+    # attribute is simply absent and this is a no-op.
+    try:
+        mp.UseSystemUnits = True
+    except Exception:
+        pass
+
+    def _arr(name, n):
+        v = safe_prop(mp, name)
+        try:
+            vals = [float(x) for x in v]
+        except (TypeError, ValueError):
+            return None
+        return vals if len(vals) == n else None
+
+    try:
+        mass = safe_prop(mp, "Mass")
+        mass = float(mass) if mass is not None else None
+    except (TypeError, ValueError):
+        mass = None
+    com = _arr("CenterOfMass", 3)
+    pm = _arr("PrincipalMomentsOfInertia", 3)
+    pax = _arr("PrincipalAxesOfInertia", 9)
+    if not (mass and mass > 0 and com and pm and pax):
+        return None, None, None
+    if not (np.all(np.isfinite(com)) and np.all(np.isfinite(pm))
+            and np.all(np.isfinite(pax))):
+        return None, None, None
+    R = np.asarray(pax, float).reshape(3, 3)     # rows = principal axes (part frame)
+    I = R.T @ np.diag(pm) @ R                      # tensor about COM, part axes
+    inertia6 = (float(I[0, 0]), float(I[0, 1]), float(I[0, 2]),
+                float(I[1, 1]), float(I[1, 2]), float(I[2, 2]))
+    return mass, [float(x) for x in com], inertia6
+
+
 @dataclass
 class Component:
     name: str
@@ -65,6 +115,14 @@ class Component:
     visual_rpy: list = field(default_factory=lambda: [0, 0, 0])
     material: str | None = None      # SolidWorks material name
     density: float | None = None     # kg/m^3 from that material
+    # SolidWorks-native mass properties (part-local frame, SI), preferred over
+    # the mesh estimate when present -- see exporter.inertia.link_inertial_from_sw
+    sw_mass: float | None = None              # kg
+    sw_com: list | None = None                # centre of mass [x,y,z] (m)
+    sw_inertia: list | None = None            # (ixx,ixy,ixz,iyy,iyz,izz) about COM
+    # set when a per-link density override (config / web editor) should drive
+    # the inertial from the mesh, overriding the SolidWorks-native values
+    density_override: bool = False
 
 
 @dataclass
@@ -200,6 +258,7 @@ def extract_components(doc, exclude=None):
         if key in matcache:
             return matcache[key]
         material = density = None
+        sw = None
         try:
             md = safe_call(ct, "GetModelDoc2")
             if md is not None:
@@ -220,12 +279,17 @@ def extract_components(doc, exclude=None):
                     d = getattr(mp, "Density", None)
                     if d and d > 1.0:           # kg/m^3
                         density = float(d)
+                    # SolidWorks-native mass/COM/inertia (exact CAD geometry +
+                    # material/override) -- preferred over the mesh estimate
+                    mass, com, inertia6 = _sw_mass_props(mp)
+                    if mass is not None:
+                        sw = {"mass": mass, "com": com, "inertia": inertia6}
                 except Exception:
                     pass
         except Exception:
             pass
-        matcache[key] = (material, density)
-        return material, density
+        matcache[key] = (material, density, sw)
+        return material, density, sw
     for c in raw:
         ct = as_iface(c, "IComponent2")
         name = safe_prop(ct, "Name2")
@@ -260,12 +324,16 @@ def extract_components(doc, exclude=None):
             ln = f"{base}_{i}"
         used.add(ln)
         material = density = None
+        sw = None
         if path and not is_asm:
-            material, density = _material_of(ct, path)
+            material, density, sw = _material_of(ct, path)
+        sw = sw or {}
         comps.append(Component(name=name, link_name=ln, part_path=path,
                                is_subassembly=is_asm, world=world,
                                fixed=fixed, dof=dof,
-                               material=material, density=density))
+                               material=material, density=density,
+                               sw_mass=sw.get("mass"), sw_com=sw.get("com"),
+                               sw_inertia=sw.get("inertia")))
     if n_skipped or n_excluded:
         print(f"      (skipped {n_skipped} suppressed/unnamed, "
               f"excluded {n_excluded} components)")
@@ -1572,7 +1640,8 @@ def _component_states(comps):
             is_subassembly=c.is_subassembly,
             world=[float(x) for x in c.world.flatten()],
             fixed=c.fixed, dof=c.dof, mesh_file=c.mesh_file,
-            material=c.material, density=c.density)
+            material=c.material, density=c.density,
+            sw_mass=c.sw_mass, sw_com=c.sw_com, sw_inertia=c.sw_inertia)
             for c in comps]
 
 
@@ -1711,7 +1780,8 @@ def from_graph(graph, exclude=None, expand=None, no_expand=None):
             name=cs.name, link_name=cs.link_name, part_path=cs.part_path,
             is_subassembly=cs.is_subassembly, world=cs.world_matrix(),
             fixed=cs.fixed, dof=cs.dof, mesh_file=cs.mesh_file,
-            material=cs.material, density=cs.density))
+            material=cs.material, density=cs.density,
+            sw_mass=cs.sw_mass, sw_com=cs.sw_com, sw_inertia=cs.sw_inertia))
     names = {c.name for c in comps}
     adjacency = {}
     for e in graph.edges:
@@ -1808,7 +1878,8 @@ def _expand_one(inst, sub, comps, adjacency, ground, deep=None, hidden=None):
             name=gname, link_name=ln, part_path=cs.part_path,
             is_subassembly=cs.is_subassembly, world=world,
             fixed=False, dof=None, mesh_file=cs.mesh_file,
-            material=cs.material, density=cs.density))
+            material=cs.material, density=cs.density,
+            sw_mass=cs.sw_mass, sw_com=cs.sw_com, sw_inertia=cs.sw_inertia))
         name_map[cs.name] = gname
         local_of[cs.name] = local
         world_of[cs.name] = world
@@ -1985,6 +2056,9 @@ def build_model(graph, robot_name=None, base_hint=None, config=None,
             c = by_ln.get(str(k)) or by_nm.get(str(k))
             if c is not None:
                 c.density = float(v)
+                # explicit density => drive mass from the mesh, not the
+                # SolidWorks-native value computed with the CAD material
+                c.density_override = True
             else:
                 print(f"      WARN: densities: '{k}' matched no link")
 

--- a/sw2robot/exporter/state.py
+++ b/sw2robot/exporter/state.py
@@ -23,6 +23,13 @@ class ComponentState(BaseModel):
     mesh_file: str | None = None    # relative path, e.g. "meshes/x.3dxml"
     material: str | None = None     # SolidWorks material name (e.g. "ABS")
     density: float | None = None    # kg/m^3 from that material
+    # SolidWorks-native mass properties of the PART, in its own (part-local)
+    # frame and SI units -- the same frame the mesh is exported in.  Preferred
+    # over the mesh-derived estimate at build time (exact CAD geometry +
+    # material/override, not a tessellation).  None on older extracts.
+    sw_mass: float | None = None              # kg
+    sw_com: list[float] | None = None         # centre of mass [x,y,z] (m)
+    sw_inertia: list[float] | None = None     # (ixx,ixy,ixz,iyy,iyz,izz) about COM
 
     def world_matrix(self):
         return np.array(self.world, float).reshape(4, 4)

--- a/sw2robot/exporter/urdf_writer.py
+++ b/sw2robot/exporter/urdf_writer.py
@@ -33,18 +33,37 @@ def _fmt(v):
 
 
 def _inertial_xml(comp, mesh_dir, density):
-    """Compute and format a link's <inertial> from its mesh; fall back to a
-    small placeholder if the mesh is missing or has no usable volume.  Returns
-    ``(xml_lines, method)`` so the caller can report approximations."""
+    """Compute and format a link's ``<inertial>``.
+
+    Source priority:
+
+    1. SolidWorks-native mass properties (exact CAD geometry + material /
+       manual override), unless the caller passed an explicit global
+       ``density`` or the link carries a per-link density override -- both of
+       which mean "drive the mass from this density instead".
+    2. The mesh estimate (volume x density via trimesh), with the part's
+       SolidWorks material density winning over the global default.
+    3. A small placeholder if neither is usable.
+
+    Returns ``(xml_lines, method)`` so the caller can report which source /
+    approximation each link used."""
     info = None
-    if comp.mesh_file and mesh_dir:
+    # 1. SolidWorks-native values (only when no density override is in force)
+    if density is None and not getattr(comp, "density_override", False):
+        info = _inertia.link_inertial_from_sw(
+            getattr(comp, "sw_mass", None), getattr(comp, "sw_com", None),
+            getattr(comp, "sw_inertia", None),
+            comp.visual_xyz, comp.visual_rpy)
+    # 2. Mesh estimate
+    if info is None and comp.mesh_file and mesh_dir:
         # mesh_file may carry Windows backslashes (extracted on Windows); split
         # on them so os.path.join builds a valid path on any platform.
         rel = comp.mesh_file.replace("\\", "/")
         # per-link density: the part's SolidWorks material wins over the
         # global default (config `density:` still overrides everything via
         # the caller)
-        d = getattr(comp, "density", None) or density
+        d = (getattr(comp, "density", None)
+             or (density if density is not None else _inertia.DEFAULT_DENSITY))
         info = _inertia.link_inertial(
             os.path.join(mesh_dir, *rel.split("/")),
             comp.visual_xyz, comp.visual_rpy, density=d)
@@ -64,12 +83,17 @@ def _inertial_xml(comp, mesh_dir, density):
 
 def _report_inertia(methods):
     """Print a one-line summary of how each link's inertia was obtained, so any
-    approximation (non-watertight mesh) is visible rather than silent."""
+    approximation (non-watertight mesh / placeholder) is visible rather than
+    silent.  ``solidworks`` (exact CAD value) and ``mesh`` (watertight volume
+    integral) are exact; ``hull``/``bbox``/``placeholder`` are approximations."""
     if not methods:
         return
-    exact = methods.get("mesh", 0)
-    approx = {k: v for k, v in methods.items() if k != "mesh"}
-    msg = f"      inertia: {exact} from mesh"
+    _EXACT = ("solidworks", "mesh")
+    exact = {k: v for k, v in methods.items() if k in _EXACT}
+    approx = {k: v for k, v in methods.items() if k not in _EXACT}
+    msg = "      inertia: " + (", ".join(f"{v} from {k}"
+                                         for k, v in sorted(exact.items()))
+                               or "0 exact")
     if approx:
         detail = ", ".join(f"{v} {k}" for k, v in sorted(approx.items()))
         msg += f"; APPROX -> {detail}"
@@ -142,7 +166,7 @@ def _port_xml(port, rn=lambda n: n, link_name=None, joint_name=None):
     ])
 
 
-def write_urdf(model, urdf_path, ros_pkg=None, density=_inertia.DEFAULT_DENSITY,
+def write_urdf(model, urdf_path, ros_pkg=None, density=None,
                link_overrides=None, joint_overrides=None):
     """Write the URDF.  ``link_overrides`` / ``joint_overrides`` map a COMPONENT
     link name / joint name to a user-chosen display name (from the editor's

--- a/tests/e2e/run.mjs
+++ b/tests/e2e/run.mjs
@@ -203,8 +203,10 @@ check('fs: close hides modal', fsClosed === 'none');
 check('fs: empty prompt hidden while robot loaded', await page.evaluate(
   () => document.getElementById('emptyprompt').style.display !== 'block'));
 
-// ---- 7. OS-dialog open buttons (hidden file inputs, robot-compiler style) --
-// uploadFile / FileChooser.accept = exactly what the native dialog does.
+// ---- 7. folder upload (hidden webkitdirectory input, kept for later) -------
+// The 📄/📁 buttons were removed, but the folder-upload plumbing stays: the
+// hidden directory picker still feeds handleDrop (uploaded files -> blob URLs),
+// so clicking it programmatically loads a whole package without a server path.
 const pkgName = await page.evaluate(async () =>
   (await (await fetch('/api/info')).json()).name);
 const pkgDir = path.resolve(
@@ -217,27 +219,19 @@ if (fs.existsSync(pkgUrdf)) {
     [...document.querySelectorAll('#log div')].slice(i)
       .map(d => d.textContent).join('\n'), n);
 
-  let mark = await logLen();
-  await (await page.$('#openfileinput')).uploadFile(pkgUrdf);
-  await sleep(4000);
-  const fileLog = await logAfter(mark);
-  check('open-file: picked .urdf reaches the drop pipeline',
-        /ファイルをドロップ/.test(fileLog) && fileLog.includes('URDF を解析'),
-        fileLog.split('\n')[0]);
-
-  mark = await logLen();
+  const mark = await logLen();
   const [chooser] = await Promise.all([
     page.waitForFileChooser({ timeout: 10000 }),
-    page.click('#openfolder'),
+    page.evaluate(() => document.getElementById('openfolderinput').click()),
   ]);
   await chooser.accept([pkgDir]);     // a DIRECTORY (webkitdirectory input)
   await sleep(30000);
   const dirLog = await logAfter(mark);
-  check('open-folder: package folder loads fully',
+  check('folder-upload: package folder loads fully',
         /\d+ 個のファイルをドロップ/.test(dirLog) && dirLog.includes('カメラを調整しました'),
         (dirLog.match(/dropped \d+ files/) ?? ['?'])[0]);
 } else {
-  console.log(`SKIP  open-file/open-folder (no local ${pkgUrdf})`);
+  console.log(`SKIP  folder-upload (no local ${pkgUrdf})`);
 }
 
 // ---- 8. self-collision: NEW contacts tint the offending links red ----------
@@ -457,57 +451,63 @@ check('extract-ui: mesh export determinate bar (30/55) + seconds',
 await page.evaluate(() => { window._phase = 'done'; });
 await sleep(1500);
 
-// ---- 11. drop-a-.sldasm UX: dim backdrop + spinner + candidate picker ------
+// ---- 11. 🗄 server browser: recent files + filter + paste-a-path extract ----
 await page.evaluate(() => {
   const of = window.fetch.bind(window);
   window.fetch = async (u, opts) => {
     const url = typeof u === 'string' ? u : u?.url;
     const J = o => new Response(JSON.stringify(o),
       { headers: { 'Content-Type': 'application/json' } });
-    if (url && url.includes('/api/locate')) {
-      await new Promise(r => setTimeout(r, 700));
-      return J({ building: false, hits: [
-        { path: 'G:/a/x.SLDASM', size: 1, size_match: false },
-        { path: 'G:/b/x.SLDASM', size: 2, size_match: false }] });
-    }
+    if (url && url.includes('/api/recent'))
+      return J(['G:/proj/recent_arm.SLDASM', 'G:/proj/recent_gripper.SLDASM']);
+    if (url && url.includes('/api/list'))
+      return J([{ name: 'built_pkg', path: 'C:/out/built_pkg' }]);
+    if (url && url.includes('/api/fs'))           // server browser root
+      return J({ path: '', parent: null, dirs: [], files: [] });
     if (url && url.includes('/api/extract?')) return J({ started: true });
     if (url && url.includes('/api/extract/status'))
       return J({ running: true, error: null, log: ['starting SolidWorks ...'] });
     return of(u, opts);
   };
-  window.sw2robot.locateAndExtract('C:/drop/x.SLDASM', 12345);
 });
-await sleep(300);
-const loc = await page.evaluate(() => ({
-  backdrop: getComputedStyle(document.getElementById('loadbackdrop')).display,
-  text: document.getElementById('loadbar').querySelector('.lb-text').textContent,
-}));
-check('drop-sldasm: dim + spinner during locate',
-      loc.backdrop === 'block' && /検索中/.test(loc.text), JSON.stringify(loc));
-await sleep(700);
-const pick = await page.evaluate(() => {
-  const ov = [...document.querySelectorAll('#viewwrap > div')].find(d =>
-    d.style.zIndex === '9' && /複数見つかりました/.test(d.textContent));
-  return { shown: !!ov,
-    backdrop: getComputedStyle(document.getElementById('loadbackdrop')).display,
-    btns: ov ? ov.querySelectorAll('button').length : 0 };
+// 🗄 surfaces SolidWorks recent files (⭐) AND built packages (⭐📦) at the root
+await page.evaluate(() => document.getElementById('fsbrowse').click());
+await sleep(400);
+const recent = await page.evaluate(() => {
+  const rows = [...document.querySelectorAll('#fslist > div')];
+  return {
+    star: rows.some(d => /⭐/.test(d.textContent) && /recent_arm/i.test(d.textContent)),
+    pkg: rows.some(d => /built_pkg/.test(d.textContent)),
+  };
 });
-check('drop-sldasm: prominent candidate picker (dim stays)',
-      pick.shown && pick.btns >= 3 && pick.backdrop === 'block',
-      JSON.stringify(pick));
+check('server-browser: lists recent files (⭐) and built packages',
+      recent.star && recent.pkg, JSON.stringify(recent));
+// filter narrows the listing to matching rows
 await page.evaluate(() => {
-  [...document.querySelectorAll('#viewwrap > div')].find(d =>
-    d.style.zIndex === '9' && /複数見つかりました/.test(d.textContent))
-    .querySelector('button').click();
+  const f = document.getElementById('fsfilter');
+  f.value = 'gripper'; f.dispatchEvent(new Event('input'));
 });
-await sleep(1500);
-const af = await page.evaluate(() => ({
-  gone: ![...document.querySelectorAll('#viewwrap > div')].some(d =>
-    d.style.zIndex === '9' && /複数見つかりました/.test(d.textContent)),
+await sleep(120);
+const filt = await page.evaluate(() => {
+  const vis = [...document.querySelectorAll('#fslist > div')]
+    .filter(d => d.style.display !== 'none').map(d => d.textContent);
+  return { n: vis.length, hasGripper: vis.some(t => /gripper/i.test(t)),
+           hasArm: vis.some(t => /recent_arm/i.test(t)) };
+});
+check('server-browser: filter narrows to matching rows',
+      filt.hasGripper && !filt.hasArm, JSON.stringify(filt));
+// the path bar IS the paste-path: type a .sldasm path + Enter -> extraction
+await page.evaluate(() => {
+  const el = document.getElementById('fspath');
+  el.value = '  "C:\\\\drop\\\\x.SLDASM"  ';     // quoted + padded, like "Copy as path"
+  el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+});
+await sleep(1200);
+const paste = await page.evaluate(() => ({
   text: document.getElementById('loadbar').querySelector('.lb-text').textContent,
 }));
-check('drop-sldasm: picking a candidate starts extraction',
-      af.gone && /SolidWorks|抽出/.test(af.text), JSON.stringify(af));
+check('server-browser: pasting a .sldasm path into the bar starts extraction',
+      /SolidWorks|抽出/.test(paste.text), JSON.stringify(paste));
 
 check('suite: no page errors at end', pageErrors.length === 0,
       pageErrors.join(' | '));

--- a/tests/test_sw_inertia.py
+++ b/tests/test_sw_inertia.py
@@ -1,0 +1,117 @@
+"""SolidWorks-native mass properties: the tensor reconstruction (principal
+moments + axes -> tensor about the COM), the link-frame transform, and the
+urdf_writer source priority (SolidWorks > mesh > placeholder)."""
+import xml.etree.ElementTree as ET
+
+import numpy as np
+
+
+# ---------------------------------------------------------------- reconstruction
+def test_sw_mass_props_reconstructs_tensor_from_principal_axes():
+    """A fake IMassProperty whose principal axes are a known rotation of the
+    part frame must round-trip to the full tensor in part axes: I = R^T D R."""
+    from sw2robot.exporter.model import _sw_mass_props
+
+    # principal moments and a rotation (its rows are the principal axes in the
+    # part frame -- SolidWorks' PrincipalAxesOfInertia layout)
+    pm = [2.0, 5.0, 9.0]
+    from scipy.spatial.transform import Rotation
+    R = Rotation.from_euler("xyz", [0.3, -0.7, 1.1]).as_matrix()
+    expected = R.T @ np.diag(pm) @ R
+
+    class FakeMP:
+        Mass = 1.25
+        CenterOfMass = (0.01, -0.02, 0.03)
+        PrincipalMomentsOfInertia = tuple(pm)
+        PrincipalAxesOfInertia = tuple(R.flatten())
+
+    mass, com, inertia6 = _sw_mass_props(FakeMP())
+    assert mass == 1.25
+    assert np.allclose(com, [0.01, -0.02, 0.03])
+    ixx, ixy, ixz, iyy, iyz, izz = inertia6
+    got = np.array([[ixx, ixy, ixz], [ixy, iyy, iyz], [ixz, iyz, izz]])
+    assert np.allclose(got, expected, atol=1e-9)
+
+
+def test_sw_mass_props_rejects_degenerate():
+    from sw2robot.exporter.model import _sw_mass_props
+
+    class NoMass:
+        Mass = 0.0
+        CenterOfMass = (0, 0, 0)
+        PrincipalMomentsOfInertia = (1, 1, 1)
+        PrincipalAxesOfInertia = tuple(np.eye(3).flatten())
+
+    assert _sw_mass_props(NoMass()) == (None, None, None)
+
+
+# ---------------------------------------------------------------- transform
+def test_link_inertial_from_sw_identity_origin():
+    """With an identity visual origin the SW values pass through unchanged."""
+    from sw2robot.exporter.inertia import link_inertial_from_sw
+
+    info = link_inertial_from_sw(
+        2.0, [0.1, 0.0, 0.0], (3.0, 0.0, 0.0, 4.0, 0.0, 5.0),
+        visual_xyz=[0, 0, 0], visual_rpy=[0, 0, 0])
+    assert info["method"] == "solidworks"
+    assert info["mass"] == 2.0
+    assert np.allclose(info["com"], [0.1, 0.0, 0.0])
+    assert np.allclose(info["inertia"], (3.0, 0.0, 0.0, 4.0, 0.0, 5.0))
+
+
+def test_link_inertial_from_sw_rotation_translation():
+    """A 90 deg rotation about Z swaps the x/y diagonal terms; the COM is both
+    rotated and translated."""
+    from sw2robot.exporter.inertia import link_inertial_from_sw
+
+    info = link_inertial_from_sw(
+        1.0, [1.0, 0.0, 0.0], (2.0, 0.0, 0.0, 7.0, 0.0, 9.0),
+        visual_xyz=[0.0, 0.0, 0.5], visual_rpy=[0.0, 0.0, np.pi / 2])
+    # com: Rz(90)@[1,0,0] = [0,1,0], then + [0,0,0.5]
+    assert np.allclose(info["com"], [0.0, 1.0, 0.5], atol=1e-9)
+    ixx, ixy, ixz, iyy, iyz, izz = info["inertia"]
+    # ixx/iyy swap under a 90 deg Z rotation; izz unchanged
+    assert np.isclose(ixx, 7.0, atol=1e-9)
+    assert np.isclose(iyy, 2.0, atol=1e-9)
+    assert np.isclose(izz, 9.0, atol=1e-9)
+
+
+def test_link_inertial_from_sw_none_on_missing():
+    from sw2robot.exporter.inertia import link_inertial_from_sw
+    assert link_inertial_from_sw(None, None, None, [0, 0, 0], [0, 0, 0]) is None
+
+
+# ---------------------------------------------------------------- writer priority
+def _model_with_sw():
+    from sw2robot.exporter.model import Component, RobotModel
+    c = Component(name="Part-1", link_name="base_link", part_path=None,
+                  is_subassembly=False, world=np.eye(4), fixed=True, dof=0,
+                  sw_mass=3.5, sw_com=[0.0, 0.0, 0.1],
+                  sw_inertia=[0.2, 0.0, 0.0, 0.3, 0.0, 0.4])
+    return RobotModel(name="demo", components=[c], joints=[],
+                      base_link="base_link")
+
+
+def test_writer_prefers_solidworks_values(tmp_path):
+    from sw2robot.exporter import urdf_writer
+    out = tmp_path / "urdf" / "demo.urdf"
+    urdf_writer.write_urdf(_model_with_sw(), str(out))   # no mesh, no density
+    inertial = ET.parse(out).getroot().find("link/inertial")
+    assert float(inertial.find("mass").get("value")) == 3.5
+    assert np.allclose([float(x) for x in inertial.find("origin").get("xyz").split()],
+                       [0.0, 0.0, 0.1])
+    inr = inertial.find("inertia")
+    assert np.isclose(float(inr.get("ixx")), 0.2)
+    assert np.isclose(float(inr.get("izz")), 0.4)
+
+
+def test_explicit_density_overrides_solidworks(tmp_path):
+    """An explicit global density means 'drive mass from this density' -> the
+    SolidWorks values are NOT used (here there is no mesh either, so it falls
+    through to the placeholder, proving the SW branch was skipped)."""
+    from sw2robot.exporter import urdf_writer
+    out = tmp_path / "urdf" / "demo.urdf"
+    urdf_writer.write_urdf(_model_with_sw(), str(out), density=1200.0)
+    inertial = ET.parse(out).getroot().find("link/inertial")
+    # placeholder mass (0.1), not the SW 3.5
+    assert float(inertial.find("mass").get("value")) == 0.1


### PR DESCRIPTION
Three related improvements to the SolidWorks → URDF exporter and the web editor.

## 1. SolidWorks-native mass properties for link inertials
Extract mass, centre of mass and the inertia tensor straight from each part's `IMassProperty` (exact CAD geometry + assigned material / manual override) and emit them into the URDF `<inertial>`, instead of always re-deriving them from the tessellated mesh and a guessed density.

- `model._sw_mass_props`: rebuild the COM-frame tensor from principal moments + principal axes (`I = R^T diag(P) R`), in the part-local frame, SI units.
- `inertia.link_inertial_from_sw`: map those into the link frame with the same visual-origin transform the mesh path uses.
- Writer priority: **SolidWorks > mesh > placeholder**; an explicit global/per-link density still drives the mass from the mesh. Values persist through `graph.json` (older extracts still load) and sub-assembly expansion.
- Falls back to the mesh estimate whenever the SolidWorks values are missing/degenerate. Adds unit tests for the tensor reconstruction, the link-frame transform and the writer priority.

## 2. Open via server-side browser + paste-path; drop the disk index
The editor relied on a name-based `.sldasm` lookup backed by a walk of hardcoded CAD shares plus a fallback walk of local Desktop/Downloads/Documents — slow and not portable to anyone else's machine. Browsers never hand a dropped/picked file its real path anyway, so the only reliable, hardcoding-free ways to name a file are the server reading its own filesystem or the user pasting a path.

- Removed: the `.sldasm` index, the CAD-share config (drive letter, shared-drive locale names, `cad_root_rels`, `config.json`) and `--cad-roots`, the local-folder walk and `/api/locate`, and the 📄/📁 buttons.
- The 🗄 server browser is now the primary entry: recent SolidWorks files (MRU) + built packages at the root, an editable path bar (paste a full path → open/extract, else navigate), type-to-narrow filtering, and a remembered last directory.
- Folder-upload (view a package without a server path) is kept for later via the hidden directory picker + drag&drop, just without a visible button. E2E updated accordingly.

## 3. Clear banner when the backend goes away
When the local server stops, every fetch throws `TypeError: Failed to fetch` — previously a cryptic "promise rejected" log line. Now a `fetch` wrapper raises a persistent top banner ("lost connection — restart the server, then reload") with a reload button, and clears it automatically when the server is back. Genuine JS errors still log as before; errors are re-thrown so existing per-call handling is unchanged.

## Notes
- No hardcoded site-specific paths remain in the source.
- Known follow-up (not in this PR): `swcom.py` pins the SolidWorks 2024 typelib (`major=32`); auto-detecting the installed version would help other-version users.

## Testing
- `ruff check`: clean
- `pytest`: 84 passed, 7 skipped
- `index.html` / `tests/e2e/run.mjs`: `node --check` clean