### PR TITLE
Bump version to 0.1.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sw2robot"
-version = "0.1.6"
+version = "0.1.7"
 description = "SolidWorks assembly -> URDF exporter with a browser-based editor"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Release the changes merged in #25 (SolidWorks-native link inertials; server-browser + paste-path open flow with the disk index removed; backend-down banner). `main` was already at 0.1.6 from #23, so this is the bump that covers #25.

`pyproject.toml`: 0.1.6 → 0.1.7