### PR TITLE
Editor: reuse the running SolidWorks; reap any instance we spawn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ tests/e2e/package-lock.json
 _server*.txt
 _client_report.json
 _sldasm_index.json
+_sw_spawned_pids.txt

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -854,6 +854,8 @@ skrobot / native-mesh consumers (not RViz-loadable)">⬇ glb</button></a>
     'extract.bar': { en: 'extracting from SolidWorks …', ja: 'SolidWorks から抽出中 …' },
     'extract.failed': { en: a => `extraction FAILED: ${a.e}`, ja: a => `抽出に失敗: ${a.e}` },
     'extract.done': { en: a => `extraction finished in ${a.time} ✓`, ja: a => `抽出が ${a.time} で完了 ✓` },
+    'extract.cancelling': { en: 'cancelling extraction … (stops at the next step)', ja: '抽出をキャンセル中 … (次の処理の区切りで停止します)' },
+    'extract.cancelled': { en: 'extraction cancelled', ja: '抽出をキャンセルしました' },
     'extract.statusElapsed': { en: a => `⏳ extracting … ${a.time}`, ja: a => `⏳ 抽出中 … ${a.time}` },
     'extract.meshBar': { en: a => `mesh ${a.i}/${a.n}  ${a.name}`, ja: a => `メッシュ ${a.i}/${a.n}  ${a.name}` },
     'extract.meshSub': { en: a => `exporting meshes — ${a.time}`, ja: a => `メッシュ出力中 — ${a.time}` },
@@ -4039,6 +4041,7 @@ document.getElementById('resetview').addEventListener('click', resetView);
 // the robot's joints/links, so removing the robot drops them too; we only have
 // to undim the SHARED materials TF may have dimmed and clear the JS-side state.
 function clearViewer() {
+  if (extracting) { cancelExtraction(); return; }  // interrupt a running extract
   if (!viewer.robot) { return; }                 // already empty
   op('clearViewer', {});
   if (mimicMode) { cancelMimic(); }
@@ -4292,6 +4295,7 @@ window.addEventListener('keydown', ev => {
 
 // ---- export box ----------------------------------------------------------
 async function openServerPath(p) {
+  await ensureNoExtraction();           // interrupt a running extraction first
   log(`/api/open ${p}`);
   const resp = await fetch('/api/open?path=' + encodeURIComponent(p));
   const info = await resp.json();
@@ -4329,8 +4333,27 @@ function extractPhase(line) {
   return t('phase.extracting');
 }
 
+// extraction runs SolidWorks in a server-side thread that checks a cancel flag
+// at every progress checkpoint (per phase / per mesh), so it can be interrupted
+// part-way through a heavy file.
+let extracting = false;
+function cancelExtraction() {
+  log(t('extract.cancelling'), 'wrn');
+  return fetch('/api/extract/cancel').catch(() => {});
+}
+// stop any running extraction before starting/loading something new, and wait
+// for it to actually settle (cooperative cancel lands within ~one mesh)
+async function ensureNoExtraction() {
+  if (!extracting) { return; }
+  await cancelExtraction();
+  for (let i = 0; i < 120 && extracting; i++) {
+    await new Promise(r => setTimeout(r, 500));
+  }
+}
+
 // SolidWorks extraction: start the job, stream its progress into the log
 async function extractFlow(p) {
+  await ensureNoExtraction();           // a heavy job in flight? cancel it first
   log(t('extract.request', { p }), 'wrn');
   statusEl.textContent = t('extract.statusRunning');
   const resp = await fetch('/api/extract?path=' + encodeURIComponent(p));
@@ -4340,6 +4363,7 @@ async function extractFlow(p) {
     return;
   }
   log(t('extract.started'));
+  extracting = true;
   showLoadbar(t('extract.bar'), { indet: true });
   const t0 = performance.now();
   let seen = 0;
@@ -4353,6 +4377,14 @@ async function extractFlow(p) {
 
     if (!st.running) {
       clearInterval(poll);
+      extracting = false;
+      if (st.cancelled) {
+        hideLoadbar();
+        document.getElementById('loadbackdrop').style.display = 'none';
+        statusEl.textContent = t('extract.cancelled');
+        log(t('extract.cancelled'), 'wrn');
+        return;
+      }
       if (st.error) {
         hideLoadbar();
         document.getElementById('loadbackdrop').style.display = 'none';

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -486,8 +486,14 @@ def _snapshot(pkg_dir, yml, label):
 
 
 # one extraction job at a time (SolidWorks is a singleton resource anyway)
-_job = {"running": False, "log": [], "error": None, "package": None}
+_job = {"running": False, "log": [], "error": None, "package": None,
+        "cancel": False, "cancelled": False}
 _job_lock = threading.Lock()
+
+
+class _CancelExtract(Exception):
+    """Raised from the progress callback to abort the extract cooperatively
+    when the user asked to cancel (via /api/extract/cancel)."""
 # warm SolidWorks session kept across extractions: starting SolidWorks is
 # by far the slowest stage (~1-2 min), so pay it once per server lifetime
 _sw = {"sess": None}
@@ -572,6 +578,10 @@ def _shutdown_sw():
 def _run_extract(sldasm):
     """Background thread: SolidWorks extract + build -> module package."""
     def progress(msg):
+        # cooperative cancel: the extract calls progress() between COM steps
+        # (per phase, per mesh), so raising here aborts at the next checkpoint
+        if _job.get("cancel"):
+            raise _CancelExtract()
         _job["log"].append(str(msg))
         print(f"[sw2robot.web] extract: {msg}")
 
@@ -630,6 +640,17 @@ def _run_extract(sldasm):
         _preconvert_meshes(str(state.package_dir))
         progress(f"done -> {state.package_dir} (SolidWorks kept warm for "
                  f"the next extraction)")
+    except _CancelExtract:
+        # the COM sequence was aborted mid-flight, so the warm session may hold
+        # a half-open doc -- tear it down so the next extraction starts clean
+        _job["cancelled"] = True
+        _job["log"].append("cancelled by user; resetting SolidWorks session ...")
+        print("[sw2robot.web] extract CANCELLED by user")
+        try:
+            _shutdown_sw()
+        except Exception:
+            pass
+        _job["log"].append("cancelled.")
     except Exception as e:
         from sw2robot.exporter.swcom import SolidWorksUnavailable
         _job["error"] = f"{type(e).__name__}: {e}"
@@ -1081,12 +1102,19 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                             {"error": "an extraction is already running"},
                             409)
                     _job.update(running=True, log=[], error=None,
-                                package=None)
+                                package=None, cancel=False, cancelled=False)
                 threading.Thread(target=_run_extract, args=(target,),
                                  daemon=True).start()
                 return self._send_json({"started": True})
             if path == "/api/extract/status":
                 return self._send_json(_job)
+            if path == "/api/extract/cancel":
+                # cooperative: the extract thread checks _job["cancel"] at its
+                # next progress() checkpoint and aborts (see _run_extract)
+                running = _job["running"]
+                if running:
+                    _job["cancel"] = True
+                return self._send_json({"cancelling": running})
             if path == "/api/open":
                 target = (query.get("path") or [""])[0]
                 try:

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -498,6 +498,64 @@ class _CancelExtract(Exception):
 # by far the slowest stage (~1-2 min), so pay it once per server lifetime
 _sw = {"sess": None}
 
+# We prefer to ATTACH to the user's running SolidWorks (no new process). When we
+# can't (no attachable instance) we spawn a private one -- and that one can leak
+# if the server is hard-killed (atexit never runs).  Record each PID we spawn to
+# a file so the NEXT startup (and a clean shutdown) can reap exactly our own
+# orphans, never the user's interactive SolidWorks.
+_SW_PID_FILE = os.path.join(_DATA_DIR, "_sw_spawned_pids.txt")
+
+
+def _sldworks_pids():
+    """Set of PIDs of every running SLDWORKS.exe (empty on failure/non-Windows)."""
+    import subprocess
+    try:
+        out = subprocess.run(
+            ["tasklist", "/FI", "IMAGENAME eq SLDWORKS.exe", "/FO", "CSV",
+             "/NH"], capture_output=True, text=True, timeout=10).stdout
+    except Exception:
+        return set()
+    pids = set()
+    for line in out.splitlines():
+        parts = [p.strip().strip('"') for p in line.split('","')]
+        if len(parts) >= 2 and parts[0].lower().startswith("sldworks"):
+            try:
+                pids.add(int(parts[1]))
+            except ValueError:
+                pass
+    return pids
+
+
+def _record_spawned_pid(pid):
+    try:
+        with open(_SW_PID_FILE, "a", encoding="utf-8") as f:
+            f.write(f"{pid}\n")
+    except OSError as e:
+        print(f"[sw2robot.web] could not record spawned SW pid: {e!r}")
+
+
+def _reap_spawned_sw():
+    """Kill any SLDWORKS.exe THIS tool spawned in a previous/this run (matched
+    by recorded PID, and only if it is still a live SLDWORKS.exe), then clear
+    the record.  Never touches the user's interactive SolidWorks."""
+    try:
+        with open(_SW_PID_FILE, encoding="utf-8") as f:
+            recorded = {int(x) for x in f.read().split() if x.strip().isdigit()}
+    except OSError:
+        return
+    import subprocess
+    for pid in recorded & _sldworks_pids():       # PID-reuse safe: must still be SW
+        try:
+            subprocess.run(["taskkill", "/PID", str(pid), "/F", "/T"],
+                           capture_output=True, timeout=10)
+            print(f"[sw2robot.web] reaped leftover spawned SolidWorks (pid {pid})")
+        except Exception:
+            pass
+    try:
+        os.remove(_SW_PID_FILE)
+    except OSError:
+        pass
+
 
 def _warm_sw(progress):
     sess = _sw["sess"]
@@ -569,10 +627,11 @@ def _shutdown_sw():
     sess = _sw.get("sess")
     if sess is not None:
         try:
-            sess.shutdown()
+            sess.shutdown()        # attach mode leaves the user's SW alone
         except Exception:
             pass
         _sw["sess"] = None
+    _reap_spawned_sw()             # belt-and-suspenders: kill any we spawned
 
 
 def _run_extract(sldasm):
@@ -626,13 +685,26 @@ def _run_extract(sldasm):
         sw = _warm_sw(progress)
         if sw is None:
             from sw2robot.exporter.swcom import SolidWorks
-            progress("starting SolidWorks (this can take a minute; later "
-                     "extractions reuse this session) ...")
-            # Create the COM object in THIS thread.  SolidWorks is STA-bound:
-            # an instance built on another thread (e.g. a timeout worker) loses
-            # its apartment when that thread ends, so OpenDoc6 then fails with
-            # CO_E_OBJNOTCONNECTED ("object not connected to server").
-            sw = SolidWorks(visible=False)
+            # Reuse the user's ALREADY-RUNNING SolidWorks if we can attach to it
+            # (same login session): no new process to start (instant, no ~1 min
+            # cold start) and nothing to leak.  The throwaway copy is opened in
+            # that instance and closed afterwards; the user's own documents are
+            # never modified.
+            try:
+                progress("attaching to the running SolidWorks ...")
+                sw = SolidWorks(attach=True)
+                progress("attached to the running SolidWorks ✓ (reusing it)")
+            except Exception:
+                progress("no attachable SolidWorks; starting a private instance "
+                         "(this can take a minute; later extractions reuse it) ...")
+                # Create the COM object in THIS thread.  SolidWorks is STA-bound:
+                # an instance built on another thread (e.g. a timeout worker)
+                # loses its apartment when that thread ends, so OpenDoc6 then
+                # fails with CO_E_OBJNOTCONNECTED ("object not connected").
+                before = _sldworks_pids()
+                sw = SolidWorks(visible=False)
+                for pid in _sldworks_pids() - before:   # the one(s) we just spawned
+                    _record_spawned_pid(pid)
             _sw["sess"] = sw
         state = core.extract_and_import(
             sldasm, out_dir=_Handler.root_dir, progress=progress, sw=sw)
@@ -1862,7 +1934,19 @@ class _Handler(http.server.BaseHTTPRequestHandler):
 
 def serve(package_dir=None, root_dir=None, port=8090, open_browser=True):
     import atexit
+    import signal
+    # reap any private SolidWorks instance a PREVIOUS run spawned and leaked
+    # (hard-killed before atexit could run) -- by recorded PID, never the user's
+    _reap_spawned_sw()
     atexit.register(_shutdown_sw)     # close the warm session on exit
+    # also catch Ctrl+C / termination so the spawned instance is torn down
+    # rather than orphaned (atexit does not run on a signal default-kill)
+    for _sig in (getattr(signal, "SIGINT", None), getattr(signal, "SIGTERM", None)):
+        if _sig is not None:
+            try:
+                signal.signal(_sig, lambda *_a: (_shutdown_sw(), os._exit(0)))
+            except (ValueError, OSError):
+                pass            # not in main thread / unsupported -- atexit covers it
     threading.Thread(target=_keepalive_loop, daemon=True).start()
     _Handler.root_dir = os.path.abspath(root_dir or _default_root())
     if package_dir:


### PR DESCRIPTION
Fixes orphan `SLDWORKS.exe` processes piling up across repeated server starts: each run spawned its own private instance, and a hard kill (no `atexit`) leaked it.

**Stacked on #29** (the attach logic sits in `_run_extract` alongside the cancel handling). Base retargets to `main` once #28 and #29 merge.

## How
- **Attach-first**: when there's no warm session, attach to the user's already-running SolidWorks (same login session) and reuse it instead of spawning. No new process to start (skips the ~1 min cold start) or to leak. The throwaway copy is opened in that instance and closed afterwards; the user's own documents aren't modified.
- **Reap what we spawn**: when nothing is attachable and we must spawn, record the new PID to a file and reap exactly those PIDs — on the **next startup** (covers a hard-killed previous run that skipped `atexit`) and on **shutdown** (`atexit` + SIGINT/SIGTERM) — and only if the PID is still a live `SLDWORKS.exe` (PID-reuse safe). The user's interactive SolidWorks is never touched (attach mode never `ExitApp`s; reaping is PID-scoped). PID file is gitignored.

## Caveat
Attach mode opens the copy in the user's **visible** SolidWorks, so a long extract occupies it; only available when attachable (same login session). When not attachable it falls back to a private instance (now reliably reaped).

## Testing
- `ruff check`: clean · `pytest`: 84 passed, 7 skipped