### PR TITLE
Editor: cancel a running SolidWorks extraction

### DIFF
--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -854,6 +854,8 @@ skrobot / native-mesh consumers (not RViz-loadable)">⬇ glb</button></a>
     'extract.bar': { en: 'extracting from SolidWorks …', ja: 'SolidWorks から抽出中 …' },
     'extract.failed': { en: a => `extraction FAILED: ${a.e}`, ja: a => `抽出に失敗: ${a.e}` },
     'extract.done': { en: a => `extraction finished in ${a.time} ✓`, ja: a => `抽出が ${a.time} で完了 ✓` },
+    'extract.cancelling': { en: 'cancelling extraction … (stops at the next step)', ja: '抽出をキャンセル中 … (次の処理の区切りで停止します)' },
+    'extract.cancelled': { en: 'extraction cancelled', ja: '抽出をキャンセルしました' },
     'extract.statusElapsed': { en: a => `⏳ extracting … ${a.time}`, ja: a => `⏳ 抽出中 … ${a.time}` },
     'extract.meshBar': { en: a => `mesh ${a.i}/${a.n}  ${a.name}`, ja: a => `メッシュ ${a.i}/${a.n}  ${a.name}` },
     'extract.meshSub': { en: a => `exporting meshes — ${a.time}`, ja: a => `メッシュ出力中 — ${a.time}` },
@@ -4039,6 +4041,7 @@ document.getElementById('resetview').addEventListener('click', resetView);
 // the robot's joints/links, so removing the robot drops them too; we only have
 // to undim the SHARED materials TF may have dimmed and clear the JS-side state.
 function clearViewer() {
+  if (extracting) { cancelExtraction(); return; }  // interrupt a running extract
   if (!viewer.robot) { return; }                 // already empty
   op('clearViewer', {});
   if (mimicMode) { cancelMimic(); }
@@ -4292,6 +4295,7 @@ window.addEventListener('keydown', ev => {
 
 // ---- export box ----------------------------------------------------------
 async function openServerPath(p) {
+  await ensureNoExtraction();           // interrupt a running extraction first
   log(`/api/open ${p}`);
   const resp = await fetch('/api/open?path=' + encodeURIComponent(p));
   const info = await resp.json();
@@ -4329,8 +4333,27 @@ function extractPhase(line) {
   return t('phase.extracting');
 }
 
+// extraction runs SolidWorks in a server-side thread that checks a cancel flag
+// at every progress checkpoint (per phase / per mesh), so it can be interrupted
+// part-way through a heavy file.
+let extracting = false;
+function cancelExtraction() {
+  log(t('extract.cancelling'), 'wrn');
+  return fetch('/api/extract/cancel').catch(() => {});
+}
+// stop any running extraction before starting/loading something new, and wait
+// for it to actually settle (cooperative cancel lands within ~one mesh)
+async function ensureNoExtraction() {
+  if (!extracting) { return; }
+  await cancelExtraction();
+  for (let i = 0; i < 120 && extracting; i++) {
+    await new Promise(r => setTimeout(r, 500));
+  }
+}
+
 // SolidWorks extraction: start the job, stream its progress into the log
 async function extractFlow(p) {
+  await ensureNoExtraction();           // a heavy job in flight? cancel it first
   log(t('extract.request', { p }), 'wrn');
   statusEl.textContent = t('extract.statusRunning');
   const resp = await fetch('/api/extract?path=' + encodeURIComponent(p));
@@ -4340,6 +4363,7 @@ async function extractFlow(p) {
     return;
   }
   log(t('extract.started'));
+  extracting = true;
   showLoadbar(t('extract.bar'), { indet: true });
   const t0 = performance.now();
   let seen = 0;
@@ -4353,6 +4377,14 @@ async function extractFlow(p) {
 
     if (!st.running) {
       clearInterval(poll);
+      extracting = false;
+      if (st.cancelled) {
+        hideLoadbar();
+        document.getElementById('loadbackdrop').style.display = 'none';
+        statusEl.textContent = t('extract.cancelled');
+        log(t('extract.cancelled'), 'wrn');
+        return;
+      }
       if (st.error) {
         hideLoadbar();
         document.getElementById('loadbackdrop').style.display = 'none';

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -486,8 +486,14 @@ def _snapshot(pkg_dir, yml, label):
 
 
 # one extraction job at a time (SolidWorks is a singleton resource anyway)
-_job = {"running": False, "log": [], "error": None, "package": None}
+_job = {"running": False, "log": [], "error": None, "package": None,
+        "cancel": False, "cancelled": False}
 _job_lock = threading.Lock()
+
+
+class _CancelExtract(Exception):
+    """Raised from the progress callback to abort the extract cooperatively
+    when the user asked to cancel (via /api/extract/cancel)."""
 # warm SolidWorks session kept across extractions: starting SolidWorks is
 # by far the slowest stage (~1-2 min), so pay it once per server lifetime
 _sw = {"sess": None}
@@ -572,6 +578,10 @@ def _shutdown_sw():
 def _run_extract(sldasm):
     """Background thread: SolidWorks extract + build -> module package."""
     def progress(msg):
+        # cooperative cancel: the extract calls progress() between COM steps
+        # (per phase, per mesh), so raising here aborts at the next checkpoint
+        if _job.get("cancel"):
+            raise _CancelExtract()
         _job["log"].append(str(msg))
         print(f"[sw2robot.web] extract: {msg}")
 
@@ -630,6 +640,17 @@ def _run_extract(sldasm):
         _preconvert_meshes(str(state.package_dir))
         progress(f"done -> {state.package_dir} (SolidWorks kept warm for "
                  f"the next extraction)")
+    except _CancelExtract:
+        # the COM sequence was aborted mid-flight, so the warm session may hold
+        # a half-open doc -- tear it down so the next extraction starts clean
+        _job["cancelled"] = True
+        _job["log"].append("cancelled by user; resetting SolidWorks session ...")
+        print("[sw2robot.web] extract CANCELLED by user")
+        try:
+            _shutdown_sw()
+        except Exception:
+            pass
+        _job["log"].append("cancelled.")
     except Exception as e:
         from sw2robot.exporter.swcom import SolidWorksUnavailable
         _job["error"] = f"{type(e).__name__}: {e}"
@@ -1081,12 +1102,19 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                             {"error": "an extraction is already running"},
                             409)
                     _job.update(running=True, log=[], error=None,
-                                package=None)
+                                package=None, cancel=False, cancelled=False)
                 threading.Thread(target=_run_extract, args=(target,),
                                  daemon=True).start()
                 return self._send_json({"started": True})
             if path == "/api/extract/status":
                 return self._send_json(_job)
+            if path == "/api/extract/cancel":
+                # cooperative: the extract thread checks _job["cancel"] at its
+                # next progress() checkpoint and aborts (see _run_extract)
+                running = _job["running"]
+                if running:
+                    _job["cancel"] = True
+                return self._send_json({"cancelling": running})
             if path == "/api/open":
                 target = (query.get("path") or [""])[0]
                 try:


### PR DESCRIPTION
Re-opened: the original #29 was auto-closed when its base branch (editor-open-ux, now merged via #28) was deleted. Same change — cooperative cancellation of a running SolidWorks extraction (🗑 Clear / opening another file aborts it; the progress poller surfaces a cancelled state).