### PR TITLE
Exporter: physics sanity-check every link's inertial

### DIFF
--- a/sw2robot/exporter/inertia.py
+++ b/sw2robot/exporter/inertia.py
@@ -143,6 +143,45 @@ def link_inertial_from_sw(mass, com_local, inertia6_local,
     }
 
 
+def validate_inertia(mass, inertia6, rel_tol=1e-6):
+    """Physics sanity-check one link's inertial; return a list of problem
+    strings (empty list == OK).
+
+    A real rigid body's inertia tensor (taken about the centre of mass) must be
+    symmetric **positive definite** -- all principal moments (eigenvalues
+    ``I1 <= I2 <= I3``) strictly positive -- and those moments must satisfy the
+    **triangle inequality** ``I1 + I2 >= I3`` (the geometric constraint every
+    physical mass distribution obeys; the other two combinations follow once all
+    are positive).  Violating either makes a simulator's integrator diverge, and
+    usually signals a units / frame / transform bug upstream.
+
+    ``rel_tol`` is applied relative to the largest principal moment so ordinary
+    floating-point / tessellation noise does not trip the checks."""
+    problems = []
+    if mass is None or not np.isfinite(mass) or mass <= 0:
+        problems.append(f"mass is not positive (= {mass})")
+    try:
+        ixx, ixy, ixz, iyy, iyz, izz = (float(x) for x in inertia6)
+    except (TypeError, ValueError):
+        problems.append("inertia is not a 6-tuple (ixx,ixy,ixz,iyy,iyz,izz)")
+        return problems
+    I = np.array([[ixx, ixy, ixz], [ixy, iyy, iyz], [ixz, iyz, izz]], float)
+    if not np.all(np.isfinite(I)):
+        problems.append("inertia tensor has non-finite entries")
+        return problems
+    e = np.linalg.eigvalsh(I)                 # ascending, real (symmetric)
+    atol = rel_tol * max(abs(float(e[-1])), 1e-12)
+    if e[0] <= atol:
+        problems.append(
+            "inertia tensor is not positive definite "
+            f"(smallest principal moment {e[0]:.4g} <= 0)")
+    elif e[0] + e[1] < e[2] - atol:           # triangle inequality (binding pair)
+        problems.append(
+            "principal moments violate the triangle inequality "
+            f"(I1+I2 < I3: {e[0]:.4g} + {e[1]:.4g} < {e[2]:.4g})")
+    return problems
+
+
 _PROPS_CACHE = {}
 
 

--- a/sw2robot/exporter/urdf_writer.py
+++ b/sw2robot/exporter/urdf_writer.py
@@ -45,8 +45,9 @@ def _inertial_xml(comp, mesh_dir, density):
        SolidWorks material density winning over the global default.
     3. A small placeholder if neither is usable.
 
-    Returns ``(xml_lines, method)`` so the caller can report which source /
-    approximation each link used."""
+    Returns ``(xml_lines, method, problems)`` so the caller can report which
+    source / approximation each link used and flag any physically invalid
+    inertial (``problems`` is a list of sanity-check failures, empty if OK)."""
     info = None
     # 1. SolidWorks-native values (only when no density override is in force)
     if density is None and not getattr(comp, "density_override", False):
@@ -78,7 +79,8 @@ def _inertial_xml(comp, mesh_dir, density):
         f'iyy="{iyy:.6g}" iyz="{iyz:.6g}" izz="{izz:.6g}"/>',
         "    </inertial>",
     ]
-    return lines, info["method"]
+    problems = _inertia.validate_inertia(info["mass"], info["inertia"])
+    return lines, info["method"], problems
 
 
 def _report_inertia(methods):
@@ -100,6 +102,20 @@ def _report_inertia(methods):
     print(msg)
 
 
+def _report_inertia_problems(bad):
+    """Loudly flag links whose ``<inertial>`` fails a physics sanity check
+    (non-positive-definite tensor, triangle-inequality violation, bad mass).
+    These make simulators diverge and usually mean a units/frame/transform bug,
+    so surface them rather than emit silently."""
+    if not bad:
+        return
+    print(f"      WARN: {len(bad)} link(s) have a physically invalid inertial "
+          f"(may diverge in simulation):")
+    for link, problems in sorted(bad.items()):
+        for p in problems:
+            print(f"        - {link}: {p}")
+
+
 def _link_xml(comp, ros_pkg=None, rn=lambda n: n, mesh_dir=None, density=None):
     lines = [f'  <link name="{rn(comp.link_name)}">']
     if comp.mesh_file:
@@ -114,10 +130,10 @@ def _link_xml(comp, ros_pkg=None, rn=lambda n: n, mesh_dir=None, density=None):
             lines.append(f'        <mesh filename="{mesh_ref}"/>')
             lines.append("      </geometry>")
             lines.append(f"    </{tag}>")
-    inertial_lines, method = _inertial_xml(comp, mesh_dir, density)
+    inertial_lines, method, problems = _inertial_xml(comp, mesh_dir, density)
     lines.extend(inertial_lines)
     lines.append("  </link>")
-    return "\n".join(lines), method
+    return "\n".join(lines), method, problems
 
 
 def _joint_xml(joint, rn=lambda n: n, jn=lambda n: n):
@@ -227,12 +243,16 @@ def write_urdf(model, urdf_path, ros_pkg=None, density=None,
 
     parts = ['<?xml version="1.0"?>', f'<robot name="{model.name}">']
     methods = {}
+    bad_inertia = {}
     for comp in model.components:
-        xml, method = _link_xml(comp, ros_pkg, rn, mesh_dir=mesh_dir,
-                                density=density)
+        xml, method, problems = _link_xml(comp, ros_pkg, rn, mesh_dir=mesh_dir,
+                                          density=density)
         parts.append(xml)
         methods[method] = methods.get(method, 0) + 1
+        if problems:
+            bad_inertia[rn(comp.link_name)] = problems
     _report_inertia(methods)
+    _report_inertia_problems(bad_inertia)
     for joint in model.joints:
         parts.append(_joint_xml(joint, rn, jn))
     for i, port in enumerate(ports):

--- a/tests/test_sw_inertia.py
+++ b/tests/test_sw_inertia.py
@@ -115,3 +115,39 @@ def test_explicit_density_overrides_solidworks(tmp_path):
     inertial = ET.parse(out).getroot().find("link/inertial")
     # placeholder mass (0.1), not the SW 3.5
     assert float(inertial.find("mass").get("value")) == 0.1
+
+
+# ---------------------------------------------------------------- validate_inertia
+def test_validate_inertia_accepts_a_real_tensor():
+    from sw2robot.exporter.inertia import validate_inertia
+    # a plausible solid block: diagonal, triangle inequality holds
+    assert validate_inertia(2.0, (3.0, 0.0, 0.0, 4.0, 0.0, 5.0)) == []
+    # off-diagonal but still SPD + valid
+    assert validate_inertia(1.0, (5.0, 0.5, 0.0, 5.0, 0.0, 6.0)) == []
+
+
+def test_validate_inertia_flags_bad_mass():
+    from sw2robot.exporter.inertia import validate_inertia
+    probs = validate_inertia(0.0, (1.0, 0.0, 0.0, 1.0, 0.0, 1.0))
+    assert any("mass" in p for p in probs)
+    assert validate_inertia(-1.0, (1.0, 0.0, 0.0, 1.0, 0.0, 1.0))
+
+
+def test_validate_inertia_flags_non_positive_definite():
+    from sw2robot.exporter.inertia import validate_inertia
+    # a negative principal moment (e.g. a sign/units bug) -> not SPD
+    probs = validate_inertia(1.0, (-1.0, 0.0, 0.0, 2.0, 0.0, 3.0))
+    assert any("positive definite" in p for p in probs)
+
+
+def test_validate_inertia_flags_triangle_violation():
+    from sw2robot.exporter.inertia import validate_inertia
+    # all positive, but I1+I2 < I3 (1 + 1 < 10) -> physically impossible
+    probs = validate_inertia(1.0, (1.0, 0.0, 0.0, 1.0, 0.0, 10.0))
+    assert any("triangle inequality" in p for p in probs)
+
+
+def test_validate_inertia_placeholder_is_valid():
+    from sw2robot.exporter.inertia import validate_inertia
+    from sw2robot.exporter.urdf_writer import _PLACEHOLDER_INERTIAL as P
+    assert validate_inertia(P["mass"], P["inertia"]) == []


### PR DESCRIPTION
A wrong units/frame/transform in an `<inertial>` silently produces a tensor that makes simulators diverge. Validate each link's inertial against the constraints a real rigid body must satisfy, and flag any that fail.

## Checks (`inertia.validate_inertia`)
- **mass > 0**
- **positive definiteness**: the COM-frame tensor is symmetric and all principal moments (eigenvalues `I1 <= I2 <= I3`, via `eigvalsh`) are > 0
- **triangle inequality**: `I1 + I2 >= I3` (the geometric constraint every physical mass distribution obeys; the other two combinations follow once all are positive)
- tolerance is relative to the largest principal moment, so float / tessellation noise doesn't trip the checks

## Integration
`urdf_writer` runs the check on the **final link-frame** inertial, so it covers both the SolidWorks-native and the mesh-derived paths. Failing links get a loud per-link `WARN` (listing each failure) in the build/extract log. Generation is **not blocked** — most CAD meshes have only minor issues, so the report is advisory; a strict/abort mode can be added later if wanted.

## Testing
- `ruff`: clean · `pytest`: 89 passed, 7 skipped (added: valid tensors, bad mass, non-positive-definite, triangle-inequality violation, placeholder)
- Building a real package (screw_drive_module_dynamixel) produces no false positives.