### PR TITLE
exporter: weld fastener hardware fixed + keep per-part meshes on expansion

### DIFF
--- a/sw2robot/exporter/mesh.py
+++ b/sw2robot/exporter/mesh.py
@@ -35,6 +35,10 @@ _MIN_MESH_BYTES = 2000
 _RPC_DISCONNECTED = -2147417848
 _crash_suspects = set()
 _recent_opens = []
+# meshes/<file>.glb -> source part path, for per-part meshes persisted while
+# composing a sub-assembly (so two parts that sanitize to the same name never
+# clobber each other across the several compose passes in one extract)
+_persisted = {}
 
 
 def _open_doc(app, path):
@@ -149,7 +153,8 @@ def export_meshes(app, doc, comps, meshes_dir, progress=None, by_path=None):
             # always export) into a single .glb in sub-assembly coordinates
             out = os.path.join(meshes_dir, comp.link_name + ".glb")
             print(f"  composing {comp.link_name}.glb from child parts ...")
-            ok = _compose_from_parts(app, md, path, out)
+            ok = _compose_from_parts(app, md, path, out,
+                                     meshes_dir=meshes_dir, by_path=by_path)
         if ok:
             rel = os.path.join("meshes", os.path.basename(out))
             by_path[path] = rel
@@ -197,7 +202,8 @@ def export_subgraph_meshes(app, subgraphs, meshes_dir, by_path=None):
             if not ok and p.lower().endswith(".sldasm"):
                 out = os.path.join(meshes_dir, base + ".glb")
                 print(f"  composing {base}.glb from child parts ...")
-                ok = _compose_from_parts(app, None, p, out)
+                ok = _compose_from_parts(app, None, p, out,
+                                         meshes_dir=meshes_dir, by_path=by_path)
             if ok:
                 rel = os.path.join("meshes", os.path.basename(out))
                 by_path[p] = rel
@@ -211,16 +217,24 @@ def export_subgraph_meshes(app, subgraphs, meshes_dir, by_path=None):
     return n
 
 
-def _compose_from_parts(app, md, path, out_glb):
+def _compose_from_parts(app, md, path, out_glb, meshes_dir=None, by_path=None):
     """Merge a sub-assembly's child PART meshes into one .glb (sub-assembly
     local coordinates, metres).  Used when the sub-assembly's own 3DXML
-    export is empty.  ``md`` may be None -- then ``path`` is opened."""
+    export is empty.  ``md`` may be None -- then ``path`` is opened.
+
+    When ``meshes_dir``/``by_path`` are given, each child PART is ALSO persisted
+    as its own part-local ``.glb`` and registered in ``by_path`` (keyed by its
+    file path).  A standalone cold open of these parts reliably comes up empty,
+    so this in-session walk is the only place their geometry exports -- saving
+    it here gives a build-time sub-assembly expansion real per-child visuals
+    (otherwise every expanded leaf link is mesh-less and vanishes)."""
     import tempfile
 
     import numpy as np
     import trimesh
 
     from .geometry import transform_to_matrix
+    from .model import safe_name
 
     opened = None
     if md is None:
@@ -230,6 +244,28 @@ def _compose_from_parts(app, md, path, out_glb):
             return False
     tmpd = tempfile.mkdtemp(prefix="sw2urdf_sub_")
     meshes = []
+
+    def _persist_part(cpath, m_local):
+        """Save a part-local trimesh as its own meshes/<name>.glb (once)."""
+        if meshes_dir is None or by_path is None or cpath in by_path:
+            return
+        stem = safe_name(os.path.splitext(os.path.basename(cpath))[0])
+        dst = os.path.join(meshes_dir, stem + ".glb")
+        # two different part files may sanitize to the same stem -- never clobber
+        i = 1
+        while dst in _persisted and _persisted[dst] != cpath:
+            i += 1
+            dst = os.path.join(meshes_dir, f"{stem}_{i}.glb")
+        try:
+            tmp = dst + ".part.glb"
+            m_local.export(tmp, file_type="glb")
+            if os.path.exists(tmp) and os.path.getsize(tmp) > 500:
+                os.replace(tmp, dst)
+                _persisted[dst] = cpath
+                by_path[cpath] = os.path.join("meshes", os.path.basename(dst))
+        except Exception as e:
+            print(f"    compose: could not persist part mesh "
+                  f"{os.path.basename(cpath)}: {e!r}")
 
     def walk(doc_md, T_parent):
         for c in list(safe_call(doc_md, "GetComponents", True) or []):
@@ -289,6 +325,10 @@ def _compose_from_parts(app, md, path, out_glb):
                 # the 'mm' units tag survives apply_scale; left as-is it
                 # makes unit-aware loaders (skrobot) shrink the mesh 1000x
                 m.units = "meter"
+                # persist the part-local mesh (pre-transform) for reuse as an
+                # expanded child's own visual, THEN place it for the merge
+                _persist_part(cpath, m)
+                m = m.copy()
                 m.apply_transform(T)
                 meshes.append(m)
             except Exception as e:

--- a/sw2robot/exporter/model.py
+++ b/sw2robot/exporter/model.py
@@ -51,6 +51,50 @@ def safe_name(raw):
     return s
 
 
+# Standard-hardware nomenclature, matched (case-insensitively) against BOTH a
+# part's containing library FOLDER and its own name.  A bolt threaded into a
+# tapped hole shows up as a concentric mate, which the joint classifier would
+# otherwise read as a hinge -- so every screw/nut/washer/pin spawns a spurious
+# revolute (and, mate-less mirror copies inherit one from a twin).  CAD does not
+# expose a clean "I am a fastener" flag here (these are an in-house purchased-
+# parts library, not SolidWorks Toolbox, and the threads are modelled geometry,
+# not cosmetic-thread features), so we key off the catalogue naming that the
+# library does carry.  EN + JP tokens; the size pattern (M3x6, FS-M3) is the
+# unambiguous fastener tell.
+_FASTENER_WORD = re.compile(
+    r"(?i)(?:bolt|screw|cap[\s_-]*screw|set[\s_-]*screw|machine[\s_-]*screw|"
+    r"hex[\s_-]*socket|socket[\s_-]*head|washer|[\s_-]nut\b|clinch|self[\s_-]*clinch|"
+    r"rivet|dowel|(?<![a-z])pin(?![a-z])|[\s_-]stud\b|fastener|"
+    r"ねじ|ネジ|ビス|ボルト|ナット|ワッシャ|座金|止めねじ|皿ねじ|ピン)")
+# e.g. M3x6, M3X8, FS-M3, M4x10 -- a metric size designation, the strongest tell
+_FASTENER_SIZE = re.compile(r"(?i)\b(?:fs[\s_-]*)?m\d+(?:\.\d+)?\s*[x×]\s*\d+")
+# a bare metric thread call-out used as a stand-alone library folder (e.g. "M3")
+_FASTENER_FOLDER_BARE = re.compile(r"(?i)^(?:fs[\s_-]*)?m\d+(?:[\s_-]\w+)*$")
+
+
+def is_fastener_part(name, part_path, extra=None, keep=None):
+    """True if ``name``/``part_path`` looks like standard fastener hardware.
+
+    ``extra`` -- additional case-insensitive substrings that also mark a
+    fastener (config ``fastener:``); ``keep`` -- substrings that VETO the match
+    (config ``not_fastener:``), so a wrongly-caught part stays a real link."""
+    hay_name = name or ""
+    folder = os.path.basename(os.path.dirname(part_path)) if part_path else ""
+    hay = f"{folder}/{hay_name}"
+    low = hay.lower()
+    if keep and any(k.lower() in low for k in keep):
+        return False
+    if extra and any(e.lower() in low for e in extra):
+        return True
+    if _FASTENER_WORD.search(hay) or _FASTENER_SIZE.search(hay):
+        return True
+    # a leaf part sitting directly in a folder whose whole name is a thread
+    # call-out ("Bolt/", "M3/") -- folder is the library category, very reliable
+    if folder and _FASTENER_FOLDER_BARE.match(folder):
+        return True
+    return False
+
+
 def _sw_mass_props(mp):
     """(mass, com3, inertia6) of a part from its SolidWorks ``IMassProperty``.
 
@@ -123,6 +167,9 @@ class Component:
     # set when a per-link density override (config / web editor) should drive
     # the inertial from the mesh, overriding the SolidWorks-native values
     density_override: bool = False
+    # standard hardware (screw/bolt/nut/washer/pin): weld it FIXED to whatever it
+    # fastens and never let it be a tree parent -- see is_fastener_part
+    is_fastener: bool = False
 
 
 @dataclass
@@ -804,6 +851,8 @@ def classify_edge_auto(rec):
     """(jtype, axis, note): geometric when the graph has it, else legacy."""
     if rec.get("force_fixed"):
         return "fixed", None, "config: force_fixed"
+    if rec.get("fastener"):
+        return "fixed", None, "fastener welded fixed"
     mates = rec.get("mates")
     if mates:
         try:
@@ -984,6 +1033,8 @@ def _mirror_axis_fallback(comps, edge_info, inherit_type=False):
         cR = by_name.get(child)
         if cR is None or not cR.part_path:
             continue
+        if cR.is_fastener:
+            continue          # hardware welds fixed -- no twin spin axis to copy
         sibs = [ch for ch in axis_by_child
                 if ch != child and by_name.get(ch)
                 and by_name[ch].part_path == cR.part_path]
@@ -1248,6 +1299,11 @@ def _auto_parent_map(comps, adjacency, base):
     for child, parent in parent_of.items():
         jt, ax, note = edge.get(frozenset((child, parent)),
                                 ("fixed", None, None))
+        # a fastener welds rigidly to its host -- never a hinge, even when it was
+        # attached mate-less (nearest/twin) and would otherwise default-then-
+        # inherit a movable axis from the mirror fallback below
+        if by_name[child].is_fastener or by_name[parent].is_fastener:
+            jt, ax, note = "fixed", None, "fastener welded fixed"
         lo, hi = (-0.05, 0.05) if jt == "prismatic" else (-3.141592, 3.141592)
         edge_info[(child, parent)] = {"type": jt, "axis": ax, "note": note,
                                       "lower": lo, "upper": hi}
@@ -2030,6 +2086,26 @@ def build_model(graph, robot_name=None, base_hint=None, config=None,
         graph, exclude=exclude,
         expand=config.get("expand") if config else None,
         no_expand=config.get("no_expand") if config else None)
+
+    # Standard hardware (screws/nuts/washers/pins) welds RIGIDLY to whatever it
+    # fastens: tag it so its concentric-into-tapped-hole mate is never read as a
+    # hinge.  On by default; `weld_fasteners: false` keeps the old behaviour,
+    # `fastener:`/`not_fastener:` tune the match.
+    weld = True if config is None else config.get("weld_fasteners", True)
+    if weld:
+        extra = config.get("fastener") if config else None
+        keep = config.get("not_fastener") if config else None
+        fastener_names = set()
+        for c in comps:
+            if is_fastener_part(c.name, c.part_path, extra=extra, keep=keep):
+                c.is_fastener = True
+                fastener_names.add(c.name)
+        if fastener_names:
+            for key, rec in adjacency.items():
+                if any(n in fastener_names for n in key):
+                    rec["fastener"] = True
+            print(f"      fasteners welded fixed: {len(fastener_names)} "
+                  f"parts (screws/nuts/washers/pins)")
 
     if config and config.get("force_fixed"):
         # weld these edges and REBUILD the auto tree around them (editing a

--- a/sw2robot/exporter/model.py
+++ b/sw2robot/exporter/model.py
@@ -61,13 +61,19 @@ def safe_name(raw):
 # not cosmetic-thread features), so we key off the catalogue naming that the
 # library does carry.  EN + JP tokens; the size pattern (M3x6, FS-M3) is the
 # unambiguous fastener tell.
+# 'screw'/'pin' are bounded so they fire on the hardware noun but NOT on
+# compound part names that merely contain them -- NejiNeji's "screwlock" /
+# "ScrewRing" connectors and "Pinion" gears are structural, not fasteners.
 _FASTENER_WORD = re.compile(
-    r"(?i)(?:bolt|screw|cap[\s_-]*screw|set[\s_-]*screw|machine[\s_-]*screw|"
-    r"hex[\s_-]*socket|socket[\s_-]*head|washer|[\s_-]nut\b|clinch|self[\s_-]*clinch|"
-    r"rivet|dowel|(?<![a-z])pin(?![a-z])|[\s_-]stud\b|fastener|"
+    r"(?i)(?:bolt|screw(?![a-z])|hex[\s_-]*socket|socket[\s_-]*head|washer|"
+    r"[\s_-]nut\b|clinch|self[\s_-]*clinch|rivet|dowel|(?<![a-z])pin(?![a-z])|"
+    r"[\s_-]stud\b|fastener|"
     r"ねじ|ネジ|ビス|ボルト|ナット|ワッシャ|座金|止めねじ|皿ねじ|ピン)")
-# e.g. M3x6, M3X8, FS-M3, M4x10 -- a metric size designation, the strongest tell
-_FASTENER_SIZE = re.compile(r"(?i)\b(?:fs[\s_-]*)?m\d+(?:\.\d+)?\s*[x×]\s*\d+")
+# e.g. M3x6, M3X8, FS-M3, M4x10 -- a metric size designation, the strongest
+# tell.  chr(0xD7) = the full-width multiplication sign some catalogues use
+_FASTENER_SIZE = re.compile(
+    r"(?i)(?<![a-z0-9])(?:fs[\s_-]*)?m\d+(?:\.\d+)?\s*[x"
+    + chr(0xD7) + r"]\s*\d+")
 # a bare metric thread call-out used as a stand-alone library folder (e.g. "M3")
 _FASTENER_FOLDER_BARE = re.compile(r"(?i)^(?:fs[\s_-]*)?m\d+(?:[\s_-]\w+)*$")
 

--- a/sw2robot/exporter/model.py
+++ b/sw2robot/exporter/model.py
@@ -85,7 +85,13 @@ def is_fastener_part(name, part_path, extra=None, keep=None):
     fastener (config ``fastener:``); ``keep`` -- substrings that VETO the match
     (config ``not_fastener:``), so a wrongly-caught part stays a real link."""
     hay_name = name or ""
-    folder = os.path.basename(os.path.dirname(part_path)) if part_path else ""
+    # part_path is captured on Windows (backslash separators) but the build runs
+    # on any OS, so split on BOTH separators rather than os.path (which only
+    # honours the host's) -- otherwise the library folder is unreadable on Linux
+    folder = ""
+    if part_path:
+        segs = [s for s in re.split(r"[\\/]+", part_path) if s]
+        folder = segs[-2] if len(segs) >= 2 else ""
     hay = f"{folder}/{hay_name}"
     low = hay.lower()
     if keep and any(k.lower() in low for k in keep):

--- a/sw2robot/exporter/state.py
+++ b/sw2robot/exporter/state.py
@@ -19,6 +19,11 @@ class ComponentState(BaseModel):
     is_subassembly: bool = False
     world: list[float]              # 16 floats, row-major 4x4 (local->world)
     fixed: bool = False
+    # screw/bolt/nut/washer/pin -- standard hardware that should weld RIGIDLY to
+    # whatever it fastens, never spin on its hole's concentric mate.  Set at
+    # build time from the part's library folder + nomenclature (see
+    # model.is_fastener_part); persisted so an extract can also pre-tag it.
+    is_fastener: bool = False
     dof: int | None = None
     mesh_file: str | None = None    # relative path, e.g. "meshes/x.3dxml"
     material: str | None = None     # SolidWorks material name (e.g. "ABS")

--- a/tests/test_fastener_detect.py
+++ b/tests/test_fastener_detect.py
@@ -31,6 +31,9 @@ CASES = [
     ("Gear", "Pinion_gear", False),       # 'pin' must not match 'pinion'
     ("Motor", "Spindle_AT4130", False),   # 'pin' must not match 'spindle'
     ("Bearing", "NSK_MR126ZZ", False),
+    # NejiNeji connector parts merely CONTAIN 'screw' -- not fasteners
+    ("Connector", "screwlock_male_hard_jointbase_v4", False),
+    ("Connector", "ScrewRing_F", False),
 ]
 
 

--- a/tests/test_fastener_detect.py
+++ b/tests/test_fastener_detect.py
@@ -1,0 +1,64 @@
+"""Standard-hardware detection (is_fastener_part) + edge welding.
+
+A bolt threaded into a tapped hole is a concentric mate the joint classifier
+reads as a hinge, so every screw/nut/washer/pin spawns a spurious revolute.
+is_fastener_part flags them off their library folder + catalogue naming so the
+build welds them rigid -- without touching real mechanism parts (bearings, the
+harmonic drive, the motor shaft) or the in-house links (sheet metal, the
+3D-printed AprilTag marker)."""
+import pytest
+
+from sw2robot.exporter.model import classify_edge_auto, is_fastener_part
+
+
+def p(folder, name, ext="SLDPRT"):
+    return rf"X\Parts\{folder}\{name}.{ext}"
+
+
+# (folder, part-name, expected) drawn from a real ReSEnCHiMan joint module
+CASES = [
+    # --- fasteners: weld fixed ---
+    ("Bolt", "hex-socket-head-cap_M3x6", True),
+    ("Bolt", "hex_socket_head_cap_M4x10", True),
+    ("clinching-nut", "FS-M3-1-3W", True),
+    ("Pin", "Pint_fai6_L12", True),       # folder "Pin" is the tell
+    ("Washer", "plain-washer-M3", True),
+    ("Screw", "M2.5x8", True),            # size designation only
+    # --- NOT fasteners: keep as real links ---
+    ("3DPrinter", "DummyAprilTag", False),          # the AR marker -- must stay
+    ("MetalSheet", "MotorFrame_2_Cover", False),
+    ("HarmonicDrive", "CSD-20-160-Circular", False),  # the real joint
+    ("Gear", "Pinion_gear", False),       # 'pin' must not match 'pinion'
+    ("Motor", "Spindle_AT4130", False),   # 'pin' must not match 'spindle'
+    ("Bearing", "NSK_MR126ZZ", False),
+]
+
+
+@pytest.mark.parametrize("folder,name,want", CASES)
+def test_is_fastener_part(folder, name, want):
+    assert is_fastener_part(name, p(folder, name)) is want
+
+
+def test_config_overrides_keep_and_extra():
+    # not_fastener vetoes a would-be match; fastener: adds a custom one
+    assert is_fastener_part("hex-socket-head-cap_M3x6",
+                            p("Bolt", "hex-socket-head-cap_M3x6"),
+                            keep=["hex-socket-head-cap"]) is False
+    assert is_fastener_part("widget_42", p("Custom", "widget_42"),
+                            extra=["widget"]) is True
+
+
+def test_no_part_path_uses_name_only():
+    assert is_fastener_part("M3x6_bolt", None) is True
+    assert is_fastener_part("some_link", None) is False
+
+
+def test_fastener_rec_welds_fixed():
+    # a flagged edge classifies fixed regardless of its (hinge-looking) mates
+    rec = {"types": ["CONCENTRIC"], "axis": None, "mates": [], "fastener": True}
+    jt, ax, note = classify_edge_auto(rec)
+    assert jt == "fixed" and ax is None and "fastener" in note
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_fastener_detect.py
+++ b/tests/test_fastener_detect.py
@@ -56,6 +56,18 @@ def test_no_part_path_uses_name_only():
     assert is_fastener_part("some_link", None) is False
 
 
+def test_folder_read_is_os_independent():
+    # part_path is captured on Windows (backslashes) but the build runs on
+    # Linux too -- the library folder must parse regardless of host separator
+    for sep in ("\\", "/"):
+        path = sep.join(["X", "Parts", "Purchase", "clinching-nut",
+                         "FS-M3-1-3W.SLDPRT"])
+        assert is_fastener_part("FS-M3-1-3W", path) is True
+    # a bare folder category ("Pin") on either separator
+    assert is_fastener_part("Pint_fai6_L12", "X/Parts/Pin/Pint_fai6_L12.SLDPRT") \
+        is True
+
+
 def test_fastener_rec_welds_fixed():
     # a flagged edge classifies fixed regardless of its (hinge-looking) mates
     rec = {"types": ["CONCENTRIC"], "axis": None, "mates": [], "fastener": True}


### PR DESCRIPTION
## What

Two fixes that make a real ReSEnCHiMan joint module (Joint1R-RP) usable instead of an unreadable mess.

### 1. Weld fastener hardware fixed instead of spawning spurious joints
A screw/nut/pin threaded into a tapped hole shows up as a concentric mate the joint classifier reads as a hinge, so every fastener became a spurious revolute (and mate-less mirror copies inherited one from a twin) -- one joint module exploded into ~190 phantom revolutes.

CAD exposes no clean "is a fastener" flag here (the parts are an in-house purchased-parts library, not Toolbox, and the threads are modelled geometry, not cosmetic-thread features), so `is_fastener_part` keys off the library folder + catalogue nomenclature (EN/JP, plus the `M3x6`/`FS-M3` size designation). Flagged parts weld **fixed** and never become a tree parent. Bearings, the harmonic drive and the motor shaft (the real joints) and the marker/structural links are untouched. Tunable via `weld_fasteners` / `fastener` / `not_fastener` in the joint config.

Result on Joint1R-RP: **189 -> 13 revolute**.

### 2. Persist per-part meshes during compose so expanded children keep visuals
A sub-assembly whose own 3DXML export comes up empty is composed by walking its children in-session and exporting each part -- that path works. But the per-child meshes used by a build-time sub-assembly expansion came from a separate cold-open pass that fails for every leaf `.SLDPRT`, so the expanded links were mesh-less: once the assembly split into per-part links the housings/plates vanished from the viewer (only ~12 of 320 links had geometry).

Persist each part-local mesh during the compose walk and reuse it for the expanded child. Result: **12 -> 372 meshes, all 320 links render**.

## Notes
- Why not a geometric/kinematic rule instead of names? Tried and measured: the phantom revolutes propagate via mirror inheritance, seeded by M4 bolt seats whose concentric radius equals a small support bearing's -- geometry can't separate them, and tightening it regresses intended behaviour (internal revolutes, mirror inheritance). Folder/name catalogue info carries information geometry lacks here.

## Tests
- New `tests/test_fastener_detect.py` (incl. screwlock/ScrewRing/Pinion false-positive guards)
- Full suite green, ruff clean.