### PR TITLE
release: put the tag version in the .exe filename

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,14 +67,29 @@ jobs:
         # it predates the FK/collision API used here) + python-fcl
         run: pip install scikit-robot python-fcl
 
+      # Put the release version right before the .exe extension so the binary
+      # is self-identifying (sw2robot-web-windows-x64-v0.1.9.exe).  On a vX.Y.Z
+      # tag that is the tag; a workflow_dispatch build (no tag) falls back to
+      # dev-<short sha> so the name is still unambiguous.
+      - name: Compose exe name
+        id: exe
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            ver="${GITHUB_REF_NAME}"
+          else
+            ver="dev-${GITHUB_SHA::7}"
+          fi
+          echo "name=sw2robot-web-windows-${{ matrix.arch }}-${ver}" >> "$GITHUB_OUTPUT"
+
       - name: Build the web editor .exe
-        run: python build_exe.py ${{ matrix.build_args }} --name sw2robot-web-windows-${{ matrix.arch }}
+        run: python build_exe.py ${{ matrix.build_args }} --name ${{ steps.exe.outputs.name }}
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: sw2robot-web-windows-${{ matrix.arch }}
-          path: dist/sw2robot-web-windows-${{ matrix.arch }}.exe
+          name: ${{ steps.exe.outputs.name }}
+          path: dist/${{ steps.exe.outputs.name }}.exe
           if-no-files-found: error
 
   release:


### PR DESCRIPTION
## What

Name the released binary with the version right before the `.exe`, so a downloaded file is self-identifying:

`sw2robot-web-windows-x64.exe` -> `sw2robot-web-windows-x64-v0.1.9.exe`

- On a `vX.Y.Z` tag the version is the tag (`github.ref_name`).
- A `workflow_dispatch` build (no tag) falls back to `dev-<short sha>` so the name is still unambiguous.

## Validation

PyInstaller handles the dotted name fine -- a local `build_exe.py --name sw2robot-web-windows-x64-v0.1.9` produced `dist/sw2robot-web-windows-x64-v0.1.9.exe` (110 MB, exit 0).

Release-workflow-only change (triggers on tags / dispatch), so the regular CI here just confirms nothing else regressed.