### PR TITLE
editor/web: fall forward to the next free port instead of crashing

### DIFF
--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1932,6 +1932,22 @@ class _Handler(http.server.BaseHTTPRequestHandler):
         pass
 
 
+def _bind_free_port(handler, port, tries=20):
+    """Bind a ThreadingTCPServer on the first free port >= ``port``.
+
+    A second editor instance (or a leftover one) would otherwise collide on the
+    default port and the launch crashes with ``WinError 10048`` (address in
+    use); walking forward to the next free port lets every instance just come
+    up. Returns ``(httpd, bound_port)``."""
+    last = None
+    for p in range(port, port + tries):
+        try:
+            return socketserver.ThreadingTCPServer(("", p), handler), p
+        except OSError as e:
+            last = e
+    raise OSError(f"no free port in {port}..{port + tries - 1}: {last}")
+
+
 def serve(package_dir=None, root_dir=None, port=8090, open_browser=True):
     import atexit
     import signal
@@ -1957,7 +1973,10 @@ def serve(package_dir=None, root_dir=None, port=8090, open_browser=True):
     else:
         print(f"[sw2robot.web] no package yet -- pick one in the browser "
               f"(root: {_Handler.root_dir})")
-    httpd = socketserver.ThreadingTCPServer(("", port), _Handler)
+    httpd, bound = _bind_free_port(_Handler, port)
+    if bound != port:
+        print(f"[sw2robot.web] port {port} busy -> using {bound}")
+    port = bound
     httpd.daemon_threads = True
     url = f"http://localhost:{port}"
     print(f"[sw2robot.web] open {url}")

--- a/tests/test_webserver_port.py
+++ b/tests/test_webserver_port.py
@@ -1,0 +1,55 @@
+"""_bind_free_port walks to the next free port instead of crashing.
+
+A second editor instance used to die with WinError 10048 (address in use) on
+the default port; now it just comes up on the next free one."""
+import socket
+import socketserver
+
+import pytest
+
+from sw2robot.editor.webserver import _bind_free_port
+
+
+class _H(socketserver.BaseRequestHandler):
+    pass
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def test_uses_requested_port_when_free():
+    p = _free_port()
+    httpd, bound = _bind_free_port(_H, p)
+    try:
+        assert bound == p
+    finally:
+        httpd.server_close()
+
+
+def test_advances_past_a_busy_port():
+    p = _free_port()
+    occupied, used = _bind_free_port(_H, p)      # takes p
+    try:
+        httpd, bound = _bind_free_port(_H, p)    # p busy -> must advance
+        try:
+            assert used == p
+            assert bound > p
+        finally:
+            httpd.server_close()
+    finally:
+        occupied.server_close()
+
+
+def test_raises_when_no_free_port_in_range():
+    p = _free_port()
+    occupied, _ = _bind_free_port(_H, p)
+    try:
+        with pytest.raises(OSError):
+            _bind_free_port(_H, p, tries=1)      # only port p, which is taken
+    finally:
+        occupied.server_close()


### PR DESCRIPTION
## What

Launching a second web-editor instance (or one while a leftover is still listening) bound the same default port and crashed with `WinError 10048` (address in use). Now `serve()` walks forward from the requested port to the first free one and logs the move:

```
[sw2robot.web] port 8090 busy -> using 8091
```

So multiple instances just come up on 8090, 8091, 8092, ... -- no crash.

## Why not a GUI port picker

The editor is a browser app and the frozen `.exe` excludes tkinter (`build_exe.py` `--exclude-module tkinter`), so a native dialog would mean re-bundling a GUI toolkit. Auto-advancing is zero-click, works headless and in the frozen console exe, and matches what Jupyter/Vite do. `--port` is still honoured as the starting point.

## Validation

- New `tests/test_webserver_port.py` (uses requested port when free, advances past a busy one, raises when the range is exhausted).
- Verified live: with a downloaded `v0.1.11` exe holding 8090, two new instances launched on `--port 8090` came up on 8091 and 8092 (both HTTP 200) instead of crashing.
- Full suite green, ruff clean.