### PR TITLE
exporter: read SolidWorks limit mates + recover gantry slides as real joints

### DIFF
--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -165,6 +165,13 @@
   .jp-snaps button.cur { background: #2d6acc; color: #fff;
                          border-color: #2d6acc; }
   .jp-lim { color: #6b7480; font-size: 10px; margin-top: 3px; }
+  .jp-limedit input.jp-num { width: 52px; color: #cdd6e0; }
+  .jp-limedit .jp-dash { color: #8a93a3; }
+  .jp-lim-apply { font-size: 10px; padding: 1px 8px; border-radius: 3px;
+    background: #25303c; color: #cfe3ff; border: 1px solid #38516b;
+    cursor: pointer; }
+  .jp-lim-apply:hover { background: #2d4a55; }
+  .jp-lim-apply:disabled { opacity: .5; cursor: default; }
   .jp-name { flex: 1; min-width: 0; color: #cfe3ff; word-break: break-all; }
   /* rename (double-click a name in the tree/panel, or the ≣ 改名 list) */
   .renamable { cursor: text; }
@@ -689,6 +696,19 @@ skrobot / native-mesh consumers (not RViz-loadable)">⬇ glb</button></a>
     'jp.lblType': { en: 'type', ja: '種類' },
     'jp.limit': { en: a => `limit ${a.lo} … ${a.hi} ${a.unit}${a.rad}`,
                   ja: a => `可動域 ${a.lo} … ${a.hi} ${a.unit}${a.rad}` },
+    'jp.range': { en: 'range', ja: '可動域' },
+    'jp.limApply': { en: 'set', ja: '設定' },
+    'jp.contLimit': { en: 'continuous — spins freely (no limits)',
+                      ja: 'continuous — 無制限に回転（範囲なし）' },
+    'jp.limBad': { en: 'enter a valid range (lower < upper)',
+                   ja: '正しい範囲を入力してください（lower < upper）' },
+    'limits.applying': { en: 'setting joint limits — rebuilding …',
+                         ja: '可動域を設定して再ビルド中 …' },
+    'limits.done': { en: 'joint limits applied', ja: '可動域を反映しました' },
+    'limits.noneMatched': { en: a => `no joint matched '${a.child}'`,
+                            ja: a => `'${a.child}' に一致する関節がありません` },
+    'limits.fail': { en: a => `set limits failed: ${a.e}`,
+                     ja: a => `可動域の設定に失敗: ${a.e}` },
     'jp.mimic': { en: a => `driven by <b>${a.mn}</b> (mimic)`, ja: a => `<b>${a.mn}</b> に追従 (mimic)` },
     'jp.mimicMult': { en: 'multiplier', ja: '倍率' },
     'jp.mimicOff': { en: 'offset', ja: 'オフセット' },
@@ -2492,6 +2512,22 @@ function jointPanelHtml(j, parentLink, childLink) {
     .join('');
   let body = '';
   if (movable && !mimic) {
+    // continuous has no endpoints; revolute/prismatic get editable lo/hi that
+    // POST to /api/set_limits (the same path the auto-limit sweep writes) so a
+    // joint WITHOUT a SolidWorks limit mate -- e.g. the Z gantry -- can still
+    // be given its travel range straight from the browser.
+    const limRow = (j.jointType === 'continuous')
+      ? `<div class="jp-lim">${t('jp.contLimit')}</div>`
+      : `<div class="jp-row jp-limedit">` +
+          `<span class="jp-lbl">${t('jp.range')}</span>` +
+          `<input type="number" class="jp-num jp-lo" step="${um.step}" ` +
+            `value="${dLo.toFixed(um.dec)}">` +
+          `<span class="jp-dash">…</span>` +
+          `<input type="number" class="jp-num jp-hi" step="${um.step}" ` +
+            `value="${dHi.toFixed(um.dec)}">` +
+          `<span class="jp-unit">${um.unit}</span>` +
+          `<button class="jp-lim-apply">${t('jp.limApply')}</button>` +
+        `</div>`;
     body =
       `<div class="jp-row">` +
         `<input type="range" class="jp-slider" min="${dLo}" max="${dHi}" ` +
@@ -2502,10 +2538,7 @@ function jointPanelHtml(j, parentLink, childLink) {
       `</div>` +
       `<div class="jp-snaps">` +
         snaps.map(s => `<button data-v="${s}">${s}${um.unit}</button>`).join('') +
-      `</div>` +
-      `<div class="jp-lim">${t('jp.limit', {
-        lo: dLo.toFixed(um.dec), hi: dHi.toFixed(um.dec), unit: um.unit,
-        rad: ang ? ` &nbsp;(${lo.toFixed(2)} … ${hi.toFixed(2)} rad)` : '' })}</div>`;
+      `</div>` + limRow;
   } else if (mimic) {
     // read the live coupling from the URDF <mimic> element (the loader exposes
     // only the master link, not multiplier/offset)
@@ -2614,6 +2647,23 @@ function wireJointPanel(el, j) {
   markCur(parseFloat(slider.value));
   // external moves (the sidebar slider) refresh this panel without re-firing
   jpSync = { name: j.name, set: nat => show(clamp(um.toDisp(nat))) };
+
+  // editable travel range (revolute/prismatic): write lower/upper -> rebuild
+  const limApply = panel.querySelector('.jp-lim-apply');
+  if (limApply) {
+    const loIn = panel.querySelector('.jp-lo');
+    const hiIn = panel.querySelector('.jp-hi');
+    limApply.addEventListener('click', () => {
+      const dlo = parseFloat(loIn.value), dhi = parseFloat(hiIn.value);
+      if (isNaN(dlo) || isNaN(dhi) || !(dhi > dlo)) {
+        log(t('jp.limBad'), 'err');
+        return;
+      }
+      limApply.disabled = true;
+      reselectAfterLoad = childLink;     // keep this panel open after rebuild
+      applyJointLimits(childLink, um.toNat(dlo), um.toNat(dhi));
+    });
+  }
 }
 
 function fillLinkInfo(name) {
@@ -2921,6 +2971,38 @@ async function applyTypeChanges(changes) {
     log(t('types.applyFail', { e: e.message ?? e }), 'err');
     reselectAfterLoad = null;
     return false;
+  }
+}
+
+// write one joint's travel range to joints.yaml (lower/upper, in NATIVE units:
+// rad for revolute, m for prismatic) and rebuild -- shares /api/set_limits with
+// the auto-limit sweep, so a joint with no SolidWorks limit mate is editable too
+async function applyJointLimits(child, lowerNat, upperNat) {
+  if (!currentInfo) {
+    reselectAfterLoad = null;
+    return;
+  }
+  log(t('limits.applying'));
+  statusEl.textContent = t('status.rebuilding');
+  try {
+    const resp = await fetch('/api/set_limits', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ limits: [{ child, lower: lowerNat,
+                                        upper: upperNat, continuous: false }] }) });
+    const r = await resp.json();
+    if (!resp.ok || r.error) { throw new Error(r.error ?? resp.status); }
+    if (!r.applied?.length) {
+      log(t('limits.noneMatched', { child }), 'err');
+      reselectAfterLoad = null;
+      return;
+    }
+    log(t('limits.done'), 'ok');
+    loadRobot(currentInfo, { keepPose: true });
+    refreshHistory();
+  } catch (e) {
+    log(t('limits.fail', { e: e.message ?? e }), 'err');
+    reselectAfterLoad = null;
   }
 }
 

--- a/sw2robot/exporter/export.py
+++ b/sw2robot/exporter/export.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import sys
 
 from . import jointcfg
 from .mesh import _SAVE_OPTS, export_meshes, export_subgraph_meshes
@@ -23,6 +24,7 @@ from .model import (
     build_model,
     capture_deep_worlds,
     extract_graph,
+    extract_limit_joints,
     extract_subgraphs,
     safe_name,
     to_graph_state,
@@ -32,6 +34,16 @@ from .swcom import SolidWorks, as_iface
 from .urdf_writer import write_ros_package, write_urdf
 
 GRAPH_FILE = "graph.json"
+
+
+def _tolerant_console():
+    """Don't let a non-ASCII component name (e.g. a Turkish 'gövde') crash a
+    print on a legacy console code page (Japanese cp932, ...)."""
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(errors="backslashreplace")
+        except Exception:
+            pass
 
 
 def _pkg_paths(assembly_path, out_dir, robot_name):
@@ -67,6 +79,11 @@ def _extract_into(sw, assembly_path, pkg_dir, meshes_dir, robot_name, _say):
             "SolidWorks 'Pack and Go' to gather the assembly + all references "
             "into one folder and point sw2robot at the .SLDASM inside it.")
 
+    _say("reading limit mates (sliders/hinges) ...")
+    limit_joints = extract_limit_joints(doc, comps)
+    if limit_joints:
+        _say(f"found {len(limit_joints)} limit-mate joint(s)")
+
     _say("reading sub-assembly internals ...")
     subgraphs = extract_subgraphs(doc, comps, sw=sw)
     deep_worlds, hidden = capture_deep_worlds(doc)
@@ -97,7 +114,7 @@ def _extract_into(sw, assembly_path, pkg_dir, meshes_dir, robot_name, _say):
     graph = to_graph_state(comps, adjacency, ground, robot_name,
                            assembly_path, assembly_mesh=whole_rel,
                            subassemblies=subgraphs, deep_worlds=deep_worlds,
-                           hidden=hidden)
+                           hidden=hidden, limit_joints=limit_joints)
     graph.save(os.path.join(pkg_dir, GRAPH_FILE))
     sw.close_doc(doc)
     return pkg_dir
@@ -110,6 +127,7 @@ def extract(assembly_path, out_dir=None, robot_name=None, visible=False,
     per exported mesh, so a UI can show how far along the (multi-minute) extract
     is.  Pass an existing ``SolidWorks`` session as ``sw`` to reuse it across
     many assemblies (batch); otherwise a private one is started and shut down."""
+    _tolerant_console()
     import time as _time
     t_state = {"last": _time.time()}
 
@@ -141,6 +159,7 @@ def extract(assembly_path, out_dir=None, robot_name=None, visible=False,
 # ---------------------------------------------------------------- build
 def build(pkg_dir, config_path=None, base_hint=None, exclude=None,
           ros_pkg=False, density=None, ros_version=1):
+    _tolerant_console()
     graph = GraphState.load(os.path.join(pkg_dir, GRAPH_FILE))
     robot_name = graph.robot_name
     urdf_path = os.path.join(pkg_dir, "urdf", robot_name + ".urdf")

--- a/sw2robot/exporter/model.py
+++ b/sw2robot/exporter/model.py
@@ -30,7 +30,14 @@ from .geometry import (
     relative_matrix,
     transform_to_matrix,
 )
-from .state import ComponentState, GraphState, MateEdge, MateGeo, SubGraph
+from .state import (
+    ComponentState,
+    GraphState,
+    LimitJoint,
+    MateEdge,
+    MateGeo,
+    SubGraph,
+)
 from .swcom import as_iface, safe_call, safe_prop
 
 MATE_TYPES = {0: "COINCIDENT", 1: "CONCENTRIC", 2: "PERPENDICULAR",
@@ -67,7 +74,7 @@ def safe_name(raw):
 _FASTENER_WORD = re.compile(
     r"(?i)(?:bolt|screw(?![a-z])|hex[\s_-]*socket|socket[\s_-]*head|washer|"
     r"[\s_-]nut\b|clinch|self[\s_-]*clinch|rivet|dowel|(?<![a-z])pin(?![a-z])|"
-    r"[\s_-]stud\b|fastener|"
+    r"[\s_-]stud\b|fastener|(?<![a-z])vida(?![a-z])|"   # vida = screw (TR)
     r"ねじ|ネジ|ビス|ボルト|ナット|ワッシャ|座金|止めねじ|皿ねじ|ピン)")
 # e.g. M3x6, M3X8, FS-M3, M4x10 -- a metric size designation, the strongest
 # tell.  chr(0xD7) = the full-width multiplication sign some catalogues use
@@ -423,6 +430,25 @@ def _entity_axis_world(me):
     return (p, d / n)
 
 
+def _com_int(v):
+    """Coerce a SolidWorks enum property to ``int`` (or None).
+
+    A typed interface returns these as plain ints, but when ``as_iface`` could
+    not wrap the object (some entities marshal late-bound) the same property
+    comes back as a win32com ``VARIANT`` -- ``int(VARIANT)`` then raises and
+    aborts the whole extract.  Pull the value out of the VARIANT instead."""
+    if v is None:
+        return None
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        inner = getattr(v, "value", None)
+        try:
+            return int(inner) if inner is not None else None
+        except (TypeError, ValueError):
+            return None
+
+
 def _entity_geo(me):
     """(etype, point, dir, radius) of one mate entity in WORLD coords.
 
@@ -445,7 +471,7 @@ def _entity_geo(me):
         if n > 1e-9:
             d = [float(x) for x in dv / n]
     radius = float(vals[6]) if len(vals) >= 7 else None
-    return (int(etype) if etype is not None else None, p, d, radius)
+    return (_com_int(etype), p, d, radius)
 
 
 def build_mate_graph(doc, comps):
@@ -472,7 +498,7 @@ def build_mate_graph(doc, comps):
         mate_count[own_name] = mate_count.get(own_name, 0) + len(_mates)
         for m in _mates:
             mate = as_iface(m, "IMate2")
-            mtype = safe_prop(mate, "Type")
+            mtype = _com_int(safe_prop(mate, "Type"))
             mname = MATE_TYPES.get(mtype, str(mtype))
             ne = safe_call(mate, "GetMateEntityCount") or 0
             tops = []
@@ -546,6 +572,118 @@ def build_mate_graph(doc, comps):
               + (f"; entities resolved to {refs}" if refs else "")
               + ") -> attaches FIXED")
     return adjacency, ground
+
+
+def _limit_joint_from_feature(sfi, name_set):
+    """A LimitDistance/LimitAngle mate FEATURE -> a joint spec, or None.
+
+    A SolidWorks *limit* mate (a DISTANCE/ANGLE mate with min != max) is a real
+    slider / hinge -- it lets the part travel between min..max.  Our geometric
+    classifier only sees a plain DISTANCE/ANGLE constraint and over-fixes it, so
+    we read the feature data: which two components, the axis, and the min/max
+    travel (which become the URDF joint limits, relative to the assembled pose)."""
+    mate2 = as_iface(safe_call(sfi, "GetSpecificFeature2"), "IMate2")
+    if mate2 is None:
+        return None
+    mtype = _com_int(safe_prop(mate2, "Type"))
+    if mtype not in (5, 6):                       # 5=DISTANCE, 6=ANGLE
+        return None
+    defn = safe_call(sfi, "GetDefinition")
+    if defn is None:
+        return None
+    if mtype == 5:
+        d = as_iface(defn, "IDistanceMateFeatureData")
+        lo = safe_prop(d, "MinimumDistance")
+        hi = safe_prop(d, "MaximumDistance")
+        cur = safe_prop(d, "Distance")
+        jtype = "prismatic"
+    else:
+        d = as_iface(defn, "IAngleMateFeatureData")
+        lo = safe_prop(d, "MinimumAngle")
+        hi = safe_prop(d, "MaximumAngle")
+        cur = safe_prop(d, "Angle")
+        jtype = "revolute"
+    try:
+        lo, hi, cur = float(lo), float(hi), float(cur)
+    except (TypeError, ValueError):
+        return None
+    if not (hi - lo) > 1e-9:                       # min==max -> a fixed mate
+        return None
+
+    ne = safe_call(mate2, "GetMateEntityCount") or 0
+    ents = []                                      # [(top_name, (etype,p,d,r))]
+    for i in range(ne):
+        me = as_iface(safe_call(mate2, "MateEntity", i), "IMateEntity2")
+        rc = as_iface(safe_prop(me, "ReferenceComponent"), "IComponent2")
+        rn = safe_prop(rc, "Name2") if rc else None
+        ents.append((_top_level(rn) if rn else None, _entity_geo(me)))
+    pair = list(dict.fromkeys(t for t, _ in ents if t in name_set))
+    if len(pair) != 2:
+        return None
+    geo_of = {}                                    # top component -> its entity geo
+    for top, geo in ents:
+        if top in pair and geo is not None:
+            geo_of.setdefault(top, geo)
+    ga, gb = geo_of.get(pair[0]), geo_of.get(pair[1])
+    if ga is None or gb is None:
+        return None
+    pa, pb = np.asarray(ga[1], float), np.asarray(gb[1], float)
+    na, nb = np.asarray(ga[2], float), np.asarray(gb[2], float)
+    pt = pa
+    if jtype == "prismatic":
+        # face normal = slide axis, ORIENTED so component `a` (=pair[0]) moving
+        # +axis grows the mate distance -- the build flips it when `a` is the
+        # tree CHILD's parent.  Without this the travel reads the wrong way.
+        axis = na.copy()
+        if float((pa - pb) @ na) < 0:
+            axis = -axis
+    else:
+        # a hinge rotates about the intersection line of the two faces
+        axis = np.cross(na, nb)
+        if np.linalg.norm(axis) < 1e-9:
+            axis = na.copy()
+    n = float(np.linalg.norm(axis))
+    if n < 1e-9:
+        return None
+    axis = axis / n
+    # URDF joint position 0 == the assembled pose (current distance/angle)
+    return {"a": pair[0], "b": pair[1], "type": jtype,
+            "axis_point": [float(x) for x in pt],
+            "axis_dir": [float(x) for x in axis],
+            "lower": lo - cur, "upper": hi - cur}
+
+
+def extract_limit_joints(doc, comps):
+    """Walk the assembly's mate features -> explicit limit-mate joints.
+
+    These ARE the assembly's real DOFs (SolidWorks LimitDistance/LimitAngle
+    mates).  Returned as ``[{a,b,type,axis_point,axis_dir,lower,upper}]`` with
+    ``a``/``b`` top-level component Name2; the build uses them to override the
+    over-constrained geometric classification on those edges."""
+    name_set = {c.name for c in comps}
+    out = []
+    feat = safe_call(doc, "FirstFeature")
+    guard = 0
+    while feat is not None and guard < 100000:
+        guard += 1
+        fi = as_iface(feat, "IFeature")
+        if safe_call(fi, "GetTypeName2") == "MateGroup":
+            sub = safe_call(fi, "GetFirstSubFeature")
+            while sub is not None:
+                sfi = as_iface(sub, "IFeature")
+                try:
+                    spec = _limit_joint_from_feature(sfi, name_set)
+                except Exception as e:
+                    spec = None
+                    print(f"      WARN: limit-mate read failed: {e!r}")
+                if spec:
+                    print("      limit joint: {} {} <-> {} [{:.3f}, {:.3f}]"
+                          .format(spec["type"], ascii(spec["a"]),
+                                  ascii(spec["b"]), spec["lower"], spec["upper"]))
+                    out.append(spec)
+                sub = safe_call(sfi, "GetNextSubFeature")
+        feat = safe_call(fi, "GetNextFeature")
+    return out
 
 
 def choose_base(comps, ground, base_hint=None, adjacency=None):
@@ -863,6 +1001,9 @@ def classify_edge_auto(rec):
     """(jtype, axis, note): geometric when the graph has it, else legacy."""
     if rec.get("force_fixed"):
         return "fixed", None, "config: force_fixed"
+    lj = rec.get("limit_joint")
+    if lj:                                  # SolidWorks LimitDistance/LimitAngle
+        return lj["type"], lj["axis"], "limit mate (SolidWorks slider/hinge)"
     if rec.get("fastener"):
         return "fixed", None, "fastener welded fixed"
     mates = rec.get("mates")
@@ -896,6 +1037,44 @@ def _edge_is_weak(jt_ax_note, types):
     return False
 
 
+def _concentric_axis_of(rec):
+    """(point, unit dir) of an edge's concentric/cylinder axis, or None."""
+    try:
+        recs = _dedup_geo(rec.get("mates") or [])
+    except Exception:
+        return None
+    for m in recs:
+        if m.get("type") in ("CONCENTRIC", "HINGE"):
+            pts, dirs = m.get("points") or [], m.get("dirs") or []
+            if pts and dirs:
+                d = np.asarray(dirs[0], float)
+                n = float(np.linalg.norm(d))
+                if n > 1e-9:
+                    return np.asarray(pts[0], float), d / n
+    return None
+
+
+def _axis_translation_is_free(rel, d, tol=1e-4):
+    """True if the relative-twist nullspace ``rel`` (6 x k: rows wx,wy,wz,
+    vx,vy,vz) can realise a PURE translation along unit ``d`` (zero rotation).
+
+    Used to second-guess the single-edge axial-slide weld with the assembly-
+    wide solve: if the two bodies can still slide freely along the concentric
+    axis once EVERY mate in the assembly is accounted for, that slide is a real
+    linear guide (the printer's Z gantry on its rails), not a bolt's unmodelled
+    face contact -- exactly what SolidWorks lets you drag."""
+    if rel.shape[1] == 0:
+        return False
+    d = np.asarray(d, float)
+    nd = float(np.linalg.norm(d))
+    if nd < 1e-9:
+        return False
+    target = np.concatenate([np.zeros(3), d / nd])
+    Q, _ = np.linalg.qr(rel)                  # orthonormal basis of col-space
+    resid = target - Q @ (Q.T @ target)
+    return float(np.linalg.norm(resid)) < tol
+
+
 def _demote_globally_locked(comps, adjacency, edge):
     """Replicate SolidWorks' GLOBAL drag solve.
 
@@ -915,6 +1094,11 @@ def _demote_globally_locked(comps, adjacency, edge):
     for key, rec in adjacency.items():
         a, b = tuple(key)
         if a not in idx or b not in idx:
+            continue
+        # a SolidWorks limit mate IS a slider/hinge -- its DISTANCE/ANGLE mate
+        # rows would (over-)constrain the global system and falsely lock the
+        # mechanism, so keep them out (and never demote it, below)
+        if rec.get("limit_joint"):
             continue
         # CLOCKING mates encode a display pose, not structure, yet they
         # really do freeze the mechanism in SolidWorks.  Two shapes:
@@ -963,6 +1147,8 @@ def _demote_globally_locked(comps, adjacency, edge):
     rigid = set()
     for key in list(edge.keys()):
         a, b = tuple(key)
+        if adjacency.get(key, {}).get("limit_joint"):
+            continue                          # authoritative slider/hinge
         rel = N[6 * idx[b]:6 * idx[b] + 6, :] - N[6 * idx[a]:6 * idx[a] + 6, :]
         if np.linalg.norm(rel) < 1e-6:
             rigid.add(key)
@@ -976,6 +1162,64 @@ def _demote_globally_locked(comps, adjacency, edge):
     if demoted:
         print(f"      global solve: {demoted} pairwise-movable edge(s) "
               f"are locked by the rest of the assembly")
+    # The reverse of demotion: classify_edge_geo welds a lone concentric-axis
+    # slide to fixed because, edge-on-its-own, it cannot tell a linear guide
+    # from a bolt's unmodelled face contact.  The assembly-wide solve CAN -- if
+    # the pair still slides freely along that axis with EVERY mate accounted
+    # for, it is a real prismatic (the Z gantry rides its rails), so promote it
+    # back.  Tagged fasteners never reach here (their edge is already "fastener
+    # welded fixed", a different note), so this won't resurrect the bolt forest.
+    promoted = 0
+    for key in list(edge.keys()):
+        jt, _ax, note = edge[key]
+        if jt != "fixed" or not note or "only axial slide" not in note:
+            continue
+        if key in rigid:
+            continue                          # global solve says it's locked
+        a, b = tuple(key)
+        if a not in idx or b not in idx:
+            continue
+        cax = _concentric_axis_of(adjacency.get(key, {}))
+        if cax is None:
+            continue
+        rel = N[6 * idx[b]:6 * idx[b] + 6, :] - N[6 * idx[a]:6 * idx[a] + 6, :]
+        if not _axis_translation_is_free(rel, cax[1]):
+            continue
+        edge[key] = ("prismatic", cax,
+                     "geo: concentric slide the global solve proves FREE "
+                     "(linear guide, not a fastener) -> prismatic")
+        promoted += 1
+    if promoted:
+        print(f"      global solve: {promoted} concentric slide(s) are FREE in "
+              f"the assembly -> prismatic (linear guide, not a fastener)")
+        # Two PARALLEL promoted slides off a common frame part, whose moving
+        # ends are directly tied, are one carriage on twin rails (the gantry's
+        # two rail holders): only ONE is the real DOF.  Weld the tie between
+        # them rigid so the spanning tree keeps the carriage in one group and
+        # drops the second rail as a loop closure -- otherwise the second
+        # holder is a phantom slider that floats off when the gantry moves.
+        prom = [k for k in edge if "linear guide" in (edge[k][2] or "")]
+        welded = 0
+        for i in range(len(prom)):
+            for j in range(i + 1, len(prom)):
+                k1, k2 = prom[i], prom[j]
+                common = k1 & k2
+                if len(common) != 1:
+                    continue
+                frame = next(iter(common))
+                c1 = next(iter(k1 - {frame}))
+                c2 = next(iter(k2 - {frame}))
+                d1 = np.asarray(edge[k1][1][1], float)
+                d2 = np.asarray(edge[k2][1][1], float)
+                if abs(float(d1 @ d2)) < 0.999:
+                    continue                  # not the same rail direction
+                tie = frozenset((c1, c2))
+                if tie in edge and edge[tie][0] == "fixed" and tie not in rigid:
+                    rigid.add(tie)
+                    welded += 1
+        if welded:
+            print(f"      global solve: {welded} twin-rail tie(s) welded "
+                  f"rigid (one carriage, one slide DOF)")
     return rigid
 
 
@@ -1039,7 +1283,7 @@ def _mirror_axis_fallback(comps, edge_info, inherit_type=False):
                      if info.get("axis") is not None}
     type_by_child = {ch: info.get("type") for (ch, _pa), info in
                      edge_info.items() if info.get("axis") is not None}
-    for (child, _parent), info in edge_info.items():
+    for (child, parent), info in edge_info.items():
         if info.get("axis") is not None:
             continue
         cR = by_name.get(child)
@@ -1047,6 +1291,14 @@ def _mirror_axis_fallback(comps, edge_info, inherit_type=False):
             continue
         if cR.is_fastener:
             continue          # hardware welds fixed -- no twin spin axis to copy
+        # a part RIGIDLY fixed onto its OWN same-part twin rides that twin's
+        # joint (the gantry's two rail holders are one carriage on one slide);
+        # inheriting a second copy of the joint here would double the DOF and
+        # the part would float off when the real joint moves -- leave it fixed.
+        pR = by_name.get(parent)
+        if info.get("type") == "fixed" and pR is not None \
+                and pR.part_path == cR.part_path:
+            continue
         sibs = [ch for ch in axis_by_child
                 if ch != child and by_name.get(ch)
                 and by_name[ch].part_path == cR.part_path]
@@ -1105,6 +1357,19 @@ def _auto_parent_map(comps, adjacency, base):
         neighbors[a].append(b)
         neighbors[b].append(a)
     rigid = _demote_globally_locked(comps, adjacency, edge) or set()
+    # A fixed edge the classifier is CONFIDENT about (a bolted/fastener mount, an
+    # explicit weld, a fully-constrained pair) is rigid STRUCTURE even when the
+    # global twist solve left it a spurious slide (an unmodelled face contact
+    # behind a bolt's concentric).  Treat it as backbone so a bolted sub-frame
+    # (e.g. the rail holder on the body) stays grouped with its parent instead of
+    # being entered through a joint from the far side.  "under-constrained" stays
+    # weak -- that one really is a low-confidence guess.
+    for key, (jt, _ax, note) in edge.items():
+        if jt == "fixed" and key not in rigid and any(
+                s in (note or "") for s in
+                ("fastener", "axial slide", "fully constrained",
+                 "force_fixed", "welded")):
+            rigid.add(key)
     _demote_coaxial_duplicates(edge, adjacency)
     weak = set()
     for key, rec in adjacency.items():
@@ -1122,8 +1387,13 @@ def _auto_parent_map(comps, adjacency, base):
     for key, (jt, ax, _note) in edge.items():
         if jt in _MOVABLE_TYPES and ax is not None:
             driven.update(key)
+    # ... but a GLOBALLY-RIGID fixed edge is structure, not a loop closure, even
+    # when both ends also carry a movable joint: the bed plate is fixed to the
+    # bed carriage while each separately slides, so this edge keeps the two in
+    # ONE rigid group instead of being split across the tree.
     loop_closure = {key for key, (jt, _ax, _n) in edge.items()
-                    if jt == "fixed" and all(n in driven for n in key)}
+                    if jt == "fixed" and key not in rigid
+                    and all(n in driven for n in key)}
     # Synthetic LOCK edges tie a sub-assembly's grounded children (fixed to its
     # frame) rigidly together.  They carry no mate geometry, so the global twist
     # solve cannot see them as rigid and they fall to the weak tier -- then a
@@ -1317,6 +1587,11 @@ def _auto_parent_map(comps, adjacency, base):
         if by_name[child].is_fastener or by_name[parent].is_fastener:
             jt, ax, note = "fixed", None, "fastener welded fixed"
         lo, hi = (-0.05, 0.05) if jt == "prismatic" else (-3.141592, 3.141592)
+        # a SolidWorks limit mate carries the real axis + travel range; orient it
+        # parent -> child so the slider moves the way it does in SolidWorks
+        lj = adjacency.get(frozenset((child, parent)), {}).get("limit_joint")
+        if lj and jt == lj["type"]:
+            ax, lo, hi = _oriented_limit(lj, by_name[child], by_name[parent])
         edge_info[(child, parent)] = {"type": jt, "axis": ax, "note": note,
                                       "lower": lo, "upper": hi}
     # mate-less mirror/pattern copies inherit the joint (type + reflected axis)
@@ -1327,6 +1602,22 @@ def _auto_parent_map(comps, adjacency, base):
 
 
 _MOVABLE_TYPES = ("revolute", "continuous", "prismatic")
+
+
+def _oriented_limit(lj, child_comp, parent_comp):
+    """(axis, lower, upper) for a limit-mate joint, oriented for the tree CHILD.
+
+    The extracted axis is oriented so the reference component ``lj['ref']``
+    (=mate side ``a``) moving +axis GROWS the mate distance, and lower/upper are
+    that growing travel.  In the URDF the joint moves the CHILD: if the child IS
+    the reference, +axis already grows the distance; if it's the other side, its
+    + motion shrinks it, so flip the axis -- then ``joint > 0`` always travels
+    toward the maximum, matching the SolidWorks slider."""
+    pt, d = lj["axis"]
+    d = np.asarray(d, float)
+    if lj.get("ref") and child_comp.name != lj["ref"]:
+        d = -d
+    return (np.asarray(pt, float), d), lj["lower"], lj["upper"]
 
 
 def _auto_mimic(comps, adjacency, parent_of, edge_info):
@@ -1412,18 +1703,29 @@ def _config_parent_map(comps, adjacency, base, directed):
     mate between the two components.  Components not mentioned are attached to
     the base with a fixed joint so the URDF stays a connected tree."""
     names = {c.name for c in comps}
+    by_name = {c.name: c for c in comps}
     parent_of = {}
     edge_info = {}
     for d in directed:
         child, parent = d["child"], d["parent"]
         if child not in names or parent not in names or child == base.name:
             continue
+        jtype = d.get("type", "fixed")
+        rec = adjacency.get(frozenset((child, parent)), {})
+        lj = rec.get("limit_joint")
         ax = None
-        if d.get("axis_point") and d.get("axis_dir"):
-            ax = (np.asarray(d["axis_point"], float),
-                  np.asarray(d["axis_dir"], float))
+        if d.get("axis_dir"):
+            # explicit direction wins; a point is optional (default: child origin)
+            pt = (np.asarray(d["axis_point"], float) if d.get("axis_point")
+                  else by_name[child].world[:3, 3].copy())
+            ax = (pt, np.asarray(d["axis_dir"], float))
+        elif lj and jtype == lj["type"]:
+            # a SolidWorks LimitDistance/LimitAngle mate is authoritative -- use
+            # its CAD axis (the joints.yaml the editor rebuilds from stores the
+            # TYPE but not the axis, so without this the limit joint silently
+            # falls back to the world +Z default below), oriented parent -> child
+            ax, _lo, _hi = _oriented_limit(lj, by_name[child], by_name[parent])
         else:
-            rec = adjacency.get(frozenset((child, parent)), {})
             ax = rec.get("axis")
             if ax is None and rec.get("mates"):
                 # No CONCENTRIC mate axis -- e.g. a MIRRORED part whose hinge is
@@ -1440,8 +1742,12 @@ def _config_parent_map(comps, adjacency, base, directed):
                     ax = geo[1]
         parent_of[child] = parent
         lo = d.get("lower"); up = d.get("upper")
+        if lj and jtype == lj["type"]:        # oriented limit-mate travel
+            _, olo, ohi = _oriented_limit(lj, by_name[child], by_name[parent])
+            lo = olo if lo is None else lo
+            up = ohi if up is None else up
         edge_info[(child, parent)] = {
-            "type": d.get("type", "fixed"), "axis": ax,
+            "type": jtype, "axis": ax,
             "lower": -3.141592 if lo is None else lo,
             "upper": 3.141592 if up is None else up,
             "mimic": d.get("mimic")}
@@ -1450,6 +1756,25 @@ def _config_parent_map(comps, adjacency, base, directed):
     # its mated twin's axis.  The config already supplies the joint TYPE here, so
     # only the axis is filled (inherit_type left off).
     _mirror_axis_fallback(comps, edge_info)
+    # A movable joint the user asked for that STILL has no axis -- no CAD mate
+    # (or a fully-constrained DISTANCE-locked one) and no mirror twin -- defaults
+    # to world +Z through the child origin, so flipping a joint to prismatic /
+    # revolute actually MOVES instead of silently snapping back to fixed.  Point
+    # it with axis_dir (e.g. [0,1,0]).  EXCEPT a part whose same-part twin DID
+    # resolve an axis: that one was left axis-less on purpose (ambiguous mirror).
+    axed_parts = {by_name[ch].part_path
+                  for (ch, _pa), info in edge_info.items()
+                  if info.get("axis") is not None and by_name.get(ch)
+                  and by_name[ch].part_path}
+    for (child, parent), info in edge_info.items():
+        if info["type"] in _MOVABLE_TYPES and info.get("axis") is None:
+            cp = by_name[child].part_path
+            if cp and cp in axed_parts:
+                continue                      # ambiguous mirror twin -- leave it
+            info["axis"] = (by_name[child].world[:3, 3].copy(),
+                            np.array([0.0, 0.0, 1.0]))
+            print(f"      note: {parent}->{child} {info['type']}: no CAD axis, "
+                  f"defaulting to world +Z (set axis_dir to change)")
     # anything unlisted -> fixed to base
     for c in comps:
         if c.name != base.name and c.name not in parent_of:
@@ -1729,7 +2054,7 @@ def _mate_edges(adjacency):
 
 def to_graph_state(comps, adjacency, ground, robot_name, source_assembly,
                    assembly_mesh=None, subassemblies=None, deep_worlds=None,
-                   hidden=None):
+                   hidden=None, limit_joints=None):
     subs = {}
     for path, (scomps, sadj, sground) in (subassemblies or {}).items():
         subs[path] = SubGraph(components=_component_states(scomps),
@@ -1739,7 +2064,9 @@ def to_graph_state(comps, adjacency, ground, robot_name, source_assembly,
                       components=_component_states(comps),
                       edges=_mate_edges(adjacency), ground=sorted(ground),
                       assembly_mesh=assembly_mesh, subassemblies=subs,
-                      deep_worlds=deep_worlds or {}, hidden=hidden or [])
+                      deep_worlds=deep_worlds or {}, hidden=hidden or [],
+                      limit_joints=[LimitJoint(**j) for j in
+                                    (limit_joints or [])])
 
 
 def capture_deep_worlds(doc):
@@ -2098,6 +2425,27 @@ def build_model(graph, robot_name=None, base_hint=None, config=None,
         graph, exclude=exclude,
         expand=config.get("expand") if config else None,
         no_expand=config.get("no_expand") if config else None)
+
+    # SolidWorks LimitDistance/LimitAngle mates ARE the assembly's real DOFs --
+    # promote those edges to prismatic/revolute with the CAD axis + travel
+    # limits, overriding the (over-constrained) geometric classification.  On by
+    # default; `use_limit_joints: false` falls back to pure geometry.
+    if config is None or config.get("use_limit_joints", True):
+        comp_names = {c.name for c in comps}
+        n_lim = 0
+        for lj in getattr(graph, "limit_joints", None) or []:
+            if lj.a not in comp_names or lj.b not in comp_names:
+                continue
+            rec = adjacency.setdefault(frozenset((lj.a, lj.b)),
+                                       {"types": [], "axis": None, "mates": []})
+            rec["limit_joint"] = {
+                "type": lj.type, "ref": lj.a,
+                "axis": (np.asarray(lj.axis_point, float),
+                         np.asarray(lj.axis_dir, float)),
+                "lower": float(lj.lower), "upper": float(lj.upper)}
+            n_lim += 1
+        if n_lim:
+            print(f"      limit-mate joints: {n_lim} (SolidWorks sliders/hinges)")
 
     # Standard hardware (screws/nuts/washers/pins) welds RIGIDLY to whatever it
     # fastens: tag it so its concentric-into-tapped-hole mate is never read as a

--- a/sw2robot/exporter/state.py
+++ b/sw2robot/exporter/state.py
@@ -69,6 +69,22 @@ class MateEdge(BaseModel):
     mates: list[MateGeo] | None = None
 
 
+class LimitJoint(BaseModel):
+    """A SolidWorks LimitDistance/LimitAngle mate = a real slider/hinge.
+
+    These carry the assembly's actual DOFs (the geometric classifier only sees a
+    plain DISTANCE/ANGLE constraint and over-fixes them), so the build uses them
+    to override the joint type/axis/limits on the ``a``--``b`` edge.  ``lower``/
+    ``upper`` are travel relative to the assembled pose (m or rad)."""
+    a: str                          # top-level component Name2
+    b: str
+    type: str                       # "prismatic" | "revolute"
+    axis_point: list[float]
+    axis_dir: list[float]
+    lower: float
+    upper: float
+
+
 class SubGraph(BaseModel):
     """Internal structure of ONE sub-assembly part file, in ITS OWN frame.
 
@@ -98,6 +114,9 @@ class GraphState(BaseModel):
     # full nested Name2 of components that are HIDDEN in the assembly --
     # SolidWorks renders (and exports) without them, so the build drops them
     hidden: list[str] = []
+    # LimitDistance/LimitAngle mates = the assembly's real sliders/hinges; the
+    # build promotes these edges to prismatic/revolute (empty on older extracts)
+    limit_joints: list[LimitJoint] = []
 
     def save(self, path):
         with open(path, "w", encoding="utf-8") as f:

--- a/sw2robot/exporter/swcom.py
+++ b/sw2robot/exporter/swcom.py
@@ -447,6 +447,34 @@ class SolidWorks:
         self._tempdirs.append(tmpdir)
         tmp = os.path.join(tmpdir, os.path.basename(path))
         shutil.copy2(path, tmp)
+        # Co-locate the assembly's sibling CAD files in the SAME temp dir so
+        # SolidWorks' "same folder as the assembly" rule resolves them by name.
+        # The search-folder registration above does NOT always override the
+        # absolute paths a downloaded (Pack-and-Go) assembly bakes in -- those
+        # then open with every component unresolved even though the parts sit
+        # right next to the .SLDASM.  A flat copy of the folder fixes that; deep
+        # sub-folder layouts still fall back to the search folders.
+        if doc_type_for(path) == SW_DOC_ASSEMBLY:
+            try:
+                siblings = os.listdir(os.path.dirname(path))
+            except OSError:
+                siblings = []
+            n_sib = 0
+            for fn in siblings:
+                if fn.startswith("~$") or not fn.lower().endswith(
+                        (".sldprt", ".sldasm", ".slddrw")):
+                    continue                    # lock files / non-CAD
+                s = os.path.join(os.path.dirname(path), fn)
+                d = os.path.join(tmpdir, fn)
+                if os.path.isfile(s) and not os.path.exists(d):
+                    try:
+                        shutil.copy2(s, d)
+                        n_sib += 1
+                    except OSError:
+                        pass
+            if n_sib:
+                print(f"      co-located {n_sib} sibling CAD file(s) for "
+                      f"reference resolution")
         t1 = _time.time()
 
         errors = byref_long()

--- a/tests/test_com_int.py
+++ b/tests/test_com_int.py
@@ -1,0 +1,36 @@
+"""_com_int tolerates SolidWorks enum properties that marshal as VARIANT.
+
+Some mate entities come back late-bound, so ``ReferenceType`` / mate ``Type``
+arrive as a win32com VARIANT instead of an int; ``int(VARIANT)`` then raised
+``TypeError`` and aborted the whole extract.  _com_int pulls the value out."""
+from sw2robot.exporter.model import _com_int
+
+
+class _FakeVariant:
+    """Stand-in for a win32com VARIANT wrapping an enum value."""
+    def __init__(self, value):
+        self.value = value
+
+    def __int__(self):
+        raise TypeError("int() argument must be ... not 'VARIANT'")
+
+
+def test_plain_int():
+    assert _com_int(1) == 1
+    assert _com_int(0) == 0
+
+
+def test_float_like():
+    assert _com_int(4.0) == 4
+
+
+def test_variant_with_value():
+    assert _com_int(_FakeVariant(1)) == 1          # CONCENTRIC
+    assert _com_int(_FakeVariant(20)) == 20        # LOCK
+
+
+def test_none_and_garbage():
+    assert _com_int(None) is None
+    assert _com_int(_FakeVariant(None)) is None
+    assert _com_int(_FakeVariant("nope")) is None
+    assert _com_int(object()) is None

--- a/tests/test_concentric_slide_promotion.py
+++ b/tests/test_concentric_slide_promotion.py
@@ -1,0 +1,100 @@
+"""A concentric axial slide that the GLOBAL solve proves free is a prismatic.
+
+classify_edge_geo welds a lone concentric-axis slide to fixed because, edge on
+its own, a linear guide and a bolt's unmodelled face contact look identical (see
+test_classify_geo.test_servo_mount_concentric_plus_perp_parallel_is_fixed).  The
+assembly-wide twist solve CAN tell them apart: if the pair still slides freely
+along that axis once every mate is accounted for, it is a real prismatic -- the
+3D printer's Z gantry riding its rails.  These tests pin that promotion (and the
+twin-rail carriage welding) so it cannot silently regress.
+"""
+import numpy as np
+
+from sw2robot.exporter.model import build_model
+from sw2robot.exporter.state import ComponentState, GraphState, MateEdge, MateGeo
+
+CYL, PLANE = 4, 3
+
+
+def _comp(name, xyz=(0, 0, 0), fixed=False, part_path=None):
+    w = np.eye(4)
+    w[:3, 3] = xyz
+    return ComponentState(
+        name=name, link_name=name.replace(" ", "_"), part_path=part_path,
+        is_subassembly=False, world=[float(x) for x in w.flatten()],
+        fixed=fixed)
+
+
+def _geo(mtype, ents):
+    """ents: list of (etype, point, dir)."""
+    return MateGeo(type=mtype,
+                   etypes=[e[0] for e in ents],
+                   points=[list(map(float, e[1])) for e in ents],
+                   dirs=[list(map(float, e[2])) for e in ents],
+                   radii=[None] * len(ents))
+
+
+def _conc_z(a, b, p):
+    return MateEdge(a=a, b=b, types=["CONCENTRIC", "PARALLEL"],
+                    axis_point=list(map(float, p)), axis_dir=[0.0, 0.0, 1.0],
+                    mates=[_geo("CONCENTRIC", [(CYL, p, [0, 0, 1]),
+                                              (CYL, p, [0, 0, 1])]),
+                           _geo("PARALLEL", [(PLANE, p, [1, 0, 0]),
+                                            (PLANE, p, [1, 0, 0])])])
+
+
+def _graph(comps, edges, ground):
+    return GraphState(robot_name="t", source_assembly="t.SLDASM",
+                      components=comps, edges=edges, ground=ground)
+
+
+def test_free_concentric_slide_becomes_prismatic():
+    # frame (grounded) + carriage held ONLY by a concentric Z + perpendicular
+    # parallel -> nothing pins Z -> the global solve promotes it to prismatic
+    frame = _comp("frame", fixed=True)
+    car = _comp("carriage", (0, 0, 0.1))
+    g = _graph([frame, car], [_conc_z("frame", "carriage", [0, 0, 0])],
+               ground=["frame"])
+    model = build_model(g)
+    j = next(j for j in model.joints if j.child == "carriage")
+    assert j.jtype == "prismatic"
+    assert abs(abs(np.dot(j.axis, [0, 0, 1])) - 1.0) < 1e-6
+
+
+def test_locked_concentric_slide_stays_fixed():
+    # same, but a COINCIDENT plane with a Z normal pins the axial position ->
+    # the global solve finds no motion -> it must stay fixed (NOT promoted)
+    frame = _comp("frame", fixed=True)
+    car = _comp("carriage", (0, 0, 0.1))
+    e = _conc_z("frame", "carriage", [0, 0, 0])
+    e.mates.append(_geo("COINCIDENT", [(PLANE, [0, 0, 0], [0, 0, 1]),
+                                       (PLANE, [0, 0, 0], [0, 0, 1])]))
+    e.types.append("COINCIDENT")
+    g = _graph([frame, car], [e], ground=["frame"])
+    model = build_model(g)
+    j = next(j for j in model.joints if j.child == "carriage")
+    assert j.jtype == "fixed"
+
+
+def test_twin_rails_collapse_to_one_carriage_one_dof():
+    # two rail holders (SAME part) each concentric-Z to the frame and tied to
+    # each other: ONE slide DOF, the other rail welded rigidly into the carriage
+    frame = _comp("frame", fixed=True)
+    railA = _comp("rail-1", (0.1, 0, 0.1), part_path="rail.SLDPRT")
+    railB = _comp("rail-2", (-0.1, 0, 0.1), part_path="rail.SLDPRT")
+    edges = [
+        _conc_z("frame", "rail-1", [0.1, 0, 0]),
+        _conc_z("frame", "rail-2", [-0.1, 0, 0]),
+        MateEdge(a="rail-1", b="rail-2", types=["WIDTH", "WIDTH"],
+                 axis_point=None, axis_dir=None,
+                 mates=[_geo("WIDTH", [(PLANE, [0, 0, 0.1], [1, 0, 0]),
+                                       (PLANE, [0, 0, 0.1], [1, 0, 0])])]),
+    ]
+    g = _graph([frame, railA, railB], edges, ground=["frame"])
+    model = build_model(g)
+    prism = [j for j in model.joints if j.jtype == "prismatic"]
+    assert len(prism) == 1                      # one carriage, one slide DOF
+    # the other rail is fixed into the carriage (rides the single slide)
+    other = next(j for j in model.joints if j.child in ("rail-1", "rail-2")
+                 and j.jtype != "prismatic")
+    assert other.jtype == "fixed"

--- a/tests/test_config_default_axis.py
+++ b/tests/test_config_default_axis.py
@@ -1,0 +1,50 @@
+"""A config-requested movable joint with NO derivable axis gets a default axis.
+
+Flipping a joint to prismatic/revolute in the editor used to silently snap back
+to fixed when the edge had no CAD axis to derive (a fully DISTANCE-constrained
+pair, or a STEP body with no mates).  It must instead default to world +Z so the
+joint is real and drivable, with axis_dir to point it.
+"""
+import numpy as np
+
+from sw2robot.exporter.model import Component, _config_parent_map
+
+
+def _comp(name, xyz=(0, 0, 0)):
+    w = np.eye(4)
+    w[:3, 3] = xyz
+    return Component(name=name, link_name=name, part_path=None,
+                     is_subassembly=False, world=w, fixed=False, dof=0)
+
+
+def _build(directed, adjacency=None):
+    base = _comp("base")
+    body = _comp("body")
+    tool = _comp("tool", (0.1, 0.2, 0.3))
+    return _config_parent_map([base, body, tool], adjacency or {}, base,
+                              directed)
+
+
+def test_axisless_prismatic_defaults_to_world_z():
+    _pa, edge = _build([{"parent": "body", "child": "tool", "type": "prismatic"}])
+    ax = edge[("tool", "body")]["axis"]
+    assert edge[("tool", "body")]["type"] == "prismatic"
+    assert ax is not None                                  # NOT degraded to fixed
+    np.testing.assert_allclose(ax[1], [0, 0, 1])           # default world +Z
+    np.testing.assert_allclose(ax[0], [0.1, 0.2, 0.3])     # through child origin
+
+
+def test_axisless_revolute_defaults_too():
+    _pa, edge = _build([{"parent": "body", "child": "tool", "type": "revolute"}])
+    assert edge[("tool", "body")]["axis"] is not None
+
+
+def test_explicit_axis_dir_wins():
+    _pa, edge = _build([{"parent": "body", "child": "tool",
+                         "type": "prismatic", "axis_dir": [0, 1, 0]}])
+    np.testing.assert_allclose(edge[("tool", "body")]["axis"][1], [0, 1, 0])
+
+
+def test_fixed_stays_axisless():
+    _pa, edge = _build([{"parent": "body", "child": "tool", "type": "fixed"}])
+    assert edge[("tool", "body")]["axis"] is None

--- a/tests/test_limit_joints.py
+++ b/tests/test_limit_joints.py
@@ -1,0 +1,116 @@
+"""SolidWorks LimitDistance/LimitAngle mates become prismatic/revolute joints.
+
+A limit mate IS a real slider/hinge (travel between min..max).  The geometric
+classifier reads it as a plain DISTANCE/ANGLE constraint and over-fixes it, and
+the global-lock solve would then demote it -- so a graph's ``limit_joints`` must
+win: the edge becomes prismatic/revolute with the CAD axis + travel limits, and
+the global solve must NOT lock it back to fixed.
+"""
+import numpy as np
+
+from sw2robot.exporter.model import build_model, classify_edge_auto
+from sw2robot.exporter.state import (
+    ComponentState,
+    GraphState,
+    LimitJoint,
+    MateEdge,
+)
+
+
+def test_classify_edge_auto_honours_limit_joint():
+    rec = {"types": ["DISTANCE"], "axis": None, "mates": [],
+           "limit_joint": {"type": "prismatic",
+                           "axis": (np.zeros(3), np.array([0.0, 1.0, 0.0])),
+                           "lower": -0.05, "upper": 0.15}}
+    jt, ax, note = classify_edge_auto(rec)
+    assert jt == "prismatic"
+    np.testing.assert_allclose(ax[1], [0, 1, 0])
+    assert "limit mate" in note
+
+
+def _comp(name, xyz=(0, 0, 0)):
+    w = np.eye(4)
+    w[:3, 3] = xyz
+    return ComponentState(name=name, link_name=name,
+                          world=[float(x) for x in w.flatten()], fixed=False)
+
+
+def _graph(limit):
+    # base + slider, with a DISTANCE mate between them (over-constraining) AND a
+    # limit-mate joint that must win
+    base = _comp("base")
+    base.fixed = True
+    slider = _comp("slider", (0.1, 0, 0))
+    edge = MateEdge(a="base", b="slider", types=["DISTANCE"],
+                    axis_point=None, axis_dir=None, mates=None)
+    return GraphState(
+        robot_name="t", source_assembly="t.SLDASM",
+        components=[base, slider], edges=[edge], ground=["base"],
+        limit_joints=[limit] if limit else [])
+
+
+def test_limit_joint_builds_prismatic_with_limits():
+    # ``a`` (the reference whose +axis grows the mate distance) is the slider =
+    # the tree child, so the axis is used as-is (no parent/child flip)
+    lj = LimitJoint(a="slider", b="base", type="prismatic",
+                    axis_point=[0, 0, 0], axis_dir=[0, 1, 0],
+                    lower=-0.05, upper=0.15)
+    model = build_model(_graph(lj))
+    j = next(j for j in model.joints if j.child == "slider")
+    assert j.jtype == "prismatic"
+    np.testing.assert_allclose([round(x) for x in j.axis], [0, 1, 0])
+    assert abs(j.lower - (-0.05)) < 1e-9
+    assert abs(j.upper - 0.15) < 1e-9
+
+
+def test_limit_joint_axis_flips_for_the_other_side():
+    # if the tree child is the OTHER mate side (not the reference ``a``), its +
+    # motion shrinks the distance, so the axis flips to keep joint>0 = toward max
+    lj = LimitJoint(a="base", b="slider", type="prismatic",
+                    axis_point=[0, 0, 0], axis_dir=[0, 1, 0],
+                    lower=-0.05, upper=0.15)
+    model = build_model(_graph(lj))
+    j = next(j for j in model.joints if j.child == "slider")
+    np.testing.assert_allclose([round(x) for x in j.axis], [0, -1, 0])
+
+
+def test_without_limit_joint_the_distance_mate_fixes_it():
+    # same geometry, no limit joint -> the lone DISTANCE constraint leaves it
+    # NOT a clean prismatic (regression guard that the win comes from the limit)
+    model = build_model(_graph(None))
+    j = next(j for j in model.joints if j.child == "slider")
+    assert j.jtype == "fixed"
+
+
+def test_rigid_group_stays_together_under_limit_joints():
+    """Bed-plate scenario: a plate is fixed to a carriage that slides, AND has a
+    redundant limit slide to a separately-sliding toolhead.  The plate must stay
+    FIXED under its carriage (one rigid group) -- not get pulled under the
+    toolhead by the redundant limit mate, which is a loop closure."""
+    base = _comp("base"); base.fixed = True
+    carriage = _comp("carriage", (0, 0.1, 0))
+    plate = _comp("plate", (0, 0.1, 0.1))
+    tool = _comp("tool", (0.1, 0, 0))
+    # plate <-> carriage: a (force-)fixed structural weld = rigid backbone
+    e = MateEdge(a="carriage", b="plate", types=["COINCIDENT"],
+                 axis_point=None, axis_dir=None, mates=None)
+    g = GraphState(
+        robot_name="t", source_assembly="t.SLDASM",
+        components=[base, carriage, plate, tool], edges=[e], ground=["base"],
+        limit_joints=[
+            LimitJoint(a="base", b="carriage", type="prismatic",
+                       axis_point=[0, 0, 0], axis_dir=[0, 1, 0],
+                       lower=-0.05, upper=0.05),
+            LimitJoint(a="base", b="tool", type="prismatic",
+                       axis_point=[0, 0, 0], axis_dir=[1, 0, 0],
+                       lower=0.0, upper=0.1),
+            LimitJoint(a="tool", b="plate", type="prismatic",  # redundant / loop
+                       axis_point=[0, 0, 0], axis_dir=[1, 0, 0],
+                       lower=0.0, upper=0.1),
+        ])
+    model = build_model(g, config={"force_fixed": [["carriage", "plate"]]})
+    jt = {j.child: j for j in model.joints}
+    assert jt["plate"].jtype == "fixed"
+    assert jt["plate"].parent == "carriage"     # stays in the carriage's group
+    assert jt["carriage"].jtype == "prismatic"
+    assert jt["tool"].jtype == "prismatic"


### PR DESCRIPTION
## Summary

Makes a real assembly (the Bambu A1 combo 3D printer) extract into a correct,
movable URDF fully automatically instead of an all-fixed model.

### Limit mates -> real joints
A SolidWorks **LimitDistance / LimitAngle** mate is a slider / hinge, but the
geometric classifier only saw a plain DISTANCE / ANGLE constraint and over-fixed
it. These mates are now read directly and the `a`-`b` edge is promoted to
prismatic / revolute with the real axis and travel range, oriented so the joint
moves the same way it does when you drag it in SolidWorks.

### Recover genuine linear guides with no limit mate
A real linear guide with no limit mate (the printer's **Z gantry on its rails**)
still classifies fixed, because a lone concentric axial slide is geometrically
indistinguishable from a bolt's unmodelled face contact on a single edge (cf.
`test_servo_mount_concentric_plus_perp_parallel_is_fixed`). The **whole-assembly
twist solve** can tell them apart: if the pair still slides freely along that
axis once every mate is accounted for, it is promoted back to prismatic.

- Two parallel rails tied together collapse into **one carriage with one slide DOF**.
- A part rigidly fixed onto its own same-part twin no longer inherits a duplicate
  of the twin's joint (the second rail holder no longer floats off).
- Tagged fasteners never reach this path, so the bolt forest does not return.

Result on the A1: 4 DOF (Z gantry, Y bed, X tool head, screen hinge) — correct
printer kinematics, no manual config.

### Editor: editable travel range
The joint panel travel range is now editable — type lower / upper (deg for
revolute, mm for prismatic) and it writes the limits and rebuilds, so a joint
**without** a SolidWorks limit mate can still be given its range in-browser.
Reuses the existing `/api/set_limits` path.

### Misc
- Tolerate non-ASCII component names on legacy consoles (Turkish names on cp932).
- Co-locate a `.SLDASM`'s sibling part files when opening a throwaway copy so its
  references resolve.

## Tests
- New: `test_limit_joints`, `test_concentric_slide_promotion` (free slide ->
  prismatic, locked slide stays fixed, twin rails -> one DOF), `test_com_int`,
  `test_config_default_axis`.
- Full suite: 126 passed, ruff clean.