### PR TITLE
exporter/editor: configurable ROS package name and URDF file name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,8 +214,9 @@ jobs:
           catkin config --install     # run the install rules into install/
           catkin build --no-status
           source install/setup.bash
-          # the URDF must parse with ROS's own urdfdom parser
-          check_urdf install/share/fingertip_description/urdf/fingertip.urdf
+          # the URDF must parse with ROS's own urdfdom parser (the URDF defaults
+          # to the package name now, so <pkg>/urdf/<pkg>.urdf)
+          check_urdf install/share/fingertip_description/urdf/fingertip_description.urdf
           # the install rules must place the package's runtime files
           test -d install/share/fingertip_description/meshes
 
@@ -246,8 +247,8 @@ jobs:
           cd ws
           colcon build
           source install/setup.bash
-          check_urdf src/fingertip_description/urdf/fingertip.urdf
+          check_urdf src/fingertip_description/urdf/fingertip_description.urdf
           share=install/fingertip_description/share/fingertip_description
-          test -f "$share/urdf/fingertip.urdf"
+          test -f "$share/urdf/fingertip_description.urdf"
           test -f "$share/launch/display.launch.py"
-          test -f "$share/rviz/fingertip.rviz"
+          test -f "$share/rviz/fingertip_description.rviz"

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -547,6 +547,26 @@
          padding:6px 8px;margin:6px 0;background:#1e2620;font-size:12px">
       <div style="color:#8fd99f;font-size:11px;margin-bottom:4px">
         📦 Export</div>
+      <div style="display:flex;gap:4px;align-items:center;margin-bottom:4px">
+        <span style="color:#8a93a3;min-width:54px" data-i18n="ui.exppkgname">package</span>
+        <input id="exppkg" type="text" spellcheck="false"
+               data-i18n-title="t.exppkgname"
+               title="ROS package name for the exported ROS1/ROS2 package
+(default <name>_description). Lowercase letters, digits and underscores only."
+               style="flex:1;min-width:0;background:#15171a;color:#cfe3ff;
+                      border:1px solid #2d4a35;border-radius:3px;padding:2px 5px;
+                      font-size:11px" placeholder="robot_description">
+      </div>
+      <div style="display:flex;gap:4px;align-items:center;margin-bottom:4px">
+        <span style="color:#8a93a3;min-width:54px" data-i18n="ui.expurdfname">URDF</span>
+        <input id="expurdf" type="text" spellcheck="false"
+               data-i18n-title="t.expurdfname"
+               title="file name (stem) of the URDF inside the package.
+Leave empty to match the package name (e.g. bambulab_description.urdf)."
+               style="flex:1;min-width:0;background:#15171a;color:#cfe3ff;
+                      border:1px solid #2d4a35;border-radius:3px;padding:2px 5px;
+                      font-size:11px" placeholder="robot_description">
+      </div>
       <div style="display:flex;gap:4px;flex-wrap:wrap;align-items:center">
         <a id="expdae" href="/api/export/zip?meshes=dae&ros=1" download>
           <button data-i18n="ui.expdae" data-i18n-title="t.expdae"
@@ -1023,6 +1043,12 @@ skrobot / native-mesh consumers (not RViz-loadable)">⬇ glb</button></a>
     't.selall': { en: 'select all', ja: 'すべて選択' },
     'ui.selectedArrow': { en: 'selected →', ja: '選択 →' },
     'ui.set': { en: 'Set', ja: '適用' },
+    'ui.exppkgname': { en: 'package', ja: 'パッケージ名' },
+    't.exppkgname': { en: 'ROS package name for the exported ROS1/ROS2 package (default <name>_description). Lowercase letters, digits and underscores only.',
+                      ja: 'エクスポートする ROS1/ROS2 パッケージの名前（既定: <name>_description）。英小文字・数字・アンダースコアのみ。' },
+    'ui.expurdfname': { en: 'URDF', ja: 'URDF名' },
+    't.expurdfname': { en: 'file name (stem) of the URDF inside the package. Leave empty to match the package name (e.g. bambulab_description.urdf).',
+                       ja: 'パッケージ内 URDF のファイル名（拡張子なし）。空欄ならパッケージ名と同じ（例: bambulab_description.urdf）。' },
     't.expdae': { en: 'portable ROS 1 (catkin) package (<name>_description): package:// URLs, visual = colour COLLADA .dae, collision = .stl (loads in RViz/Gazebo)',
                   ja: 'ポータブルな ROS 1 (catkin) パッケージ (<name>_description): package:// URL、visual = カラー COLLADA .dae、collision = .stl（RViz/Gazebo で読込可）' },
     'ui.expdae': { en: '⬇ ROS1 package', ja: '⬇ ROS1 パッケージ' },
@@ -3094,6 +3120,53 @@ autolimitsBtn.addEventListener('click', async () => {
   }
 });
 
+// ---- export names: thread the chosen package + URDF names into the ZIP links
+// the ROS1/ROS2/glb downloads are plain <a download> links; on click we rewrite
+// their ?name=&urdf= from these fields so the exported package (and zip) carry
+// them.  Empty URDF name -> the URDF inside is named after the package.
+const exppkg = document.getElementById('exppkg');
+const expurdf = document.getElementById('expurdf');
+const expLinks = ['expdae', 'expros2', 'expglb']
+  .map(id => document.getElementById(id)).filter(Boolean);
+function exportDefaultName() {
+  // mirror the server: sanitise the assembly name to a valid ROS package name
+  // ('Assem1' -> 'assem1_description') so the placeholder matches what ships
+  const n = currentInfo?.name;
+  if (!n) { return 'robot_description'; }
+  let base = n.toLowerCase().replace(/[^a-z0-9_]/g, '_').replace(/^_+|_+$/g, '');
+  if (!base || !/[a-z]/.test(base[0])) { base = base ? 'robot_' + base : 'robot'; }
+  return `${base}_description`;
+}
+function effectivePkgName() {
+  return (exppkg?.value || '').trim() || exportDefaultName();
+}
+function refreshExportName() {
+  if (exppkg) { exppkg.placeholder = exportDefaultName(); }
+  if (expurdf) { expurdf.placeholder = effectivePkgName(); }  // urdf = pkg name
+}
+// keep the package field a valid ROS package name as the user types (lowercase,
+// digits, underscore; must start with a letter) -- matches the server check
+exppkg?.addEventListener('input', () => {
+  const clean = exppkg.value.toLowerCase()
+    .replace(/[^a-z0-9_]/g, '_').replace(/^[^a-z]+/, '');
+  if (exppkg.value !== clean) { exppkg.value = clean; }
+  if (expurdf) { expurdf.placeholder = effectivePkgName(); }
+});
+// the URDF stem is a filename: letters/digits/_/-/. , starting alphanumeric
+expurdf?.addEventListener('input', () => {
+  const clean = expurdf.value
+    .replace(/[^A-Za-z0-9_.-]/g, '_').replace(/^[^A-Za-z0-9]+/, '');
+  if (expurdf.value !== clean) { expurdf.value = clean; }
+});
+expLinks.forEach(a => a.addEventListener('click', () => {
+  const base = a.getAttribute('href').split('&name=')[0].split('&urdf=')[0];
+  const name = (exppkg?.value || '').trim();
+  const urdf = (expurdf?.value || '').trim();
+  a.href = base
+    + (name ? `&name=${encodeURIComponent(name)}` : '')
+    + (urdf ? `&urdf=${encodeURIComponent(urdf)}` : '');
+}));
+
 // ---- camera: bbox helpers, SolidWorks-style view presets, auto-fit ------
 function robotBox() {
   // bbox of the actual MODEL: visible meshes only, helpers excluded
@@ -4385,6 +4458,7 @@ function loadRobot(info, { drop = false, keepPose = false,
   dropMode = drop;
   if (!drop) { viewer.urlModifierFunc = null; currentInfo = info; }
   else { currentInfo = null; }
+  refreshExportName();          // export field placeholder follows the open pkg
   // cover the reload gap with a display-only clone of the current robot
   // (same world pose -> the swap is pixel-invisible); geometry/materials
   // are shared so this costs milliseconds

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -174,30 +174,41 @@ def _read_root_pose(txt):
             float(m.group(1)) if m else 0.0)
 
 
-def _export_zip(pkg_dir, robot_name, mesh_fmt="dae", ros_version=1):
-    """ZIP a portable ``<robot_name>_description`` package (package:// URLs).
+def _export_zip(pkg_dir, robot_name, mesh_fmt="dae", ros_version=1,
+                pkg_name=None, urdf_name=None):
+    """ZIP a portable ROS package (package:// URLs), named ``pkg_name`` if given
+    else ``<robot_name>_description``; the URDF inside is named ``urdf_name`` if
+    given, else the package name.
 
     ``mesh_fmt='dae'`` (default): ``<visual>`` as colour COLLADA ``.dae`` +
     ``<collision>`` as plain ``.stl`` -- the RViz/Gazebo-ready variant.
     ``mesh_fmt='glb'``: a uniform ``.glb`` package (colour kept) for three.js /
     skrobot / native-mesh consumers (not RViz-loadable).
 
-    ``ros_version`` (1 = catkin, 2 = ament_cmake) selects the build files."""
+    ``ros_version`` (1 = catkin, 2 = ament_cmake) selects the build files.
+    Returns ``(pkg, bytes)`` so the caller can name the download after the
+    actual package."""
     if mesh_fmt not in ("dae", "glb"):
         raise ValueError(f"unsupported mesh format: {mesh_fmt}")
 
     import io as _io
     import zipfile
 
-    from sw2robot.exporter.ros_export import GLB_CTX_FMT, build_ros_description
+    from sw2robot.exporter.ros_export import (
+        GLB_CTX_FMT,
+        build_ros_description,
+        ros_pkg_name,
+    )
+    pkg = ros_pkg_name(robot_name, pkg_name)
     kwargs = {"ctx_fmt": GLB_CTX_FMT} if mesh_fmt == "glb" else {}
     buf = _io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
         for arc, data in build_ros_description(pkg_dir, robot_name,
                                                ros_version=ros_version,
-                                               **kwargs):
+                                               pkg_name=pkg,
+                                               urdf_name=urdf_name, **kwargs):
             z.writestr(arc, data)
-    return buf.getvalue()
+    return pkg, buf.getvalue()
 
 
 # --- joint/link rename overlay (joints.yaml link_names / joint_names) --------
@@ -1211,10 +1222,17 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                     return self._send_json(
                         {"error": f"unsupported ros version: {ros}"}, 400)
                 ros_version = int(ros)
-                data = _export_zip(cls.pkg_dir, cls.robot_name, fmt,
-                                   ros_version=ros_version)
+                pkg_name = (query.get("name") or [""])[0].strip() or None
+                urdf_name = (query.get("urdf") or [""])[0].strip() or None
+                try:
+                    pkg, data = _export_zip(cls.pkg_dir, cls.robot_name, fmt,
+                                            ros_version=ros_version,
+                                            pkg_name=pkg_name,
+                                            urdf_name=urdf_name)
+                except ValueError as e:
+                    return self._send_json({"error": str(e)}, 400)
                 fname = (f"{cls.robot_name}_glb.zip" if fmt == "glb"
-                         else f"{cls.robot_name}_description.zip")
+                         else f"{pkg}.zip")
                 self.send_response(200)
                 self.send_header("Content-Type", "application/zip")
                 self.send_header("Content-Disposition",

--- a/sw2robot/exporter/build.py
+++ b/sw2robot/exporter/build.py
@@ -19,11 +19,17 @@ def main():
     ap.add_argument("--ros2", action="store_true",
                     help="make --ros-pkg an ament_cmake (ROS 2) package with "
                          "launch/ + rviz/ instead of catkin; implies --ros-pkg")
+    ap.add_argument("--ros-pkg-name", default=None,
+                    help="name for the --ros-pkg package (default "
+                         "<name>_description); lowercase letters/digits/_ only")
+    ap.add_argument("--ros-urdf-name", default=None,
+                    help="stem for the URDF inside --ros-pkg (default: pkg name)")
     args = ap.parse_args()
     exclude = [x.strip() for x in args.exclude.split(",")] if args.exclude else None
     build(args.pkg_dir, config_path=args.config, base_hint=args.base,
           exclude=exclude, ros_pkg=args.ros_pkg or args.ros2,
-          ros_version=2 if args.ros2 else 1)
+          ros_version=2 if args.ros2 else 1, ros_pkg_name=args.ros_pkg_name,
+          ros_urdf_name=args.ros_urdf_name)
 
 
 if __name__ == "__main__":

--- a/sw2robot/exporter/export.py
+++ b/sw2robot/exporter/export.py
@@ -158,7 +158,8 @@ def extract(assembly_path, out_dir=None, robot_name=None, visible=False,
 
 # ---------------------------------------------------------------- build
 def build(pkg_dir, config_path=None, base_hint=None, exclude=None,
-          ros_pkg=False, density=None, ros_version=1):
+          ros_pkg=False, density=None, ros_version=1, ros_pkg_name=None,
+          ros_urdf_name=None):
     _tolerant_console()
     graph = GraphState.load(os.path.join(pkg_dir, GRAPH_FILE))
     robot_name = graph.robot_name
@@ -189,13 +190,14 @@ def build(pkg_dir, config_path=None, base_hint=None, exclude=None,
 
     desc_dir = None
     if ros_pkg:
-        # a standalone <robot_name>_description package next to pkg_dir:
-        # package:// URLs + COLLADA .dae meshes (RViz/Gazebo-ready).
-        # ros_version 2 also bundles launch/ + rviz/ for `ros2 launch`.
+        # a standalone package next to pkg_dir (default <robot_name>_description,
+        # or --ros-pkg-name): package:// URLs + COLLADA .dae meshes
+        # (RViz/Gazebo-ready).  ros_version 2 also bundles launch/ + rviz/.
         from .ros_export import write_ros_description_package
         desc_dir = write_ros_description_package(
             pkg_dir, robot_name, os.path.dirname(os.path.abspath(pkg_dir)),
-            ros_version=ros_version)
+            ros_version=ros_version, pkg_name=ros_pkg_name,
+            urdf_name=ros_urdf_name)
 
     print(f"\nDONE. Package: {pkg_dir}")
     print(f"  URDF:   {urdf_path}")
@@ -211,10 +213,11 @@ def build(pkg_dir, config_path=None, base_hint=None, exclude=None,
 # ---------------------------------------------------------------- export
 def export(assembly_path, out_dir=None, robot_name=None, visible=False,
            config_path=None, base_hint=None, exclude=None, ros_pkg=False,
-           ros_version=1):
+           ros_version=1, ros_pkg_name=None, ros_urdf_name=None):
     pkg_dir = extract(assembly_path, out_dir, robot_name, visible)
     return build(pkg_dir, config_path=config_path, base_hint=base_hint,
-                 exclude=exclude, ros_pkg=ros_pkg, ros_version=ros_version)
+                 exclude=exclude, ros_pkg=ros_pkg, ros_version=ros_version,
+                 ros_pkg_name=ros_pkg_name, ros_urdf_name=ros_urdf_name)
 
 
 def _exclude_list(s):
@@ -238,12 +241,20 @@ def main():
                     help="make the --ros-pkg an ament_cmake (ROS 2) package "
                          "with launch/ + rviz/ instead of catkin (ROS 1); "
                          "implies --ros-pkg")
+    ap.add_argument("--ros-pkg-name", default=None,
+                    help="name for the --ros-pkg package (default "
+                         "<name>_description); must be a valid ROS package "
+                         "name: lowercase letters, digits, underscores")
+    ap.add_argument("--ros-urdf-name", default=None,
+                    help="stem for the URDF file inside the --ros-pkg package "
+                         "(default: the package name)")
     args = ap.parse_args()
     export(args.assembly, args.out, args.name, args.visible,
            config_path=args.config, base_hint=args.base,
            exclude=_exclude_list(args.exclude),
            ros_pkg=args.ros_pkg or args.ros2,
-           ros_version=2 if args.ros2 else 1)
+           ros_version=2 if args.ros2 else 1,
+           ros_pkg_name=args.ros_pkg_name, ros_urdf_name=args.ros_urdf_name)
 
 
 if __name__ == "__main__":

--- a/sw2robot/exporter/ros_export.py
+++ b/sw2robot/exporter/ros_export.py
@@ -22,6 +22,7 @@ zip it in memory and the CLI can write it to disk.
 from __future__ import annotations
 
 import os
+import re
 import xml.etree.ElementTree as ET
 
 from .urdf_writer import (
@@ -150,10 +151,55 @@ def _resolve_mesh(pkg_dir, ref):
     return base, src, ext
 
 
+def ros_pkg_name(robot_name, pkg_name=None):
+    """The ROS package name to emit: an explicit ``pkg_name`` (validated) or the
+    default ``<robot_name>_description``.  catkin/ament require a name starting
+    with a lowercase letter and containing only lowercase, digits and
+    underscores.
+
+    The default is SANITIZED to that form (a SolidWorks assembly like 'Assem1'
+    -> 'assem1_description'), since the assembly name often has capitals; an
+    EXPLICIT name is validated strictly and rejected if malformed, so a typo
+    surfaces instead of silently changing."""
+    if not pkg_name:
+        base = re.sub(r"[^a-z0-9_]", "_", robot_name.lower()).strip("_")
+        if not base or not base[0].isalpha():
+            base = "robot_" + base if base else "robot"
+        return f"{base}_description"
+    pkg = pkg_name.strip()
+    if not re.fullmatch(r"[a-z][a-z0-9_]*", pkg):
+        raise ValueError(
+            f"invalid ROS package name {pkg_name!r}: must start with a "
+            "lowercase letter and contain only lowercase letters, digits and "
+            "underscores (e.g. 'bambu_a1_description')")
+    return pkg
+
+
+def ros_urdf_stem(pkg, urdf_name=None):
+    """The URDF file stem to emit inside the package: an explicit ``urdf_name``
+    (validated) or, when blank, the package name itself -- so the package ships
+    ``<pkg>/urdf/<pkg>.urdf`` by default instead of leaking the SolidWorks
+    assembly name."""
+    if not urdf_name:
+        return pkg
+    stem = urdf_name.strip()
+    if stem.lower().endswith(".urdf"):
+        stem = stem[:-5]
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]*", stem):
+        raise ValueError(
+            f"invalid URDF name {urdf_name!r}: use letters, digits, '_', '-' "
+            "or '.' and start with a letter or digit (e.g. 'bambu_a1')")
+    return stem
+
+
 def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
-                          ctx_fmt=_CTX_FMT, ros_version=1):
+                          ctx_fmt=_CTX_FMT, ros_version=1, pkg_name=None,
+                          urdf_name=None):
     """``pkg_dir`` (a built package) -> ``[(arcname, bytes), ...]`` for a portable
-    ``<robot_name>_description`` ROS package, all behind ``package://`` URLs.
+    ROS package, all behind ``package://`` URLs.  The package is named
+    ``pkg_name`` if given (validated, see :func:`ros_pkg_name`), else
+    ``<robot_name>_description``.  The URDF inside is named ``urdf_name`` if
+    given, else the package name (so ``<pkg>/urdf/<pkg>.urdf`` by default).
 
     ``ctx_fmt`` maps each URDF context to a mesh format; the default emits
     ``<visual>`` as colour ``.dae`` and ``<collision>`` as plain ``.stl`` (the
@@ -162,7 +208,7 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
     ``ros_version`` picks the build system: ``1`` (default) writes a catkin
     ``package.xml`` (format 2) + ``CMakeLists.txt``; ``2`` writes an ament_cmake
     ``package.xml`` (format 3) + ``CMakeLists.txt`` and bundles a
-    ``launch/display.launch.py`` + ``rviz/<name>.rviz`` so the package runs with
+    ``launch/display.launch.py`` + ``rviz/<urdf>.rviz`` so the package runs with
     ``ros2 launch <name> display.launch.py``.
 
     Reads the on-disk ``urdf/<robot_name>.urdf`` (which already carries the
@@ -170,7 +216,8 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
     before any entries are emitted, so a half-rewritten package never ships."""
     if ros_version not in (1, 2):
         raise ValueError(f"unsupported ros_version: {ros_version}")
-    pkg = f"{robot_name}_description"
+    pkg = ros_pkg_name(robot_name, pkg_name)
+    urdf_stem = ros_urdf_stem(pkg, urdf_name)
     urdf_path = os.path.join(pkg_dir, "urdf", robot_name + ".urdf")
     root = ET.parse(urdf_path).getroot()
 
@@ -210,7 +257,7 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
     new_urdf = '<?xml version="1.0"?>\n' + ET.tostring(root, encoding="unicode")
     if not new_urdf.endswith("\n"):
         new_urdf += "\n"
-    files.append((f"{pkg}/urdf/{robot_name}.urdf", new_urdf.encode("utf-8")))
+    files.append((f"{pkg}/urdf/{urdf_stem}.urdf", new_urdf.encode("utf-8")))
 
     if ros_version == 2:
         # the root (first) link is the natural RViz fixed frame
@@ -223,9 +270,9 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
         files.append((f"{pkg}/CMakeLists.txt",
                       CMAKELISTS_ROS2.format(name=pkg).encode("utf-8")))
         files.append((f"{pkg}/launch/display.launch.py",
-                      DISPLAY_LAUNCH_ROS2.format(name=pkg, robot=robot_name)
+                      DISPLAY_LAUNCH_ROS2.format(name=pkg, robot=urdf_stem)
                       .encode("utf-8")))
-        files.append((f"{pkg}/rviz/{robot_name}.rviz",
+        files.append((f"{pkg}/rviz/{urdf_stem}.rviz",
                       RVIZ_CONFIG_ROS2.format(fixed_frame=fixed_frame)
                       .encode("utf-8")))
     else:
@@ -237,16 +284,21 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
 
 
 def write_ros_description_package(pkg_dir, robot_name, dest_dir,
-                                  email="auto@example.com", ros_version=1):
-    """Write the ``<robot_name>_description`` package under ``dest_dir`` and return
-    its directory path.  ``ros_version`` (1 = catkin, 2 = ament_cmake) is passed
-    through to :func:`build_ros_description`."""
+                                  email="auto@example.com", ros_version=1,
+                                  pkg_name=None, urdf_name=None):
+    """Write the ROS package under ``dest_dir`` and return its directory path.
+    The package is named ``pkg_name`` if given, else ``<robot_name>_description``;
+    the URDF inside is named ``urdf_name`` if given, else the package name.
+    ``ros_version`` (1 = catkin, 2 = ament_cmake) is passed through to
+    :func:`build_ros_description`."""
+    pkg = ros_pkg_name(robot_name, pkg_name)
     files = build_ros_description(pkg_dir, robot_name, email=email,
-                                  ros_version=ros_version)
+                                  ros_version=ros_version, pkg_name=pkg,
+                                  urdf_name=urdf_name)
     root = os.path.abspath(dest_dir)
     for arc, data in files:
         dst = os.path.join(root, *arc.split("/"))
         os.makedirs(os.path.dirname(dst), exist_ok=True)
         with open(dst, "wb") as f:
             f.write(data)
-    return os.path.join(root, f"{robot_name}_description")
+    return os.path.join(root, pkg)

--- a/tests/test_ros_export.py
+++ b/tests/test_ros_export.py
@@ -70,11 +70,12 @@ def test_build_ros_description_layout(tmp_path):
 
     assert "fing_description/package.xml" in arcs
     assert "fing_description/CMakeLists.txt" in arcs
-    assert "fing_description/urdf/fing.urdf" in arcs
+    # URDF inside is named after the package by default (not the assembly name)
+    assert "fing_description/urdf/fing_description.urdf" in arcs
     assert "fing_description/meshes/part.dae" in arcs       # visual
     assert "fing_description/meshes/part.stl" in arcs       # collision
 
-    urdf = files["fing_description/urdf/fing.urdf"].decode()
+    urdf = files["fing_description/urdf/fing_description.urdf"].decode()
     import xml.etree.ElementTree as ET
     link = ET.fromstring(urdf).find("link")
     vis = link.find("visual").find(".//mesh").get("filename")
@@ -105,16 +106,16 @@ def test_build_ros2_description_layout(tmp_path):
     files = dict(build_ros_description(pkg_dir, "fing", ros_version=2))
     arcs = set(files)
 
-    # same description payload as ROS 1
-    assert "fing_description/urdf/fing.urdf" in arcs
+    # same description payload as ROS 1 (URDF named after the package)
+    assert "fing_description/urdf/fing_description.urdf" in arcs
     assert "fing_description/meshes/part.dae" in arcs
     assert "fing_description/meshes/part.stl" in arcs
-    urdf = files["fing_description/urdf/fing.urdf"].decode()
+    urdf = files["fing_description/urdf/fing_description.urdf"].decode()
     assert "package://fing_description/meshes/part.dae" in urdf
 
     # ROS 2 specific files
     assert "fing_description/launch/display.launch.py" in arcs
-    assert "fing_description/rviz/fing.rviz" in arcs
+    assert "fing_description/rviz/fing_description.rviz" in arcs
 
     pxml = files["fing_description/package.xml"].decode()
     assert 'format="3"' in pxml
@@ -129,10 +130,12 @@ def test_build_ros2_description_layout(tmp_path):
     launch = files["fing_description/launch/display.launch.py"].decode()
     assert "robot_state_publisher" in launch
     assert 'get_package_share_directory("fing_description")' in launch
+    assert '"fing_description.urdf"' in launch     # urdf named after the package
+    assert '"fing_description.rviz"' in launch
     # the launch python must be syntactically valid
     compile(launch, "display.launch.py", "exec")
 
-    rviz = files["fing_description/rviz/fing.rviz"].decode()
+    rviz = files["fing_description/rviz/fing_description.rviz"].decode()
     assert "RobotModel" in rviz
     assert "Fixed Frame: base_link" in rviz   # the urdf's first link
 
@@ -160,7 +163,8 @@ def test_glb_ctx_exports_uniform_glb(tmp_path):
 
     assert "g_description/meshes/part.glb" in files
     assert not any(a.endswith((".dae", ".stl")) for a in files)   # uniform glb
-    link = ET.fromstring(files["g_description/urdf/g.urdf"].decode()).find("link")
+    link = ET.fromstring(
+        files["g_description/urdf/g_description.urdf"].decode()).find("link")
     for ctx in ("visual", "collision"):
         assert (link.find(ctx).find(".//mesh").get("filename")
                 == "package://g_description/meshes/part.glb")
@@ -266,13 +270,109 @@ def test_urdf_loads_in_skrobot_with_package_meshes_resolved(tmp_path,
     from skrobot.models.urdf import RobotModelFromURDF
 
     desc = _write_desc(tmp_path, "fing", ros_version)
-    robot = RobotModelFromURDF(urdf_file=os.path.join(desc, "urdf", "fing.urdf"))
+    robot = RobotModelFromURDF(
+        urdf_file=os.path.join(desc, "urdf", "fing_description.urdf"))
 
     assert "base_link" in [link.name for link in robot.link_list]
     vms = robot.link_list[0].visual_mesh
     vms = vms if isinstance(vms, (list, tuple)) else [vms]
     faces = sum(len(m.faces) for m in vms if hasattr(m, "faces"))
     assert faces > 0, "package:// visual mesh did not resolve to real geometry"
+
+
+def test_custom_pkg_name_renames_everything(tmp_path):
+    """An explicit ``pkg_name`` renames the package dir, the manifest <name>,
+    the project(), every ``package://`` URL, AND the urdf file (which defaults
+    to the package name) -- the assembly name 'fing' must not leak through."""
+    from sw2robot.exporter.ros_export import build_ros_description
+
+    pkg_dir = _make_pkg(tmp_path, robot="fing")
+    files = dict(build_ros_description(pkg_dir, "fing",
+                                       pkg_name="bambu_a1_description"))
+    arcs = set(files)
+
+    assert "bambu_a1_description/package.xml" in arcs
+    # urdf defaults to the package name, not the assembly name
+    assert "bambu_a1_description/urdf/bambu_a1_description.urdf" in arcs
+    assert "bambu_a1_description/meshes/part.dae" in arcs
+    assert not any("/fing.urdf" in a for a in arcs)
+    assert not any(a.startswith("fing_description/") for a in arcs)
+
+    urdf = files["bambu_a1_description/urdf/bambu_a1_description.urdf"].decode()
+    assert "package://bambu_a1_description/meshes/part.dae" in urdf
+    pxml = files["bambu_a1_description/package.xml"].decode()
+    assert re.search(r"<name>\s*bambu_a1_description\s*</name>", pxml)
+    cmake = files["bambu_a1_description/CMakeLists.txt"].decode()
+    assert "project(bambu_a1_description)" in cmake
+
+
+def test_explicit_urdf_name_overrides_package_default(tmp_path):
+    """An explicit ``urdf_name`` names the urdf (and ros2 launch/rviz), while
+    the package keeps its own name; an empty urdf_name falls back to the pkg."""
+    from sw2robot.exporter.ros_export import build_ros_description
+
+    pkg_dir = _make_pkg(tmp_path, robot="fing")
+    files = dict(build_ros_description(pkg_dir, "fing", ros_version=2,
+                                       pkg_name="my_arm", urdf_name="bambu_a1"))
+    assert "my_arm/urdf/bambu_a1.urdf" in files            # explicit stem
+    assert "my_arm/rviz/bambu_a1.rviz" in files
+    launch = files["my_arm/launch/display.launch.py"].decode()
+    assert 'get_package_share_directory("my_arm")' in launch   # pkg unchanged
+    assert '"bambu_a1.urdf"' in launch                         # urdf stem
+    compile(launch, "display.launch.py", "exec")
+
+    # a '.urdf' suffix on the input is stripped, not doubled
+    files2 = dict(build_ros_description(pkg_dir, "fing",
+                                        pkg_name="my_arm", urdf_name="foo.urdf"))
+    assert "my_arm/urdf/foo.urdf" in files2
+
+
+def test_custom_pkg_name_ros2_launch_and_rviz(tmp_path):
+    from sw2robot.exporter.ros_export import build_ros_description
+
+    pkg_dir = _make_pkg(tmp_path, robot="fing")
+    files = dict(build_ros_description(pkg_dir, "fing", ros_version=2,
+                                       pkg_name="my_arm"))
+    assert "my_arm/launch/display.launch.py" in files
+    assert "my_arm/urdf/my_arm.urdf" in files              # urdf = pkg by default
+    launch = files["my_arm/launch/display.launch.py"].decode()
+    assert 'get_package_share_directory("my_arm")' in launch
+    compile(launch, "display.launch.py", "exec")
+
+
+def test_invalid_pkg_name_rejected():
+    import pytest
+
+    from sw2robot.exporter.ros_export import ros_pkg_name, ros_urdf_stem
+
+    assert ros_pkg_name("fing") == "fing_description"          # default
+    # the default sanitises an assembly name with capitals/punctuation into a
+    # VALID ROS package name (so the no-name export never 400s)
+    assert ros_pkg_name("Assem1") == "assem1_description"
+    assert ros_pkg_name("My-Robot 2") == "my_robot_2_description"
+    assert ros_pkg_name("123") == "robot_123_description"      # must start alpha
+    assert ros_pkg_name("fing", "robot_x2") == "robot_x2"      # valid passes
+    for bad in ("Bad-Name", "2leading", "has space", "Caps", "-x"):
+        with pytest.raises(ValueError, match="invalid ROS package name"):
+            ros_pkg_name("fing", bad)
+    # urdf stem: defaults to the package, accepts filename-ish names, rejects junk
+    assert ros_urdf_stem("my_pkg") == "my_pkg"
+    assert ros_urdf_stem("my_pkg", "Bambu_A1-v2") == "Bambu_A1-v2"
+    for bad in ("has space", "/etc/passwd", "-x", ".hidden"):
+        with pytest.raises(ValueError, match="invalid URDF name"):
+            ros_urdf_stem("my_pkg", bad)
+
+
+def test_write_pkg_with_custom_name_returns_that_dir(tmp_path):
+    from sw2robot.exporter.ros_export import write_ros_description_package
+
+    src = tmp_path / "src"
+    src.mkdir()
+    pkg_dir = _make_pkg(src, robot="fing")
+    out = write_ros_description_package(pkg_dir, "fing", str(tmp_path / "out"),
+                                        pkg_name="custom_desc")
+    assert os.path.basename(out) == "custom_desc"
+    assert os.path.exists(os.path.join(out, "package.xml"))
 
 
 def test_missing_mesh_aborts_instead_of_half_broken_package(tmp_path):


### PR DESCRIPTION
## Summary

The exported ROS 1 / 2 package was always ``<robot>_description`` with the URDF
inside named after the SolidWorks assembly (e.g.
``bambulab_description/urdf/Assem1.urdf``).  Both are now configurable, and the
defaults are sensible.

### Package name
- ``ros_pkg_name()``: an explicit name is validated against catkin/ament rules
  (lowercase letter start; lowercase, digits, underscores) and rejected if
  malformed, so a typo surfaces instead of silently shipping a broken package.
- the **default** is now **sanitized** from the assembly name
  (``Assem1`` → ``assem1_description``) instead of used verbatim, so the no-name
  export always produces a package a build tool will accept (the old default
  could contain capitals and fail).

### URDF file name
- the URDF inside now defaults to the **package name**
  (``bambulab_description.urdf``), not the assembly name, and can be overridden.
- the ROS 2 ``display.launch.py`` + ``rviz`` config follow the chosen URDF stem.

### Editor
- the 📦 Export box gains **package** and **URDF** name fields (the URDF field
  follows the package name when left blank); the download links thread them as
  ``?name=&urdf=``.  Invalid names are rejected server-side (400).

### CLI
- ``build`` / ``export`` gain ``--ros-pkg-name`` and ``--ros-urdf-name``.

## Tests
- ``test_ros_export``: custom package name renames everything; explicit URDF
  name overrides the package default; default is sanitized from a capitalised
  assembly name; invalid names rejected.  Existing layout tests updated to the
  new URDF-name default.
- Full suite: 131 passed, ruff clean, editor JS ``node --check`` OK.