### PR TITLE
editor: fix prismatic drag direction for joints with a rotated origin

### DIFF
--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -1967,6 +1967,19 @@ function applyPoseDrag() {
   if (dc !== _origDragControls) {
     _origDragControls = dc;
     _origOnHover = dc.onHover; _origOnUnhover = dc.onUnhover;
+    // urdf-loader's getPrismaticDelta projects the pointer onto the axis
+    // transformed by joint.PARENT.matrixWorld -- it drops the joint's own
+    // <origin rpy>, so a prismatic with a rotated origin drags the WRONG way
+    // (getRevoluteDelta already uses joint.matrixWorld).  The real motion runs
+    // the axis through the joint's own frame, so use joint.matrixWorld here too
+    // and every slider drags the way the mouse moves, not just the rpy=0 ones.
+    const _pdN = new THREE.Vector3();
+    const _pdD = new THREE.Vector3();
+    dc.getPrismaticDelta = (joint, startPoint, endPoint) => {
+      _pdD.subVectors(endPoint, startPoint);
+      _pdN.copy(joint.axis).transformDirection(joint.matrixWorld).normalize();
+      return _pdD.dot(_pdN);
+    };
   } else {
     if (dc.onHover !== _noopHover && dc.onHover !== _origOnHover) {
       _origOnHover = dc.onHover;


### PR DESCRIPTION
## Summary

In the editor''s pose mode (drag a link to move its joint), two of the printer''s
three prismatic joints dragged the **opposite** way to the mouse; only one
tracked it correctly.

## Root cause

A mismatch in urdf-loader 0.12.7:

- `getPrismaticDelta` projects the pointer delta onto the joint axis transformed
  by **`joint.parent.matrixWorld`** — it drops the joint''s own `<origin rpy>`.
- but the actual prismatic motion (`URDFJoint.setJointValue`) runs the axis
  through the joint''s own frame (`axis.applyEuler(joint.rotation)`), and
  `getRevoluteDelta` correctly uses `joint.matrixWorld`.

So a prismatic whose origin carries a rotation drags inverted; only an `rpy=0`
joint is consistent. On the Bambu A1: `k_zak_tutucu_1` (rpy 0) was correct,
while `tabla` (rpy ~−90° Z) and `ana_parça` (rpy ~90°/180°) were reversed.

## Fix

Override `getPrismaticDelta` on our drag controls to transform the axis by
`joint.matrixWorld` (same frame as the real motion and as `getRevoluteDelta`),
so the drag axis matches the motion and every slider follows the mouse,
regardless of the joint''s origin rotation.

Editor-only change; `node --check` clean.