### PR TITLE
exporter: keep joint limits across template regen and re-extract

### DIFF
--- a/sw2robot/editor/core.py
+++ b/sw2robot/editor/core.py
@@ -188,6 +188,19 @@ def extract_and_import(assembly_path, out_dir=None, robot_name=None,
                  else "starting SolidWorks (this can take a minute) ...")
     pkg_dir = extract(assembly_path, out_dir=out_dir, robot_name=robot_name,
                       visible=visible, progress=progress, sw=sw)
+    # A re-extract regenerates graph.json but extract() leaves the existing
+    # <name>.joints.yaml in place.  Without a config the build would take the
+    # auto path and OVERWRITE that file -- silently dropping every edit the user
+    # made (joint types, axes, renames, base, and the travel range of a joint
+    # with no SolidWorks limit mate, which lives ONLY here).  So reuse it as the
+    # config: re-extracting refreshes the geometry while keeping the user's work.
+    if config_path is None:
+        existing = sorted(Path(pkg_dir).glob("*.joints.yaml"))
+        if existing:
+            config_path = str(existing[0])
+            if progress:
+                progress(f"reusing your joint config {existing[0].name} "
+                         f"(keeps types/limits/renames across the re-extract)")
     if progress:
         progress("building URDF from the CAD graph ...")
     return import_module(pkg_dir, config_path=config_path, base_hint=base_hint)

--- a/sw2robot/exporter/jointcfg.py
+++ b/sw2robot/exporter/jointcfg.py
@@ -70,6 +70,14 @@ def write_template(model, path):
         lines.append(f"  - parent: {j.parent}")
         lines.append(f"    child:  {j.child}")
         lines.append(f"    type:   {j.jtype}{hint}")
+        # round-trip the travel range so re-running --config keeps it -- a joint
+        # WITHOUT a SolidWorks limit mate (a promoted concentric slide) has no
+        # other home for its limits, so omitting them here silently reset it to
+        # the default on the next build.  continuous joints have no endpoints.
+        if j.jtype in ("revolute", "prismatic") \
+                and j.lower is not None and j.upper is not None:
+            lines.append(f"    lower: {float(j.lower):.5f}")
+            lines.append(f"    upper: {float(j.upper):.5f}")
     # robot-compiler module interface (root is emitted as base_link by default)
     lines.append("")
     lines.append("# --- robot-compiler module interface (optional) ---")

--- a/tests/test_limit_joints.py
+++ b/tests/test_limit_joints.py
@@ -63,6 +63,22 @@ def test_limit_joint_builds_prismatic_with_limits():
     assert abs(j.upper - 0.15) < 1e-9
 
 
+def test_template_round_trips_joint_limits(tmp_path):
+    # write_template must emit lower/upper -- a joint without a SolidWorks limit
+    # mate (a promoted slide) has its travel range ONLY in the config, so a
+    # template that drops it silently resets the joint on the next build
+    from sw2robot.exporter import jointcfg
+    lj = LimitJoint(a="slider", b="base", type="prismatic",
+                    axis_point=[0, 0, 0], axis_dir=[0, 1, 0],
+                    lower=-0.05, upper=0.15)
+    model = build_model(_graph(lj))
+    out = tmp_path / "j.joints.yaml"
+    jointcfg.write_template(model, str(out))
+    txt = out.read_text(encoding="utf-8")
+    assert "lower: -0.05000" in txt
+    assert "upper: 0.15000" in txt
+
+
 def test_limit_joint_axis_flips_for_the_other_side():
     # if the tree child is the OTHER mate side (not the reference ``a``), its +
     # motion shrinks the distance, so the axis flips to keep joint>0 = toward max


### PR DESCRIPTION
## Summary

A joint with **no SolidWorks limit mate** -- a promoted concentric slide such as
the printer''s Z gantry -- has its travel range stored **only** in
`joints.yaml`. Two paths silently reset it:

1. `write_template` never emitted `lower`/`upper`, so regenerating the joint
   config dropped every joint limit; the promoted joint then fell back to its
   default (±0.05 m) on the next build.
2. the editor **re-extract** rebuilt with no config, taking the auto path and
   **overwriting** `joints.yaml` -- wiping the user''s limits (and types/renames).

## Fix

- `write_template` now round-trips `lower`/`upper` for revolute/prismatic joints.
- `extract_and_import` reuses an existing `<name>.joints.yaml` as the config when
  none is passed, so a re-extract refreshes the geometry while keeping the
  user''s edits (types, axes, limits, renames, base).

## Tests
- new `test_template_round_trips_joint_limits`; full suite 132 passed, ruff clean.