### PR TITLE
exporter: pivot a LimitAngle revolute on its concentric axis, not the angle face

### DIFF
--- a/sw2robot/exporter/model.py
+++ b/sw2robot/exporter/model.py
@@ -2438,10 +2438,26 @@ def build_model(graph, robot_name=None, base_hint=None, config=None,
                 continue
             rec = adjacency.setdefault(frozenset((lj.a, lj.b)),
                                        {"types": [], "axis": None, "mates": []})
+            ax_pt = np.asarray(lj.axis_point, float)
+            ax_dir = np.asarray(lj.axis_dir, float)
+            if lj.type == "revolute":
+                # a LimitAngle mate fixes the travel but its plane point is NOT
+                # on the rotation axis -- the hinge is the concentric/cylinder
+                # mate on the same pair.  Pivoting about the angle-plane point
+                # swings the part around an offset centre (the screen hinge was
+                # ~5 cm off); use the concentric axis line so it rotates in
+                # place.  Keep the limit's direction SIGN (lower/upper + ref are
+                # relative to it).
+                cax = _concentric_axis_of(rec)
+                if cax is not None:
+                    cp, cd = cax
+                    n = np.linalg.norm(ax_dir) or 1.0
+                    if abs(float(cd @ (ax_dir / n))) > 0.99:
+                        ax_pt = cp
+                        ax_dir = cd if float(cd @ ax_dir) >= 0 else -cd
             rec["limit_joint"] = {
                 "type": lj.type, "ref": lj.a,
-                "axis": (np.asarray(lj.axis_point, float),
-                         np.asarray(lj.axis_dir, float)),
+                "axis": (ax_pt, ax_dir),
                 "lower": float(lj.lower), "upper": float(lj.upper)}
             n_lim += 1
         if n_lim:

--- a/tests/test_limit_joints.py
+++ b/tests/test_limit_joints.py
@@ -90,6 +90,31 @@ def test_limit_joint_axis_flips_for_the_other_side():
     np.testing.assert_allclose([round(x) for x in j.axis], [0, -1, 0])
 
 
+def test_revolute_limit_joint_pivots_on_concentric_axis():
+    # a LimitAngle mate stores its plane point, which is NOT on the rotation
+    # axis; the hinge is the concentric mate.  build_model must pivot the
+    # revolute on the concentric axis line, not the (offset) angle point.
+    from sw2robot.exporter.state import MateGeo
+    base = _comp("base"); base.fixed = True
+    door = _comp("door", (0.2, 0, 0))
+    conc = MateGeo(type="CONCENTRIC", etypes=[4, 4],
+                   points=[[0.05, 0.0, 0.0], [0.05, 0.0, 0.02]],
+                   dirs=[[0, 0, 1], [0, 0, 1]], radii=[None, None])
+    edge = MateEdge(a="base", b="door", types=["CONCENTRIC"],
+                    axis_point=None, axis_dir=None, mates=[conc])
+    lj = LimitJoint(a="door", b="base", type="revolute",
+                    axis_point=[0.3, 0.4, 0.1],   # bogus off-axis angle point
+                    axis_dir=[0, 0, 1], lower=-0.5, upper=0.5)
+    g = GraphState(robot_name="t", source_assembly="t.SLDASM",
+                   components=[base, door], edges=[edge], ground=["base"],
+                   limit_joints=[lj])
+    model = build_model(g)
+    j = next(jj for jj in model.joints if jj.child == "door")
+    assert j.jtype == "revolute"
+    # the axis line goes through the concentric point (x=0.05, y=0), NOT (0.3,0.4)
+    np.testing.assert_allclose(j.sw_axis_point[:2], [0.05, 0.0], atol=1e-6)
+
+
 def test_without_limit_joint_the_distance_mate_fixes_it():
     # same geometry, no limit joint -> the lone DISTANCE constraint leaves it
     # NOT a clean prismatic (regression guard that the win comes from the limit)


### PR DESCRIPTION
## Summary

A revolute joint built from a SolidWorks **LimitAngle** mate spun around the
wrong centre. The printer screen (`ekran`) hinge pivoted ~5 cm off, swinging in
an arc instead of rotating in place.

## Cause

A revolute axis is a **line** = point + direction. The direction was right
(vertical), but the *point* was taken from the LimitAngle mate -- which is
defined between two **faces**, so its point lies on a face, **not on the rotation
axis**. The real hinge is the **CONCENTRIC** mate (the pin/bearing) on the same
pair.

Only this case was affected:
- the geometric (concentric-derived) revolute path was always correct;
- prismatic limit joints dont care about the axis *point* (a slide is the same
  along its whole line), so the sliders were fine;
- this is the limit-mate path added recently, and `ekran` is the first
  revolute-from-LimitAngle joint with a noticeable offset.

## Fix

For a revolute limit joint, take the axis line from the concentric mate (point +
direction) when it is parallel to the limit axis, keeping the limits direction
sign so the travel limits and parent->child orientation stay consistent. Applied
at build time, so existing `graph.json` is corrected on rebuild (no re-extract).

## Tests
- new `test_revolute_limit_joint_pivots_on_concentric_axis`; full suite 133 passed, ruff clean.