### PR TITLE
Add per-link colour override in the web editor (viewer + export)

### DIFF
--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -761,6 +761,14 @@ skrobot / native-mesh consumers (not RViz-loadable)">⬇ glb</button></a>
     'li.com': { en: 'CoM 🟣', ja: '重心 🟣' },
     'li.inertia': { en: 'inertia', ja: '慣性' },
     'li.color': { en: 'color', ja: '色' },
+    'li.setColor': { en: 'set color', ja: '色を変更' },
+    'li.colorReset': { en: 'reset', ja: '戻す' },
+    'li.recentColors': { en: 'palette', ja: 'よく使う色' },
+    'li.colorResetTitle': { en: 'back to the mesh’s original colour',
+                            ja: 'メッシュ本来の色に戻す' },
+    'li.colorOk': { en: 'colour updated ✓', ja: '色を更新しました ✓' },
+    'li.colorFail': { en: a => `set color failed: ${a.e}`,
+                      ja: a => `色の変更に失敗: ${a.e}` },
     'li.material': { en: 'material', ja: '材質' },
     'li.mesh': { en: 'mesh', ja: 'メッシュ' },
     'li.override': { en: '(override)', ja: '(上書き)' },
@@ -1260,6 +1268,7 @@ viewer.addEventListener('joint-mouseover', e => {
 let dropMode = false;          // meshes come from dropped blobs, not /pkg/
 let currentInfo = null;        // {name, urdf} of the open server package
 let compMeta = {};             // link -> {material, density, name, override}
+let linkColors = {};           // URDF/viewer link name -> '#rrggbb' override
 let excludedList = [];         // component names excluded from the URDF
 
 // ---- operation log + diagnostic dump: every user action is recorded, and
@@ -1277,6 +1286,8 @@ async function refreshCompMeta() {
     const r = await (await fetch('/api/components')).json();
     if (!r.error) {
       compMeta = r.links ?? {};
+      linkColors = r.colors ?? {};   // keyed by viewer link name (composed too)
+      applyPersistedColors();     // meta may arrive after geometry-loaded
       excludedList = r.excluded ?? [];
       const chip = document.getElementById('exclchip');
       chip.style.display = excludedList.length ? '' : 'none';
@@ -2316,7 +2327,136 @@ function _tintLink(linkName, kind) {   // kind: 'hov' | 'sel' | null
 // hover tint, but never repaint over the selection
 function highlightLink(linkName, on) {
   if (linkName === selectedLink) { return; }
-  _tintLink(linkName, on ? 'hov' : baseTint(linkName));
+  _tintLink(linkName, on ? 'hov' : _colorTint(linkName));
+}
+
+// ---- per-link visual colour override -----------------------------------
+// We repaint the link's OWN (non-marker) mesh materials -- the same materials
+// the tint system saves in `savedMats`, so a tint overlays the override and
+// deselect/dehover falls back to it (not the CAD colour).  The very first
+// override of a material stashes its original colour so 'reset' can restore it.
+// Materials are shared with the mesh cache, so this survives edit-rebuilds; on a
+// fresh page load applyPersistedColors() re-applies from the server.
+const origMatColor = new WeakMap();   // material -> THREE.Color before overrides
+// while the colour picker for a link is open we suppress that link's tint
+// (selection cyan etc.) so the user judges the TRUE colour, not the overlay
+let colorPreviewLink = null;
+// the tint a link should currently wear, honouring colour-preview suppression
+function _colorTint(name) {
+  return name === colorPreviewLink ? null : baseTint(name);
+}
+
+// recently-set colours, newest first, shown as a reusable palette and kept in
+// localStorage so they persist across sessions
+const RECENT_KEY = 'sw2robot.recentColors';
+const RECENT_MAX = 30;
+let recentColors = [];
+try {
+  const r = JSON.parse(localStorage.getItem(RECENT_KEY) || '[]');
+  if (Array.isArray(r)) {
+    recentColors = r.filter(h => /^#[0-9a-f]{6}$/.test(h)).slice(0, RECENT_MAX);
+  }
+} catch { /* corrupt/absent -> empty palette */ }
+function pushRecentColor(hex) {
+  if (!hex) { return; }
+  const h = hex.toLowerCase();
+  if (!/^#[0-9a-f]{6}$/.test(h)) { return; }
+  recentColors = [h, ...recentColors.filter(x => x !== h)].slice(0, RECENT_MAX);
+  try { localStorage.setItem(RECENT_KEY, JSON.stringify(recentColors)); }
+  catch { /* storage full/blocked -> keep in memory only */ }
+}
+
+// start previewing a link's true colour: strip its tint so the colour (picker
+// or freshly-applied swatch) is judged without the selection-cyan overlay.  The
+// preview persists until a DIFFERENT link is selected (selectLink clears it).
+function beginColorPreview(name) {
+  colorPreviewLink = name;
+  _tintLink(name, null);
+  viewer.redraw();
+}
+
+// the link's own mesh materials, reading through an in-progress drag-hover the
+// same way _tintLink does (so we never lose the true original)
+function _linkBaseMaterials(linkName) {
+  const link = viewer.robot?.links?.[linkName];
+  const out = [];
+  if (!link) { return out; }
+  (function walk(node) {
+    for (const c of node.children) {
+      if (c.isURDFJoint) { continue; }
+      if (c.isMesh && !c.userData.sw2robotMarker
+          && c.material !== viewer.highlightMaterial) {
+        const m = savedMats.get(c)
+          ?? (c.__origMaterial !== undefined ? c.__origMaterial : c.material);
+        if (m && m.color) { out.push(m); }
+      }
+      walk(c);
+    }
+  })(link);
+  return out;
+}
+
+function applyLinkColor(linkName, hex) {
+  const col = new THREE.Color(hex);
+  for (const m of _linkBaseMaterials(linkName)) {
+    // remember the true original so reset can restore it
+    if (!origMatColor.has(m)) {
+      origMatColor.set(m, { color: m.color.clone(), vc: m.vertexColors });
+    }
+    m.color.copy(col);
+    // the CAD colours are baked as VERTEX colours (GLB COLOR_0); while those are
+    // active the shader does material.color * vertexColour, so a colour change
+    // is barely visible -- disable them so the override shows as a solid colour
+    if (m.vertexColors) { m.vertexColors = false; m.needsUpdate = true; }
+    tintClones.delete(m);            // stale tints must rebuild from new base
+  }
+  _tintLink(linkName, _colorTint(linkName));   // re-overlay tint unless previewing
+  viewer.redraw();
+}
+
+function resetLinkColor(linkName) {
+  for (const m of _linkBaseMaterials(linkName)) {
+    const orig = origMatColor.get(m);
+    if (orig) {
+      m.color.copy(orig.color);
+      if (m.vertexColors !== orig.vc) { m.vertexColors = orig.vc; m.needsUpdate = true; }
+    }
+    tintClones.delete(m);
+  }
+  _tintLink(linkName, baseTint(linkName));
+  viewer.redraw();
+}
+
+// re-apply every server-persisted override (compMeta.color) to the live robot;
+// safe to call repeatedly (idempotent) once geometry + compMeta are both in
+function applyPersistedColors() {
+  if (!viewer.robot) { return; }
+  for (const [name, hex] of Object.entries(linkColors)) {
+    if (hex && viewer.robot.links[name]) { applyLinkColor(name, hex); }
+  }
+}
+
+// persist a colour (or null to clear) and apply it live; mirrors set_material's
+// flow but needs NO rebuild -- the override is purely a viewer/export concern
+async function setLinkColor(name, hex) {
+  op('setColor', { link: name, color: hex });
+  colorPreviewLink = name;          // keep the true colour visible after applying
+  if (hex) { applyLinkColor(name, hex); } else { resetLinkColor(name); }
+  try {
+    const resp = await fetch('/api/set_color', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ link: name, color: hex }) });
+    const r = await resp.json();
+    if (!resp.ok || r.error) { throw new Error(r.error ?? resp.status); }
+    if (compMeta[name]) { compMeta[name].color = r.color; }
+    if (r.color) { linkColors[name] = r.color; } else { delete linkColors[name]; }
+    if (r.color) { pushRecentColor(r.color); }   // remember for the palette
+    log(t('li.colorOk'), 'ok');
+    if (name === selectedLink) { selectLink(name); }   // refresh reset-btn state
+  } catch (e) {
+    log(t('li.colorFail', { e: e.message ?? e }), 'err');
+  }
 }
 
 // ---- live self-collision: NEW contacts (not present at the rest pose)
@@ -2767,8 +2907,35 @@ function fillLinkInfo(name) {
     }
   }
   const c = mat?.color?.getHexString?.();
-  add(t('li.color'), (c ? `<span class="sw" style="background:#${c}"></span> ` +
-                    `#${c}` : t('common.na')));
+  // editable colour: the picker shows the persisted override if any, else the
+  // mesh's own colour; the 'reset' button (active only when overridden) clears
+  // the override back to the CAD colour
+  const ov = linkColors[name];                         // '#rrggbb' or undefined
+  const cur = (ov || (c ? '#' + c : '#cccccc')).toLowerCase();
+  rowsHtml.push(
+    `<tr><td>${t('li.color')}</td><td>` +
+    `<input type="color" id="li_color" value="${cur}" ` +
+    `style="vertical-align:middle;width:36px;height:20px;padding:0;` +
+    `background:#15171a;border:1px solid #444;border-radius:3px;` +
+    `cursor:pointer">` +
+    ` <button id="li_color_reset" title="${t('li.colorResetTitle')}" ` +
+    `style="font-size:10px;background:#15171a;color:#bbb;border:1px solid #444;` +
+    `border-radius:3px;padding:1px 6px;cursor:pointer"` +
+    `${ov ? '' : ' disabled'}>${t('li.colorReset')}</button>` +
+    (ov ? ` <span style="color:#e8c468">${t('li.override')}</span>` : '') +
+    `</td></tr>`);
+  // reusable palette of recently-set colours: click a swatch to apply it
+  if (recentColors.length) {
+    const sw = recentColors.map(h =>
+      // pointer-events:auto -- #linkinfo is pointer-events:none and only
+      // re-enables select/button/input, so a bare <span> swatch would be unclickable
+      `<span class="palsw" data-c="${h}" title="${h}" style="display:inline-block;` +
+      `width:16px;height:16px;border-radius:3px;margin:1px;cursor:pointer;` +
+      `pointer-events:auto;` +
+      `vertical-align:middle;border:1px solid ${h === cur ? '#e8c468' : '#444'};` +
+      `background:${h}"></span>`).join('');
+    rowsHtml.push(`<tr><td>${t('li.recentColors')}</td><td>${sw}</td></tr>`);
+  }
   // SolidWorks material + density (with web override), editable below
   const meta = compMeta[name];
   const matTxt = meta?.override
@@ -2825,6 +2992,22 @@ function fillLinkInfo(name) {
       log(t('li.densityFail', { e: e.message ?? e }), 'err');
     }
   });
+  const colInp = el.querySelector('#li_color');
+  if (colInp) {
+    // focus strips the selection tint so the picker shows the TRUE colour;
+    // 'input' previews live while dragging; 'change' persists once.  The preview
+    // lingers (no blur restore) until another link is selected, so the applied
+    // colour stays visible instead of being re-masked by the selection cyan.
+    colInp.addEventListener('focus', () => beginColorPreview(name));
+    colInp.addEventListener('input', () => applyLinkColor(name, colInp.value));
+    colInp.addEventListener('change', () => setLinkColor(name, colInp.value));
+  }
+  const colReset = el.querySelector('#li_color_reset');
+  if (colReset) {
+    colReset.addEventListener('click', () => setLinkColor(name, null));
+  }
+  el.querySelectorAll('.palsw').forEach(s =>
+    s.addEventListener('click', () => setLinkColor(name, s.dataset.c)));
   el.style.display = 'block';   // '' would fall back to the stylesheet's
                                 // display:none and never show
 }
@@ -2832,12 +3015,15 @@ function fillLinkInfo(name) {
 function selectLink(linkName) {
   op('select', { link: linkName });
   if (linkName && boxSelected.size) { clearBoxSelection(); }  // single replaces box
+  // moving to a different link ends any colour preview, so the link we leave
+  // gets its normal resting tint back
+  if (linkName !== colorPreviewLink) { colorPreviewLink = null; }
   const prev = selectedLink;
   selectedLink = linkName;
-  if (prev) { _tintLink(prev, baseTint(prev)); }
+  if (prev) { _tintLink(prev, _colorTint(prev)); }
   const bar = document.getElementById('selbar');
   if (linkName) {
-    _tintLink(linkName, baseTint(linkName));   // red survives selection
+    _tintLink(linkName, _colorTint(linkName));   // red survives selection
     statusEl.textContent = t('sel.status', { name: linkName });
     document.getElementById('selname').textContent = linkName;
     document.getElementById('seleye').classList.toggle(
@@ -4351,6 +4537,7 @@ viewer.addEventListener('geometry-loaded', () => {
     hiddenLinks.forEach(n => applyLinkVisibility(n));
     tfNodes = [];                  // old robot's TF nodes died with it
     undimAll();                    // restore shared (cached) materials!
+    applyPersistedColors();        // re-paint server-saved colour overrides
     collisionLinks = new Set();    // fresh meshes wear no stale red
     initCollision();
     if (tfOn()) { setTF(true); }

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -175,7 +175,7 @@ def _read_root_pose(txt):
 
 
 def _export_zip(pkg_dir, robot_name, mesh_fmt="dae", ros_version=1,
-                pkg_name=None, urdf_name=None):
+                pkg_name=None, urdf_name=None, colors=None):
     """ZIP a portable ROS package (package:// URLs), named ``pkg_name`` if given
     else ``<robot_name>_description``; the URDF inside is named ``urdf_name`` if
     given, else the package name.
@@ -206,7 +206,8 @@ def _export_zip(pkg_dir, robot_name, mesh_fmt="dae", ros_version=1,
         for arc, data in build_ros_description(pkg_dir, robot_name,
                                                ros_version=ros_version,
                                                pkg_name=pkg,
-                                               urdf_name=urdf_name, **kwargs):
+                                               urdf_name=urdf_name,
+                                               colors=colors, **kwargs):
             z.writestr(arc, data)
     return pkg, buf.getvalue()
 
@@ -241,6 +242,24 @@ def _link_names_inverse(yml_txt):
     if base and root_name:
         inv[root_name] = base
     return inv
+
+
+def _read_colors(pkg_dir, urdf_rel):
+    """``{component link name -> '#RRGGBB'}`` from the package's joints.yaml
+    ``colors:`` block; empty when there is no package/config/block."""
+    if not pkg_dir or not urdf_rel:
+        return {}
+    name = os.path.splitext(os.path.basename(urdf_rel))[0]
+    yml = os.path.join(pkg_dir, name + ".joints.yaml")
+    if not os.path.exists(yml):
+        return {}
+    import yaml as _yaml
+    try:
+        cfg = _yaml.safe_load(open(yml, encoding="utf-8").read()) or {}
+    except Exception:
+        return {}
+    colors = cfg.get("colors")
+    return colors if isinstance(colors, dict) else {}
 
 
 def _upsert_yaml_map(txt, mapkey, key, value):
@@ -1064,12 +1083,14 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                                 overrides[k] = float(v)
                             except ValueError:
                                 pass
+                colors = _read_colors(cls.pkg_dir, cls.urdf_rel)
                 links = {}
                 for c in gs.components:
                     links[c.link_name] = {
                         "material": c.material, "density": c.density,
                         "name": c.name,
-                        "override": overrides.get(c.link_name)}
+                        "override": overrides.get(c.link_name),
+                        "color": colors.get(c.link_name)}
                 excluded = []
                 if os.path.exists(yml):
                     m = re.search(r"(?m)^exclude:\n((?:- .*\n)*)",
@@ -1077,8 +1098,13 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                     if m:
                         excluded = [ln[2:].strip()
                                     for ln in m.group(1).splitlines()]
+                # raw colour overrides keyed by URDF/viewer link name (composed
+                # sub-links like 'linkB_1__part_1' are NOT in `links`, which is
+                # built per top-level component, so the viewer keys colours off
+                # this map directly instead of compMeta)
                 return self._send_json({"links": links,
-                                        "excluded": excluded})
+                                        "excluded": excluded,
+                                        "colors": colors})
             if path == "/api/fs":
                 # tiny server-side file browser: the OS file dialog cannot
                 # hand a PATH to the page, so the page browses through us
@@ -1258,7 +1284,9 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                     pkg, data = _export_zip(cls.pkg_dir, cls.robot_name, fmt,
                                             ros_version=ros_version,
                                             pkg_name=pkg_name,
-                                            urdf_name=urdf_name)
+                                            urdf_name=urdf_name,
+                                            colors=_read_colors(
+                                                cls.pkg_dir, cls.urdf_rel))
                 except ValueError as e:
                     return self._send_json({"error": str(e)}, 400)
                 fname = (f"{cls.robot_name}_glb.zip" if fmt == "glb"
@@ -1706,6 +1734,52 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                         {"error": f"rebuild failed: {e}"}, 500)
                 print(f"[sw2robot.web] set_material: {link} -> {density}")
                 return self._send_json({"link": link, "density": density})
+            if parsed.path == "/api/set_color":
+                # per-link visual colour override, stored as a `colors:` block in
+                # joints.yaml ({component name -> '#RRGGBB'}).  The viewer paints
+                # it client-side, so NO rebuild is needed here; the exporter bakes
+                # it into the <visual> .dae/.glb at export time.
+                cls = type(self)
+                n = int(self.headers.get("Content-Length", 0))
+                body = json.loads(self.rfile.read(n) or b"{}")
+                link = body.get("link")
+                color = body.get("color")         # None / '' removes the override
+                if not cls.pkg_dir or not link:
+                    return self._send_json({"error": "no package/link"}, 400)
+                norm = None
+                if color:
+                    h = str(color).strip().lstrip("#").lower()
+                    if not re.fullmatch(r"[0-9a-f]{6}", h):
+                        return self._send_json(
+                            {"error": f"invalid color {color!r}: want #RRGGBB"},
+                            400)
+                    norm = "#" + h
+                name = os.path.splitext(os.path.basename(cls.urdf_rel))[0]
+                yml = os.path.join(cls.pkg_dir, name + ".joints.yaml")
+                if not os.path.exists(yml):
+                    return self._send_json(
+                        {"error": "joints.yaml not found"}, 400)
+                with open(yml, encoding="utf-8") as f:
+                    txt = f.read()
+                comp = _link_names_inverse(txt).get(link, link)
+                _snapshot(cls.pkg_dir, yml, f"color of {comp[:30]}")
+                m = re.search(r"(?m)^colors:\n((?:[ \t]+\S+:.*\n)*)", txt)
+                block = m.group(1) if m else ""
+                pat = re.compile(r"(?m)^[ \t]+" + re.escape(comp) + r":.*\n?")
+                block = pat.sub("", block)
+                if norm:
+                    # quote: a bare '#...' is a YAML comment
+                    block += f"  {comp}: '{norm}'\n"
+                if m:
+                    txt = txt[:m.start()] \
+                        + (f"colors:\n{block}" if block else "") \
+                        + txt[m.end():]
+                elif block:
+                    txt = f"colors:\n{block}" + txt
+                with open(yml, "w", encoding="utf-8") as f:
+                    f.write(txt)
+                print(f"[sw2robot.web] set_color: {comp} -> {norm}")
+                return self._send_json({"link": comp, "color": norm})
             if parsed.path == "/api/rename":
                 # rename a link or joint to a user-chosen name.  Stored as a
                 # component->display overlay in joints.yaml (link_names /

--- a/sw2robot/exporter/export.py
+++ b/sw2robot/exporter/export.py
@@ -194,10 +194,13 @@ def build(pkg_dir, config_path=None, base_hint=None, exclude=None,
         # or --ros-pkg-name): package:// URLs + COLLADA .dae meshes
         # (RViz/Gazebo-ready).  ros_version 2 also bundles launch/ + rviz/.
         from .ros_export import write_ros_description_package
+        # per-link colour overrides (joints.yaml `colors:`) repaint <visual>
+        # meshes in the exported package
+        colors = config.get("colors") if isinstance(config, dict) else None
         desc_dir = write_ros_description_package(
             pkg_dir, robot_name, os.path.dirname(os.path.abspath(pkg_dir)),
             ros_version=ros_version, pkg_name=ros_pkg_name,
-            urdf_name=ros_urdf_name)
+            urdf_name=ros_urdf_name, colors=colors)
 
     print(f"\nDONE. Package: {pkg_dir}")
     print(f"  URDF:   {urdf_path}")

--- a/sw2robot/exporter/ros_export.py
+++ b/sw2robot/exporter/ros_export.py
@@ -63,24 +63,62 @@ def _load_mesh_metres(src):
     return mesh
 
 
-def _mesh_to_dae_bytes(src):
-    """COLLADA (.dae) bytes in metres, with colours baked into materials."""
-    meshes = _collada_meshes(_load_mesh_metres(src))
+def _hex_to_rgba(hex_color):
+    """``'#RRGGBB'`` / ``'#RRGGBBAA'`` (the leading ``#`` optional) -> a uint8
+    ``[R, G, B, A]`` numpy array, or ``None`` for a missing/malformed value."""
+    if not hex_color:
+        return None
+    import numpy as np
+
+    h = str(hex_color).strip().lstrip("#")
+    if len(h) == 6:
+        h += "ff"
+    if len(h) != 8:
+        return None
+    try:
+        return np.array([int(h[i:i + 2], 16) for i in (0, 2, 4, 6)],
+                        dtype=np.uint8)
+    except ValueError:
+        return None
+
+
+def _apply_uniform_color(mesh, hex_color):
+    """Repaint every face of ``mesh`` one solid colour (dropping any original
+    texture/material), so a per-link override wins in every output format.  A
+    falsy/invalid ``hex_color`` leaves the mesh untouched."""
+    rgba = _hex_to_rgba(hex_color)
+    if rgba is None:
+        return mesh
+    import numpy as np
+    import trimesh
+
+    mesh.visual = trimesh.visual.ColorVisuals(
+        mesh=mesh, face_colors=np.tile(rgba, (len(mesh.faces), 1)))
+    return mesh
+
+
+def _mesh_to_dae_bytes(src, color=None):
+    """COLLADA (.dae) bytes in metres, with colours baked into materials.
+    ``color`` (``'#RRGGBB'``) overrides the mesh's own colours when given."""
+    meshes = _collada_meshes(_apply_uniform_color(_load_mesh_metres(src), color))
     if len(meshes) == 1:
         return meshes[0].export(file_type="dae")
     from trimesh.exchange.dae import export_collada
     return export_collada(meshes)
 
 
-def _mesh_to_stl_bytes(src):
-    """STL bytes in metres (colour is dropped -- collision geometry needs none)."""
+def _mesh_to_stl_bytes(src, color=None):
+    """STL bytes in metres (colour is dropped -- collision geometry needs none,
+    so ``color`` is accepted for a uniform converter signature but ignored)."""
     return _load_mesh_metres(src).export(file_type="stl")
 
 
-def _mesh_to_glb_bytes(src):
+def _mesh_to_glb_bytes(src, color=None):
     """GLB bytes in metres, keeping the original material/texture (for
-    three.js / skrobot consumers, not RViz)."""
-    return _load_mesh_metres(src).export(file_type="glb")
+    three.js / skrobot consumers, not RViz).  ``color`` (``'#RRGGBB'``)
+    overrides the mesh's own colours when given."""
+    return _apply_uniform_color(_load_mesh_metres(src), color).export(
+        file_type="glb")
 
 
 _CONVERT = {"dae": _mesh_to_dae_bytes, "stl": _mesh_to_stl_bytes,
@@ -194,7 +232,7 @@ def ros_urdf_stem(pkg, urdf_name=None):
 
 def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
                           ctx_fmt=_CTX_FMT, ros_version=1, pkg_name=None,
-                          urdf_name=None):
+                          urdf_name=None, colors=None):
     """``pkg_dir`` (a built package) -> ``[(arcname, bytes), ...]`` for a portable
     ROS package, all behind ``package://`` URLs.  The package is named
     ``pkg_name`` if given (validated, see :func:`ros_pkg_name`), else
@@ -204,6 +242,11 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
     ``ctx_fmt`` maps each URDF context to a mesh format; the default emits
     ``<visual>`` as colour ``.dae`` and ``<collision>`` as plain ``.stl`` (the
     usual ROS split).  Pass :data:`GLB_CTX_FMT` for a uniform ``.glb`` package.
+
+    ``colors`` is an optional ``{component link name -> '#RRGGBB'}`` map (the
+    mesh basename equals the component link name) that repaints that link's
+    ``<visual>`` mesh a solid colour, overriding its CAD colours; collision STL
+    is colourless and unaffected.
 
     ``ros_version`` picks the build system: ``1`` (default) writes a catkin
     ``package.xml`` (format 2) + ``CMakeLists.txt``; ``2`` writes an ament_cmake
@@ -220,6 +263,7 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
     urdf_stem = ros_urdf_stem(pkg, urdf_name)
     urdf_path = os.path.join(pkg_dir, "urdf", robot_name + ".urdf")
     root = ET.parse(urdf_path).getroot()
+    colors = colors or {}
 
     files = []
     done = {}          # (base, fmt) -> arcname  (instances + visual/collision share)
@@ -229,7 +273,7 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
         if (base, fmt) in done:
             return
         try:
-            data = _CONVERT[fmt](src)
+            data = _CONVERT[fmt](src, color=colors.get(base))
         except Exception as e:
             errors.append(f"{base}: {fmt} convert failed ({e!r})")
             return
@@ -285,16 +329,16 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
 
 def write_ros_description_package(pkg_dir, robot_name, dest_dir,
                                   email="auto@example.com", ros_version=1,
-                                  pkg_name=None, urdf_name=None):
+                                  pkg_name=None, urdf_name=None, colors=None):
     """Write the ROS package under ``dest_dir`` and return its directory path.
     The package is named ``pkg_name`` if given, else ``<robot_name>_description``;
     the URDF inside is named ``urdf_name`` if given, else the package name.
-    ``ros_version`` (1 = catkin, 2 = ament_cmake) is passed through to
-    :func:`build_ros_description`."""
+    ``ros_version`` (1 = catkin, 2 = ament_cmake) and ``colors`` (per-link
+    colour overrides) are passed through to :func:`build_ros_description`."""
     pkg = ros_pkg_name(robot_name, pkg_name)
     files = build_ros_description(pkg_dir, robot_name, email=email,
                                   ros_version=ros_version, pkg_name=pkg,
-                                  urdf_name=urdf_name)
+                                  urdf_name=urdf_name, colors=colors)
     root = os.path.abspath(dest_dir)
     for arc, data in files:
         dst = os.path.join(root, *arc.split("/"))

--- a/tests/test_ros_export.py
+++ b/tests/test_ros_export.py
@@ -174,6 +174,50 @@ def test_glb_ctx_exports_uniform_glb(tmp_path):
     assert len(m.faces) > 0
 
 
+def test_colour_override_repaints_visual_mesh(tmp_path):
+    """A per-link colour override repaints the <visual> mesh one solid colour
+    (keyed by the mesh basename), overriding the CAD colours, in both the direct
+    GLB converter and the full .dae export."""
+    if not os.path.exists(_SAMPLE_MESH):
+        pytest.skip("sample .3dxml mesh not present")
+    import numpy as np
+    import trimesh
+
+    from sw2robot.exporter.ros_export import (
+        _hex_to_rgba,
+        _mesh_to_glb_bytes,
+        build_ros_description,
+    )
+
+    assert (_hex_to_rgba("#1188ff") == np.array([0x11, 0x88, 0xFF, 255])).all()
+    assert _hex_to_rgba("#abc") is None and _hex_to_rgba(None) is None
+
+    # direct GLB converter: every vertex/face wears the solid override colour
+    glb = _mesh_to_glb_bytes(_SAMPLE_MESH, color="#1188ff")
+    m = trimesh.load(io.BytesIO(glb), file_type="glb")
+    m = m.dump(concatenate=True) if isinstance(m, trimesh.Scene) else m
+    vis = m.visual.to_color() if m.visual.kind == "texture" else m.visual
+    cols = np.asarray(vis.vertex_colors)
+    assert len(cols) and (cols[:, :3] == [0x11, 0x88, 0xFF]).all()
+
+    # full export threads `colors` (keyed by the mesh basename 'part') into .dae
+    pkg_dir = _make_pkg(tmp_path, robot="fing")
+    files = dict(build_ros_description(pkg_dir, "fing",
+                                       colors={"part": "#1188ff"}))
+    dae_txt = files["fing_description/meshes/part.dae"].decode()
+    triples = {tuple(round(float(x), 2) for x in c.split()[:3])
+               for c in re.findall(r"<color[^>]*>([^<]+)</color>", dae_txt)}
+    assert (0.07, 0.53, 1.0) in triples           # #1188ff in 0..1 floats
+
+    # with no override the export keeps the mesh's own (non-override) colours
+    plain = dict(build_ros_description(pkg_dir, "fing"))
+    plain_txt = plain["fing_description/meshes/part.dae"].decode()
+    plain_triples = {tuple(round(float(x), 2) for x in c.split()[:3])
+                     for c in re.findall(r"<color[^>]*>([^<]+)</color>",
+                                         plain_txt)}
+    assert (0.07, 0.53, 1.0) not in plain_triples
+
+
 def test_working_package_is_not_modified(tmp_path):
     """The converter only READS the package -- the source urdf/mesh are untouched
     (the working URDF must stay mesh-relative for the viewer / auto-limits)."""


### PR DESCRIPTION
## What

Add a per-link colour override to the web editor: select a link and pick a
colour from the info panel to repaint that part, with a "recent colours"
palette for quick reuse. Overrides are stored in `joints.yaml` (`colors:`)
and baked into the exported `<visual>` `.dae`/`.glb` meshes; collision `.stl`
stays colourless.

## Why

CAD colours were view-only. This makes them editable from the viewer and
carries the choice through to the exported ROS/GLB packages.

## Changes

- **exporter** (`ros_export.py`, `export.py`): `#RRGGBB` -> rgba helper and a
  uniform colour application, threaded through `build_ros_description` /
  `_emit` / `write_ros_description_package`; `build()` reads `config["colors"]`
  for CLI parity.
- **webserver**: `POST /api/set_color` persists the `colors:` block (no rebuild
  needed); `/api/components` returns the raw colour map keyed by viewer link
  name so composed sub-links resolve; export zip threads colours through.
- **viewer** (`index.html`): colour picker + palette UI; client-side apply that
  disables baked vertex colours (GLB `COLOR_0`) so the override shows as a solid
  colour; selection-tint suppression while editing; persisted colours
  re-applied on reload.

## Tests

- New `test_colour_override_repaints_visual_mesh` in `tests/test_ros_export.py`.
- Full suite: 134 passed, 7 skipped; `ruff` clean.
