### PR TITLE
Add app icon to the .exe (v0.1.20)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sw2robot"
-version = "0.1.19"
+version = "0.1.20"
 description = "SolidWorks assembly -> URDF exporter with a browser-based editor"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Embed the project logo into the PyInstaller-built Windows .exe.

- `assets/icon.ico`: the logo with the white page + gray drop-shadow made
  transparent (edge flood-fill that preserves interior white), cropped tight and
  saved as a multi-resolution icon.
- `build_exe.py`: embeds `assets/icon.ico` by default (with a `--icon` override),
  so every freeze -- including the release workflow -- is branded with no extra
  flags.
- Bump version to 0.1.20.

After merge, the release is cut by pushing the `v0.1.20` tag manually (the
automated bump/tag cascade is currently down because the `AUTO_MERGE_PAT` secret
is missing; a tag pushed from a developer machine still triggers `release.yml`).