### PR TITLE
Bump version to 0.1.20

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sw2robot"
-version = "0.1.19"
+version = "0.1.20"
 description = "SolidWorks assembly -> URDF exporter with a browser-based editor"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Bump the version from 0.1.19 to 0.1.20 to cut a new release.

The release includes the app-icon change already merged in #61 (the
PyInstaller `.exe` is now branded via `assets/icon.ico`).

Cutting the release manually: merge this PR, then push the `v0.1.20` tag from a
developer machine -- the automated bump/tag cascade is currently down because
the `AUTO_MERGE_PAT` secret is missing, but a tag pushed by a user (not
GITHUB_TOKEN) still triggers `release.yml` to build and publish the `.exe`.