### PR TITLE
Add URDF-input editing mode (open & edit any URDF, re-export)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,62 @@ jobs:
         if: failure()
         run: cat server.log
 
+  e2e-urdf:
+    name: web e2e -- URDF-input mode (puppeteer)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Chrome
+        id: chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: stable
+
+      - name: Install sw2robot
+        # no [ui]/mesh deps: the fixture is a box-geometry URDF (no meshes), so
+        # the viewer renders it without the glb converter
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+
+      - name: Start the web editor on the box URDF fixture (URDF-input mode)
+        run: |
+          nohup python -m sw2robot.editor.webserver tests/e2e/fixtures/boxbot \
+            --port 8099 > server.log 2>&1 &
+          for i in $(seq 1 60); do
+            if curl -fsS http://localhost:8099/api/info >/dev/null 2>&1; then
+              echo "server up"; exit 0
+            fi
+            sleep 1
+          done
+          echo "server did not come up"; cat server.log; exit 1
+
+      - name: Install e2e dependencies
+        working-directory: tests/e2e
+        run: npm install
+
+      - name: Run the inertial-editing e2e
+        working-directory: tests/e2e
+        env:
+          CHROME_PATH: ${{ steps.chrome.outputs.chrome-path }}
+          CHROME_ARGS: '--no-sandbox,--disable-setuid-sandbox,--enable-unsafe-swiftshader,--use-gl=angle,--use-angle=swiftshader'
+        run: node verify_inertial.mjs http://localhost:8099
+
+      - name: Server log (on failure)
+        if: failure()
+        run: cat server.log
+
   # ----- the exported ROS packages must BUILD as real catkin / colcon packages,
   # not just have the right files.  sw2robot needs Python >=3.12 but the ROS
   # images ship 3.8 (Noetic) / 3.10 (Humble), so we split: generate the

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@ examples/*/CMakeLists.txt
 # test / tooling
 tests/e2e/node_modules/
 tests/e2e/package-lock.json
+# runtime artifacts the editor writes into a served URDF package (keep the
+# e2e fixtures pristine -- the overlay sidecar + live copy are regenerated)
+tests/e2e/fixtures/**/*.sw2robot.json
+tests/e2e/fixtures/**/.*.live.urdf
 _server*.txt
 _client_report.json
 _sldasm_index.json

--- a/sw2robot/editor/core.py
+++ b/sw2robot/editor/core.py
@@ -450,10 +450,13 @@ def reverse_direction(state: RobotCompilerState, joint: str) -> None:
     _require_joint(state, joint)
     e = state.edit_for(joint)
     parsed = next((j for j in state.joints if j["name"] == joint), {})
-    lo = e.lower if e.lower is not None else parsed.get("lowerLimit", 0.0)
-    hi = e.upper if e.upper is not None else parsed.get("upperLimit", 0.0)
     e.flip_axis = not e.flip_axis
-    e.lower, e.upper = -hi, -lo
+    # only revolute/prismatic joints carry a travel range -- don't fabricate a
+    # degenerate [0, 0] limit on a continuous/fixed joint that has none
+    if state.effective_type(parsed) in ("revolute", "prismatic"):
+        lo = e.lower if e.lower is not None else parsed.get("lowerLimit", 0.0)
+        hi = e.upper if e.upper is not None else parsed.get("upperLimit", 0.0)
+        e.lower, e.upper = -hi, -lo
 
 
 # --------------------------------------------------------------- link edits

--- a/sw2robot/editor/core.py
+++ b/sw2robot/editor/core.py
@@ -670,13 +670,16 @@ def _sanitize_urdf_names(root) -> None:
             mim.set("joint", jmap[mim.get("joint")])
 
 
-def build_urdf(state: RobotCompilerState) -> str:
+def build_urdf(state: RobotCompilerState, sanitize: bool = True) -> str:
     """The CAD URDF with the interactive overlay baked in -- per-joint (rename,
     limits, mimic, axis flip, joint type) AND per-link (colour, inertial) -- so
     the exported package and configs stay consistent.
 
-    Link/joint names are passed through :func:`_sanitize_urdf_names` last, so the
-    final URDF is guaranteed free of hyphens and other unsafe characters."""
+    With ``sanitize`` (default), link/joint names are passed through
+    :func:`_sanitize_urdf_names` last, so a CAD-derived URDF is guaranteed free
+    of hyphens and other unsafe characters.  Pass ``sanitize=False`` when editing
+    a URDF the user opened directly: its names are already its own contract (the
+    viewer shows them, edits reference them), so they must be preserved verbatim."""
     root = ET.fromstring(Path(state.urdf_path).read_text(encoding="utf-8"))
     renames = {j: e.rename for j, e in state.edits.items() if e.rename}
 
@@ -723,6 +726,20 @@ def build_urdf(state: RobotCompilerState) -> str:
             mim.set("joint", e.mimic_joint)
             mim.set("multiplier", f"{e.mimic_multiplier:g}")
             mim.set("offset", f"{e.mimic_offset:g}")
+        # a joint made movable (e.g. fixed -> revolute) must satisfy URDF's
+        # requirements: an <axis> and, for revolute/prismatic, a <limit>.  Add
+        # placeholders when the type edit didn't supply them, so the type change
+        # alone never yields an invalid URDF (the user refines limits afterwards).
+        ftype = je.get("type")
+        if ftype in ("revolute", "prismatic", "continuous") \
+                and je.find("axis") is None:
+            ET.SubElement(je, "axis").set("xyz", "0 0 1")
+        if ftype in ("revolute", "prismatic") and je.find("limit") is None:
+            lim = ET.SubElement(je, "limit")
+            lim.set("lower", "-3.14159" if ftype == "revolute" else "0")
+            lim.set("upper", "3.14159" if ftype == "revolute" else "0.1")
+            lim.set("effort", "10")
+            lim.set("velocity", "3.14")
 
     # repoint any mimic that referenced a now-renamed joint
     for je in root.findall("joint"):
@@ -742,7 +759,8 @@ def build_urdf(state: RobotCompilerState) -> str:
             _apply_inertial(le, led.mass, led.com, led.inertia)
 
     # final guarantee: no hyphens/spaces/etc. in any emitted link or joint name
-    _sanitize_urdf_names(root)
+    if sanitize:
+        _sanitize_urdf_names(root)
     return ET.tostring(root, encoding="unicode")
 
 

--- a/sw2robot/editor/core.py
+++ b/sw2robot/editor/core.py
@@ -19,6 +19,7 @@ issues (lower>=upper, duplicate servo ids) are surfaced by ``validate()``.
 
 from __future__ import annotations
 
+import math
 import re
 import shutil
 import xml.etree.ElementTree as ET
@@ -44,6 +45,8 @@ __all__ = [
     "save_state",
     "set_actuator",
     "set_axis_flip",
+    "set_color",
+    "set_inertial",
     "set_joint_type",
     "set_limits",
     "set_mimic",
@@ -120,9 +123,9 @@ def load_state(path) -> RobotCompilerState:
 
 def load_edits(state: RobotCompilerState, path=None) -> int:
     """Merge a saved edit overlay into ``state`` IN PLACE, keeping ``state``'s
-    freshly-built joints/URDF.  Only edits whose joint still exists are applied
-    (so a rebuilt module with changed names is handled gracefully).  Returns the
-    number of edits applied; 0 if no sidecar exists."""
+    freshly-built joints/URDF.  Only edits whose joint/link still exists are
+    applied (so a rebuilt module with changed names is handled gracefully).
+    Returns the number of edits applied; 0 if no sidecar exists."""
     p = state_path(state, path)
     if not p.is_file():
         return 0
@@ -132,6 +135,11 @@ def load_edits(state: RobotCompilerState, path=None) -> int:
     for jn, edit in saved.edits.items():
         if jn in valid:
             state.edits[jn] = edit
+            n += 1
+    valid_links = {l["name"] for l in state.links}
+    for ln, ledit in saved.link_edits.items():
+        if ln in valid_links:
+            state.link_edits[ln] = ledit
             n += 1
     return n
 
@@ -333,6 +341,11 @@ def _require_joint(state, joint):
         raise ValueError(f"no such joint: {joint}")
 
 
+def _require_link(state, link):
+    if link not in {l["name"] for l in state.links}:
+        raise ValueError(f"no such link: {link}")
+
+
 def rename_joint(state: RobotCompilerState, joint: str, new_name: str) -> None:
     _require_joint(state, joint)
     new_name = (new_name or "").strip()
@@ -443,6 +456,67 @@ def reverse_direction(state: RobotCompilerState, joint: str) -> None:
     e.lower, e.upper = -hi, -lo
 
 
+# --------------------------------------------------------------- link edits
+_HEX6 = re.compile(r"[0-9a-f]{6}")
+
+
+def set_color(state: RobotCompilerState, link: str, color: str | None) -> None:
+    """Set a link's visual colour as ``#RRGGBB`` (baked into the URDF
+    ``<visual><material>`` by :func:`build_urdf`).  ``color=None`` / ``''``
+    clears the override (keeping whatever the base URDF carries)."""
+    _require_link(state, link)
+    if not color:
+        if link in state.link_edits:     # clear without creating a stray entry
+            state.link_edits[link].color = None
+        return
+    h = str(color).strip().lstrip("#").lower()
+    if not _HEX6.fullmatch(h):
+        raise ValueError(f"invalid color {color!r}: want #RRGGBB")
+    state.link_edit_for(link).color = "#" + h
+
+
+def set_inertial(state: RobotCompilerState, link: str,
+                 mass: float | None = None,
+                 com: list | None = None,
+                 inertia: list | None = None) -> None:
+    """Override a link's inertial properties (any subset).  ``mass`` kg (> 0),
+    ``com`` the inertial-origin ``[x, y, z]``, ``inertia`` the tensor
+    ``[ixx, ixy, ixz, iyy, iyz, izz]``.  Unset fields keep the base URDF value;
+    pass a value to change just that one."""
+    _require_link(state, link)
+    # validate EVERYTHING before touching state, so a rejected request leaves no
+    # partial override behind (matches the fail-fast contract of the setters)
+    if mass is not None:
+        mass = float(mass)
+        if not math.isfinite(mass) or mass <= 0:
+            raise ValueError(f"mass must be a finite number > 0 (got {mass})")
+    if com is not None:
+        com = [float(x) for x in com]
+        if len(com) != 3:
+            raise ValueError("com must be [x, y, z]")
+        if not all(math.isfinite(x) for x in com):
+            raise ValueError(f"com must be finite (got {com})")
+    if inertia is not None:
+        inertia = [float(x) for x in inertia]
+        if len(inertia) != 6:
+            raise ValueError("inertia must be [ixx, ixy, ixz, iyy, iyz, izz]")
+        # physics sanity (positive-definite + triangle inequality): the same
+        # check the exporter applies to generated inertials, so a hand-entered
+        # tensor can't export a simulator-breaking link.  The tensor checks are
+        # mass-independent, so use a positive placeholder when mass is unset here.
+        from sw2robot.exporter.inertia import validate_inertia
+        probs = validate_inertia(mass if mass is not None else 1.0, inertia)
+        if probs:
+            raise ValueError("invalid inertia: " + "; ".join(probs))
+    e = state.link_edit_for(link)
+    if mass is not None:
+        e.mass = mass
+    if com is not None:
+        e.com = com
+    if inertia is not None:
+        e.inertia = inertia
+
+
 # --------------------------------------------------------------- validation
 def validate(state: RobotCompilerState) -> list:
     """Return a list of human-readable problems with the current state.  Empty
@@ -479,6 +553,71 @@ def validate(state: RobotCompilerState) -> list:
 # --------------------------------------------------------------- #4 export
 def _set_xyz(elem, vec):
     elem.set("xyz", " ".join(f"{v:.8g}" for v in vec))
+
+
+def _hex_to_rgba(hex_color: str) -> str:
+    """``#RRGGBB`` -> a URDF ``rgba`` string with opaque alpha."""
+    h = hex_color.lstrip("#")
+    r, g, b = (int(h[i:i + 2], 16) / 255.0 for i in (0, 2, 4))
+    return f"{r:.6g} {g:.6g} {b:.6g} 1"
+
+
+def _apply_color(link_elem, hex_color: str) -> None:
+    """Set ``<material><color rgba>`` on every ``<visual>`` of the link (creating
+    the material/color when absent) -- URDF's per-visual colour model.  A no-op
+    when the link has no ``<visual>`` (nothing to paint)."""
+    rgba = _hex_to_rgba(hex_color)
+    mat_name = "color_" + hex_color.lstrip("#")
+    for vis in link_elem.findall("visual"):
+        mat = vis.find("material")
+        if mat is None:
+            mat = ET.SubElement(vis, "material")
+        mat.set("name", mat_name)
+        col = mat.find("color")
+        if col is None:
+            col = ET.SubElement(mat, "color")
+        col.set("rgba", rgba)
+
+
+def _apply_inertial(link_elem, mass, com, inertia) -> None:
+    """Override the subset of ``<inertial>`` (mass / origin xyz / inertia tensor)
+    that is not None, creating the ``<inertial>`` and its children as needed.
+
+    A partial edit on a link that has NO ``<inertial>`` would otherwise emit an
+    invalid block (URDF requires both ``<mass>`` and ``<inertia>``), so when the
+    block is freshly created any field this edit did not supply is backfilled
+    with the same neutral placeholder the exporter uses (mass 0.1 kg, diagonal
+    inertia 1e-4)."""
+    ine = link_elem.find("inertial")
+    created = ine is None
+    if created:
+        ine = ET.SubElement(link_elem, "inertial")
+    if com is not None:
+        org = ine.find("origin")
+        if org is None:
+            org = ET.SubElement(ine, "origin")
+            org.set("rpy", "0 0 0")
+        _set_xyz(org, com)
+    if mass is not None:
+        m = ine.find("mass")
+        if m is None:
+            m = ET.SubElement(ine, "mass")
+        m.set("value", f"{mass:.8g}")
+    if inertia is not None:
+        tensor = ine.find("inertia")
+        if tensor is None:
+            tensor = ET.SubElement(ine, "inertia")
+        for k, v in zip(("ixx", "ixy", "ixz", "iyy", "iyz", "izz"), inertia):
+            tensor.set(k, f"{v:.8g}")
+    if created:                       # guarantee a complete, valid <inertial>
+        if ine.find("mass") is None:
+            ET.SubElement(ine, "mass").set("value", "0.1")
+        if ine.find("inertia") is None:
+            tensor = ET.SubElement(ine, "inertia")
+            for k in ("ixx", "iyy", "izz"):
+                tensor.set(k, "0.0001")
+            for k in ("ixy", "ixz", "iyz"):
+                tensor.set(k, "0")
 
 
 def _safe_name(name: str) -> str:
@@ -532,8 +671,9 @@ def _sanitize_urdf_names(root) -> None:
 
 
 def build_urdf(state: RobotCompilerState) -> str:
-    """The CAD URDF with the interactive overlay baked in (rename, limits, mimic,
-    axis flip, joint type), so the exported package and configs stay consistent.
+    """The CAD URDF with the interactive overlay baked in -- per-joint (rename,
+    limits, mimic, axis flip, joint type) AND per-link (colour, inertial) -- so
+    the exported package and configs stay consistent.
 
     Link/joint names are passed through :func:`_sanitize_urdf_names` last, so the
     final URDF is guaranteed free of hyphens and other unsafe characters."""
@@ -589,6 +729,17 @@ def build_urdf(state: RobotCompilerState) -> str:
         mim = je.find("mimic")
         if mim is not None and mim.get("joint") in renames:
             mim.set("joint", renames[mim.get("joint")])
+
+    # per-link overlay: visual colour + inertial (keyed by the base-URDF name,
+    # applied before the name sanitize so references stay consistent)
+    for le in root.findall("link"):
+        led = state.link_edits.get(le.get("name"))
+        if led is None:
+            continue
+        if led.color:
+            _apply_color(le, led.color)
+        if led.mass is not None or led.com is not None or led.inertia is not None:
+            _apply_inertial(le, led.mass, led.com, led.inertia)
 
     # final guarantee: no hyphens/spaces/etc. in any emitted link or joint name
     _sanitize_urdf_names(root)

--- a/sw2robot/editor/core.py
+++ b/sw2robot/editor/core.py
@@ -694,6 +694,11 @@ def build_urdf(state: RobotCompilerState, sanitize: bool = True) -> str:
                     el = je.find(tag)
                     if el is not None:
                         je.remove(el)
+        # backfill the <axis> BEFORE the flip, so flipping a joint that this same
+        # edit just made movable (it had no axis) still takes effect
+        if je.get("type") in ("revolute", "prismatic", "continuous") \
+                and je.find("axis") is None:
+            ET.SubElement(je, "axis").set("xyz", "0 0 1")
         if e.flip_axis:
             ax = je.find("axis")
             if ax is not None:
@@ -727,13 +732,10 @@ def build_urdf(state: RobotCompilerState, sanitize: bool = True) -> str:
             mim.set("multiplier", f"{e.mimic_multiplier:g}")
             mim.set("offset", f"{e.mimic_offset:g}")
         # a joint made movable (e.g. fixed -> revolute) must satisfy URDF's
-        # requirements: an <axis> and, for revolute/prismatic, a <limit>.  Add
-        # placeholders when the type edit didn't supply them, so the type change
-        # alone never yields an invalid URDF (the user refines limits afterwards).
+        # requirement of a <limit> for revolute/prismatic; add a placeholder when
+        # the type edit didn't supply one (the <axis> was backfilled above), so
+        # the type change alone never yields an invalid URDF.
         ftype = je.get("type")
-        if ftype in ("revolute", "prismatic", "continuous") \
-                and je.find("axis") is None:
-            ET.SubElement(je, "axis").set("xyz", "0 0 1")
         if ftype in ("revolute", "prismatic") and je.find("limit") is None:
             lim = ET.SubElement(je, "limit")
             lim.set("lower", "-3.14159" if ftype == "revolute" else "0")

--- a/sw2robot/editor/state.py
+++ b/sw2robot/editor/state.py
@@ -80,6 +80,13 @@ class RobotCompilerState(BaseModel):
         e = self.edits.get(joint_name)
         return e.rename if (e and e.rename) else joint_name
 
+    def effective_type(self, joint: dict) -> str | None:
+        """The joint's type with the overlay's ``jtype`` override applied -- so a
+        joint made movable (or fixed) via :func:`core.set_joint_type` is treated
+        consistently by mimic validation and ``movable_joints``."""
+        e = self.edits.get(joint["name"])
+        return e.jtype if (e and e.jtype) else joint.get("type")
+
     def movable_joints(self) -> list[dict]:
         return [j for j in self.joints
-                if j.get("type") in ("revolute", "continuous", "prismatic")]
+                if self.effective_type(j) in ("revolute", "continuous", "prismatic")]

--- a/sw2robot/editor/state.py
+++ b/sw2robot/editor/state.py
@@ -38,6 +38,19 @@ class JointEdit(BaseModel):
     jtype: str | None = None   # override joint type (revolute/continuous/...)
 
 
+class LinkEdit(BaseModel):
+    """Interactive overlay edits for ONE link -- the per-link properties the
+    joint overlay can't carry: visual colour and the inertial mass / centre of
+    mass / inertia tensor.  All fields optional; only the set ones are applied on
+    top of the base URDF.  Keyed by the link's name in the base URDF."""
+
+    color: str | None = None       # "#RRGGBB" (None = keep the URDF default)
+    mass: float | None = None      # kg (None = keep)
+    com: list[float] | None = None     # inertial origin xyz [x, y, z] (None = keep)
+    # inertia tensor [ixx, ixy, ixz, iyy, iyz, izz] (None = keep)
+    inertia: list[float] | None = None
+
+
 class RobotCompilerState(BaseModel):
     """Everything needed to configure + export one CAD module, GUI-free.
 
@@ -52,10 +65,16 @@ class RobotCompilerState(BaseModel):
     links: list[dict] = Field(default_factory=list)
     root_link: str | None = None
     edits: dict[str, JointEdit] = Field(default_factory=dict)
+    # per-link overlay (colour / inertial), keyed by the link's ORIGINAL name
+    link_edits: dict[str, LinkEdit] = Field(default_factory=dict)
 
     def edit_for(self, joint_name: str) -> JointEdit:
         """Get (creating if needed) the overlay for ``joint_name``."""
         return self.edits.setdefault(joint_name, JointEdit())
+
+    def link_edit_for(self, link_name: str) -> LinkEdit:
+        """Get (creating if needed) the per-link overlay for ``link_name``."""
+        return self.link_edits.setdefault(link_name, LinkEdit())
 
     def effective_name(self, joint_name: str) -> str:
         e = self.edits.get(joint_name)

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -65,12 +65,12 @@
   #linkinfo { border: 1px solid #456; border-radius: 4px; padding: 6px 8px;
               background: #1c2228cc; font-size: 11.5px; display: none;
               position: absolute; top: 76px; left: 8px; z-index: 5;
-              width: 280px; max-height: 45%; overflow-y: auto;
-              /* let orbit/drag pass THROUGH the card; only its controls
-                 are interactive (a big opaque card was a dead zone) */
-              pointer-events: none; }
-  #linkinfo select, #linkinfo button, #linkinfo input,
-  #linkinfo .jp-rename { pointer-events: auto; }
+              width: 280px; max-height: calc(100vh - 92px); overflow-y: auto;
+              /* interactive so the card scrolls (a tall per-link panel -- joint
+                 editor + colour + inertial -- can exceed the viewport) and all
+                 its controls are clickable; orbit/drag still work everywhere
+                 outside this small top-left card */
+              pointer-events: auto; }
   #linkinfo h2 { font-size: 12px; margin: 0 0 4px; color: #7fd0ff; }
   #linkinfo table { border-collapse: collapse; width: 100%; }
   #linkinfo td { padding: 1px 4px 1px 0; vertical-align: top; }

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -762,6 +762,17 @@ skrobot / native-mesh consumers (not RViz-loadable)">⬇ glb</button></a>
     'li.mass': { en: 'mass', ja: '質量' },
     'li.com': { en: 'CoM 🟣', ja: '重心 🟣' },
     'li.inertia': { en: 'inertia', ja: '慣性' },
+    'li.editMass': { en: 'mass (kg)', ja: '質量 (kg)' },
+    'li.editCom': { en: 'CoM (m) 🟣', ja: '重心 (m) 🟣' },
+    'li.editInertia': { en: 'inertia (kg·m²)', ja: '慣性 (kg·m²)' },
+    'li.inertialApply': { en: 'apply inertial', ja: '慣性を適用' },
+    'li.settingInertial': { en: a => `setting inertial of ${a.name} …`,
+      ja: a => `${a.name} の慣性を設定中 …` },
+    'li.inertialOk': { en: 'inertial updated ✓', ja: '慣性を更新しました ✓' },
+    'li.inertialBadNum': { en: 'inertial: every field must be a number',
+      ja: '慣性: すべての欄に数値を入力してください' },
+    'li.inertialFail': { en: a => `set inertial failed: ${a.e}`,
+      ja: a => `慣性の設定に失敗: ${a.e}` },
     'li.color': { en: 'color', ja: '色' },
     'li.setColor': { en: 'set color', ja: '色を変更' },
     'li.colorReset': { en: 'reset', ja: '戻す' },
@@ -3052,7 +3063,10 @@ function fillLinkInfo(name) {
   if (size) {
     add(t('li.bbox'), `${mm(size.x)} × ${mm(size.y)} × ${mm(size.z)} mm`);
   }
-  if (inert) {
+  // CAD packages show inertia read-only (it is derived from mesh + density);
+  // a directly-opened URDF lets the user edit it (URDF-input mode).
+  const urdfMode = currentInfo?.mode === 'urdf';
+  if (inert && !urdfMode) {
     add(t('li.mass'), inert.mass >= 0.1
       ? `${inert.mass.toFixed(3)} kg` : `${(inert.mass * 1000).toFixed(1)} g`);
     add(t('li.com'), `(${inert.com.map(mm).join(', ')}) mm`);
@@ -3061,6 +3075,28 @@ function fillLinkInfo(name) {
       add(t('li.inertia'), `ixx=${ii.ixx.toExponential(2)} ` +
           `iyy=${ii.iyy.toExponential(2)} izz=${ii.izz.toExponential(2)}`);
     }
+  }
+  if (urdfMode) {
+    // editable inertial -- mass (kg), CoM origin (m), inertia tensor (kg·m²),
+    // matching the URDF's own SI units; applied together via the button below
+    const im = inert || { mass: 0.1, com: [0, 0, 0], inertia: null };
+    const ii = im.inertia
+      || { ixx: 1e-4, ixy: 0, ixz: 0, iyy: 1e-4, iyz: 0, izz: 1e-4 };
+    const niSt = 'width:62px;background:#15171a;color:#ddd;border:1px solid #444;'
+      + 'border-radius:3px;font-size:11px';
+    const ni = (id, v) =>
+      `<input type="number" step="any" id="${id}" value="${v}" style="${niSt}">`;
+    add(t('li.editMass'), `${ni('li_mass', im.mass)} kg`);
+    add(t('li.editCom'),
+      `${ni('li_cx', im.com[0])}${ni('li_cy', im.com[1])}${ni('li_cz', im.com[2])} m`);
+    add(t('li.editInertia'),
+      `ixx${ni('li_ixx', ii.ixx)} iyy${ni('li_iyy', ii.iyy)} izz${ni('li_izz', ii.izz)}`
+      + `<br>ixy${ni('li_ixy', ii.ixy)} ixz${ni('li_ixz', ii.ixz)} `
+      + `iyz${ni('li_iyz', ii.iyz)}`);
+    rowsHtml.push('<tr><td></td><td><button id="li_inertial_apply" '
+      + 'style="font-size:11px;background:#15171a;color:#ddd;border:1px solid #444;'
+      + `border-radius:3px;padding:2px 10px;cursor:pointer">${t('li.inertialApply')}`
+      + '</button></td></tr>');
   }
   const c = mat?.color?.getHexString?.();
   // editable colour: the picker shows the persisted override if any, else the
@@ -3164,6 +3200,37 @@ function fillLinkInfo(name) {
   }
   el.querySelectorAll('.palsw').forEach(s =>
     s.addEventListener('click', () => setLinkColor(name, s.dataset.c)));
+  const inApply = el.querySelector('#li_inertial_apply');
+  if (inApply) {
+    inApply.addEventListener('click', async () => {
+      const num = id => parseFloat(el.querySelector('#' + id).value);
+      const mass = num('li_mass');
+      const com = [num('li_cx'), num('li_cy'), num('li_cz')];
+      const inertia = [num('li_ixx'), num('li_ixy'), num('li_ixz'),
+                       num('li_iyy'), num('li_iyz'), num('li_izz')];
+      if (![mass, ...com, ...inertia].every(Number.isFinite)) {
+        log(t('li.inertialBadNum'), 'err');   // an empty field -> NaN; don't post
+        return;
+      }
+      const body = { link: name, mass, com, inertia };
+      op('setInertial', { link: name });
+      log(t('li.settingInertial', { name }));
+      try {
+        const resp = await fetch('/api/set_inertial', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body) });
+        const r = await resp.json();
+        if (!resp.ok || r.error) { throw new Error(r.error ?? resp.status); }
+        log(t('li.inertialOk'), 'ok');
+        loadRobot(currentInfo, { keepPose: true });   // re-read the edited URDF
+        refreshHistory();
+        const reselect = name;
+        setTimeout(() => selectLink(reselect), 1500);  // reopen panel after rebuild
+      } catch (e) {
+        log(t('li.inertialFail', { e: e.message ?? e }), 'err');
+      }
+    });
+  }
   el.style.display = 'block';   // '' would fall back to the stylesheet's
                                 // display:none and never show
 }

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -171,6 +171,14 @@ def _resolve_package(path):
 _um = {"state": None, "rev": 0, "live_rev": -1, "undo": [], "redo": []}
 
 
+def _um_close():
+    """Drop the in-memory overlay (state + undo/redo + caches) when switching or
+    closing a package.  The hidden .live.urdf copy is intentionally NOT deleted:
+    a background collision / auto-limit worker may still be reading it, and the
+    file is hidden + gitignored and overwritten on the package's next use."""
+    _um.update(state=None, rev=0, live_rev=-1, undo=[], redo=[])
+
+
 def _cad_mode(pkg_dir):
     """True when the package has a CAD graph (the joints.yaml + build() path);
     False for a plain URDF opened directly (the overlay path)."""
@@ -383,6 +391,11 @@ def _um_set_mimic(state, changes):
         j = _um_joint_by_child(state, child)
         if not j:
             missed.append(child)
+            continue
+        jd = next((x for x in state.joints if x["name"] == j), None)
+        if not ch.get("clear") and (jd is None or state.effective_type(jd)
+                                    not in ("revolute", "continuous", "prismatic")):
+            missed.append(child)           # a fixed joint can't follow a mimic
             continue
         try:
             if ch.get("clear"):
@@ -1804,11 +1817,11 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                     return self._send_json({"error": str(e)}, 400)
                 cls.pkg_dir, cls.urdf_rel = pkg, rel
                 cls.robot_name = os.path.splitext(os.path.basename(rel))[0]
-                # plain URDF (no CAD graph) -> load the in-memory edit overlay;
-                # a CAD package uses the joints.yaml + build() path (no overlay)
-                if _cad_mode(pkg):
-                    _um["state"] = None
-                else:
+                # drop the previous package's overlay + its hidden live URDF, then
+                # load the new one (plain URDF -> in-memory overlay; a CAD package
+                # uses the joints.yaml + build() path, no overlay)
+                _um_close()
+                if not _cad_mode(pkg):
                     _um_load(pkg, rel)
                 print(f"[sw2robot.web] open: {cls.robot_name} ({pkg})"
                       f"{'' if _cad_mode(pkg) else ' [urdf-input mode]'}")

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -166,7 +166,9 @@ def _resolve_package(path):
 # ``rev`` bumps on every edit so on-disk readers (collision / auto-limits) can
 # cache against a stable (path, mtime) -- the live URDF is only rewritten when
 # ``rev`` actually changed (see _um_live_urdf).
-_um = {"state": None, "rev": 0, "live_rev": -1}
+# undo/redo in URDF mode snapshot the overlay (edits + link_edits) as JSON, since
+# there is no joints.yaml to snapshot (the CAD path's history mechanism).
+_um = {"state": None, "rev": 0, "live_rev": -1, "undo": [], "redo": []}
 
 
 def _cad_mode(pkg_dir):
@@ -183,7 +185,24 @@ def _um_load(pkg_dir, urdf_rel):
     core.load_edits(state)            # restore a prior session's edits, if any
     _um["state"] = state
     _um["rev"], _um["live_rev"] = 0, -1
+    _um["undo"], _um["redo"] = [], []
     return state
+
+
+def _um_overlay_json(state):
+    """A compact snapshot of just the editable overlay (for undo/redo)."""
+    return state.model_dump_json(include={"edits", "link_edits"})
+
+
+def _um_restore(snap):
+    """Replace the live overlay with a snapshot's edits/link_edits."""
+    from .state import JointEdit, LinkEdit
+    data = json.loads(snap)
+    st = _um["state"]
+    st.edits = {k: JointEdit(**v) for k, v in (data.get("edits") or {}).items()}
+    st.link_edits = {k: LinkEdit(**v)
+                     for k, v in (data.get("link_edits") or {}).items()}
+    _um_save(st)
 
 
 def _um_save(state):
@@ -270,7 +289,7 @@ def _um_joint_by_child(state, child):
     return next((j["name"] for j in state.joints if j["childLink"] == child), None)
 
 
-def _rewrite_package_urls(urdf_text, urdf_rel):
+def _rewrite_package_urls(urdf_text, urdf_rel, pkg_dir):
     """Rewrite mesh ``package://<pkg>/<rest>`` URIs so the viewer can fetch them
     from the package root (served at ``/pkg/``).  urdf-loaders resolves a mesh
     path RELATIVE to the URDF's own URL, so emit ``<../ per dir>rest`` -- e.g. a
@@ -278,11 +297,27 @@ def _rewrite_package_urls(urdf_text, urdf_rel):
     normalizes ``/pkg/urdf/../<rest>`` -> ``/pkg/<rest>`` (the package root).
     Layout-independent (depth derived from ``urdf_rel``).  Applied ONLY to the
     URDF served to the viewer; the on-disk file (and the ROS export) keep their
-    original ``package://`` references."""
+    original ``package://`` references.
+
+    A ref is rewritten only when its mesh actually EXISTS in this package -- so
+    own meshes load regardless of the URI's package name (folder need not match),
+    while a ref to another ROS package whose file is not here is left as
+    ``package://`` (unresolvable in-browser either way, but not mis-pointed)."""
     depth = len([s for s in posixpath.dirname(urdf_rel).split("/") if s])
     prefix = "../" * depth
-    return re.sub(r'filename="package://[^/"]+/',
-                  lambda _m: f'filename="{prefix}', urdf_text)
+    root = os.path.normpath(pkg_dir)
+
+    def repl(m):
+        rest = m.group(1)
+        local = os.path.normpath(os.path.join(root, *rest.split("/")))
+        try:
+            inside = os.path.commonpath([root, local]) == root
+        except ValueError:
+            inside = False
+        if inside and os.path.exists(local):
+            return f'filename="{prefix}{rest}"'
+        return m.group(0)                  # not in this package -- leave as-is
+    return re.sub(r'filename="package://[^/"]+/([^"]+)"', repl, urdf_text)
 
 
 def _um_colors(state):
@@ -1512,11 +1547,19 @@ class _Handler(http.server.BaseHTTPRequestHandler):
     def _um_reply(self, fn, *args):
         """Run a URDF-mode edit and JSON-reply, turning a bad-input error into a
         400 the editor surfaces (rather than the generic 500) -- TypeError covers
-        a malformed body, e.g. a null in the com/inertia arrays."""
+        a malformed body, e.g. a null in the com/inertia arrays.  Snapshots the
+        pre-edit overlay for undo, but only once the edit actually succeeds."""
+        snap = (_um_overlay_json(_um["state"])
+                if _um["state"] is not None else None)
         try:
-            return self._send_json(fn(_um["state"], *args))
+            result = fn(_um["state"], *args)
         except (ValueError, TypeError) as e:
             return self._send_json({"error": str(e)}, 400)
+        if snap is not None:
+            _um["undo"].append(snap)
+            del _um["undo"][:-50]
+            _um["redo"].clear()
+        return self._send_json(result)
 
     # -- routes -----------------------------------------------------------
     def do_GET(self):
@@ -1634,6 +1677,10 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                      "dirs": dirs[:400], "files": files[:400]})
             if path == "/api/history":
                 cls = type(self)
+                if cls.pkg_dir and not _cad_mode(cls.pkg_dir):   # URDF-mode stack
+                    return self._send_json(
+                        {"undo": ["edit"] * len(_um["undo"]),
+                         "redo": ["edit"] * len(_um["redo"])})
                 h = _hist(cls.pkg_dir) if cls.pkg_dir else {"undo": [],
                                                             "redo": []}
                 return self._send_json(
@@ -1830,7 +1877,7 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                     from . import core
                     served = _rewrite_package_urls(
                         core.build_urdf(_um["state"], sanitize=False),
-                        cls.urdf_rel)
+                        cls.urdf_rel, cls.pkg_dir)
                     return self._send_bytes(served.encode("utf-8"),
                                             "application/xml")
                 full = self._resolve(cls.pkg_dir, rel)
@@ -2603,11 +2650,19 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 cls = type(self)
                 if not cls.pkg_dir:
                     return self._send_json({"error": "no package open"}, 400)
+                src = "undo" if parsed.path.endswith("undo") else "redo"
+                dst = "redo" if src == "undo" else "undo"
+                if not _cad_mode(cls.pkg_dir):       # URDF-input mode: overlay stack
+                    if not _um[src]:
+                        return self._send_json({"error": f"nothing to {src}"}, 400)
+                    _um[dst].append(_um_overlay_json(_um["state"]))
+                    _um_restore(_um[src].pop())
+                    return self._send_json(
+                        {"done": src, "undo": len(_um["undo"]),
+                         "redo": len(_um["redo"])})
                 name = os.path.splitext(os.path.basename(cls.urdf_rel))[0]
                 yml = os.path.join(cls.pkg_dir, name + ".joints.yaml")
                 h = _hist(cls.pkg_dir)
-                src = "undo" if parsed.path.endswith("undo") else "redo"
-                dst = "redo" if src == "undo" else "undo"
                 if not h[src]:
                     return self._send_json({"error": f"nothing to {src}"},
                                            400)

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -270,13 +270,19 @@ def _um_joint_by_child(state, child):
     return next((j["name"] for j in state.joints if j["childLink"] == child), None)
 
 
-def _rewrite_package_urls(urdf_text):
-    """Rewrite mesh ``package://<pkg>/<rest>`` URIs to the server's ``/pkg/``
-    root (where the opened package is served) so the viewer can fetch them:
-    ``package://<pkg>/<rest>`` -> ``/pkg/<rest>``.  Applied ONLY to the URDF
-    served to the viewer in URDF-input mode -- the on-disk file (and therefore
-    the ROS export) keep their original ``package://`` references."""
-    return re.sub(r'(filename=")package://[^/"]+/', r'\1/pkg/', urdf_text)
+def _rewrite_package_urls(urdf_text, urdf_rel):
+    """Rewrite mesh ``package://<pkg>/<rest>`` URIs so the viewer can fetch them
+    from the package root (served at ``/pkg/``).  urdf-loaders resolves a mesh
+    path RELATIVE to the URDF's own URL, so emit ``<../ per dir>rest`` -- e.g. a
+    URDF served at ``/pkg/urdf/x.urdf`` gets ``../<rest>`` so the browser
+    normalizes ``/pkg/urdf/../<rest>`` -> ``/pkg/<rest>`` (the package root).
+    Layout-independent (depth derived from ``urdf_rel``).  Applied ONLY to the
+    URDF served to the viewer; the on-disk file (and the ROS export) keep their
+    original ``package://`` references."""
+    depth = len([s for s in posixpath.dirname(urdf_rel).split("/") if s])
+    prefix = "../" * depth
+    return re.sub(r'filename="package://[^/"]+/',
+                  lambda _m: f'filename="{prefix}', urdf_text)
 
 
 def _um_colors(state):
@@ -1823,7 +1829,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                         and not _cad_mode(cls.pkg_dir)):
                     from . import core
                     served = _rewrite_package_urls(
-                        core.build_urdf(_um["state"], sanitize=False))
+                        core.build_urdf(_um["state"], sanitize=False),
+                        cls.urdf_rel)
                     return self._send_bytes(served.encode("utf-8"),
                                             "application/xml")
                 full = self._resolve(cls.pkg_dir, rel)

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -21,6 +21,7 @@ localhost.  No third-party server deps; mesh conversion reuses trimesh which
 sw2robot.exporter already requires.
 """
 import argparse
+import contextlib
 import http.server
 import json
 import os
@@ -150,6 +151,230 @@ def _resolve_package(path):
                     return path, rel.replace("\\", "/")
         raise ValueError(f"no *.urdf under {path}")
     raise ValueError(f"not a package dir or .urdf file: {path}")
+
+
+# --- URDF-input editing mode -------------------------------------------------
+# A package WITHOUT a graph.json is a plain URDF the user opened directly: there
+# is no CAD graph to rebuild from, so edits cannot go through joints.yaml +
+# build().  Instead we hold the core overlay (RobotCompilerState: per-joint and
+# per-link edits) in memory and route every edit through the SAME core setters
+# the headless CLI uses.  The URDF URL is served as build_urdf(state), so the
+# on-disk .urdf stays the pristine base: the declarative overlay re-applies
+# cleanly on every request and survives a restart via the .sw2robot.json sidecar.
+_um = {"state": None}     # RobotCompilerState for the current URDF-mode package
+
+
+def _cad_mode(pkg_dir):
+    """True when the package has a CAD graph (the joints.yaml + build() path);
+    False for a plain URDF opened directly (the overlay path)."""
+    return bool(pkg_dir) and os.path.exists(os.path.join(pkg_dir, "graph.json"))
+
+
+def _um_load(pkg_dir, urdf_rel):
+    """(Re)build the URDF-mode overlay state for the freshly-opened package and
+    merge any saved sidecar edits.  Returns the state."""
+    from . import core
+    state = core.load_module(os.path.join(pkg_dir, urdf_rel), package_dir=pkg_dir)
+    core.load_edits(state)            # restore a prior session's edits, if any
+    _um["state"] = state
+    return state
+
+
+def _um_save(state):
+    from . import core
+    try:
+        core.save_state(state)
+    except OSError:
+        pass                          # persistence is best-effort
+
+
+@contextlib.contextmanager
+def _um_materialized(pkg_dir, urdf_rel):
+    """Temporarily write the overlay-applied URDF to disk so on-disk readers (the
+    ROS exporter) see URDF-mode edits, then restore the pristine base.  The
+    served URDF is normally computed on the fly (disk stays pristine); export is
+    the one path that reads the file directly.  A no-op in CAD mode."""
+    if _cad_mode(pkg_dir) or _um["state"] is None:
+        yield
+        return
+    from . import core
+    served = os.path.join(pkg_dir, urdf_rel)
+    # build the edited URDF BEFORE truncating `served` -- build_urdf reads the
+    # pristine base from that same path, so opening it "w" first would empty it
+    edited = core.build_urdf(_um["state"], sanitize=False)
+    try:
+        with open(served, encoding="utf-8") as f:
+            pristine = f.read()
+    except OSError:
+        pristine = None
+    try:
+        with open(served, "w", encoding="utf-8") as f:
+            f.write(edited)
+        yield
+    finally:
+        if pristine is not None:
+            with open(served, "w", encoding="utf-8") as f:
+                f.write(pristine)
+
+
+def _um_joint_by_child(state, child):
+    """Map a child-link name (what the limits/types/mimic UI sends) to its joint
+    name (what the overlay is keyed by); None if no joint has that child."""
+    return next((j["name"] for j in state.joints if j["childLink"] == child), None)
+
+
+def _um_colors(state):
+    """``{link -> '#RRGGBB'}`` from the overlay -- the ROS exporter uses this to
+    repaint converted meshes (URDF mode has no joints.yaml ``colors:`` block)."""
+    return {ln: le.color for ln, le in state.link_edits.items() if le.color}
+
+
+def _um_components(state):
+    """The /api/components payload for URDF mode: links straight from the parsed
+    URDF, colours from the overlay (no CAD material/density concept here)."""
+    links, colors = {}, {}
+    for ln in state.links:
+        name = ln["name"]
+        le = state.link_edits.get(name)
+        col = le.color if le else None
+        links[name] = {"material": None, "density": None, "name": name,
+                       "override": None, "color": col}
+        if col:
+            colors[name] = col
+    return {"links": links, "excluded": [], "colors": colors}
+
+
+def _um_set_limits(state, limits):
+    from . import core
+    applied, missed = [], []
+    for lm in limits:
+        child = lm.get("child")
+        j = _um_joint_by_child(state, child)
+        if not j:
+            missed.append(child)
+            continue
+        if lm.get("continuous"):
+            core.set_joint_type(state, j, "continuous")
+        else:
+            core.set_limits(state, j, float(lm.get("lower", 0.0)),
+                            float(lm.get("upper", 0.0)))
+        applied.append(child)
+    _um_save(state)
+    return {"applied": applied, "missed": missed}
+
+
+def _um_set_types(state, changes):
+    from . import core
+    applied, missed = [], []
+    for ch in changes:
+        child, t = ch.get("child"), ch.get("type")
+        j = _um_joint_by_child(state, child)
+        if not j or t not in core.JOINT_TYPES:
+            missed.append(ch)
+            continue
+        core.set_joint_type(state, j, t)
+        applied.append(child)
+    _um_save(state)
+    return {"applied": applied, "missed": missed}
+
+
+def _um_set_mimic(state, changes):
+    from . import core
+    applied, missed = [], []
+    for ch in changes:
+        child = ch.get("child")
+        j = _um_joint_by_child(state, child)
+        if not j:
+            missed.append(child)
+            continue
+        try:
+            if ch.get("clear"):
+                core.clear_mimic(state, j)
+            else:
+                # the UI sends the master's CURRENT (effective) name; the overlay
+                # is keyed by original names, so map it back before validating
+                master = ch.get("master")
+                master = next((m["name"] for m in state.joints
+                               if state.effective_name(m["name"]) == master),
+                              master)
+                core.set_mimic(state, j, master,
+                               float(ch.get("multiplier", 1.0)),
+                               float(ch.get("offset", 0.0)))
+        except ValueError:
+            missed.append(child)
+            continue
+        applied.append(child)
+    _um_save(state)
+    return {"applied": applied, "missed": missed}
+
+
+def _um_set_axis(state, joints):
+    from . import core
+    applied, missed = [], []
+    # the UI posts CURRENT (effective) joint names; the overlay is keyed by
+    # original names, so map each back before flipping (as mimic/rename do)
+    by_effective = {state.effective_name(j["name"]): j["name"] for j in state.joints}
+    for jn in joints:
+        orig = by_effective.get(jn)
+        if orig is None:
+            missed.append(jn)
+            continue
+        core.reverse_direction(state, orig)  # flip axis + remap limits (self-inverse)
+        applied.append(jn)
+    _um_save(state)
+    return {"applied": applied, "missed": missed}
+
+
+def _um_set_color(state, link, color):
+    from . import core
+    core.set_color(state, link, color)      # raises ValueError on a bad hex
+    _um_save(state)
+    le = state.link_edits.get(link)
+    return {"link": link, "color": le.color if le else None}
+
+
+def _um_set_inertial(state, body):
+    from . import core
+    link = body.get("link")
+    if not link:
+        raise ValueError("link required")
+    core.set_inertial(state, link, mass=body.get("mass"),
+                      com=body.get("com"), inertia=body.get("inertia"))
+    _um_save(state)
+    le = state.link_edits.get(link)
+    return {"link": link,
+            "mass": le.mass if le else None,
+            "com": le.com if le else None,
+            "inertia": le.inertia if le else None}
+
+
+def _um_reset_names(state):
+    n = 0
+    for e in state.edits.values():
+        if e.rename:
+            e.rename = None
+            n += 1
+    _um_save(state)
+    return {"ok": True, "reset": n}
+
+
+def _um_rename(state, kind, old, new):
+    from . import core
+    if kind == "link":
+        raise ValueError("link rename is not yet supported in URDF-input mode")
+    # joints are keyed by ORIGINAL name; the UI sends the CURRENT (effective)
+    # name, so map back through the rename overlay
+    orig = next((j["name"] for j in state.joints
+                 if state.effective_name(j["name"]) == old), None)
+    if orig is None:
+        raise ValueError(f"no such joint: {old}")
+    if not new:                              # empty -> reset to the original name
+        if orig in state.edits:
+            state.edits[orig].rename = None
+    else:
+        core.rename_joint(state, orig, new)
+    _um_save(state)
+    return {"kind": kind, "old": old, "new": new}
 
 
 # Opening an assembly needs its REAL on-disk path (SolidWorks resolves the
@@ -1111,6 +1336,14 @@ class _Handler(http.server.BaseHTTPRequestHandler):
         return {"name": cls.robot_name, "urdf": "/pkg/" + cls.urdf_rel} \
             if cls.urdf_rel else {"name": None, "urdf": None}
 
+    def _um_reply(self, fn, *args):
+        """Run a URDF-mode edit and JSON-reply, turning a validation error into a
+        400 the editor surfaces (rather than the generic 500)."""
+        try:
+            return self._send_json(fn(_um["state"], *args))
+        except ValueError as e:
+            return self._send_json({"error": str(e)}, 400)
+
     # -- routes -----------------------------------------------------------
     def do_GET(self):
         parsed = urllib.parse.urlparse(self.path)
@@ -1143,6 +1376,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 cls = type(self)
                 if not cls.pkg_dir:
                     return self._send_json({"error": "no package open"}, 400)
+                if not _cad_mode(cls.pkg_dir):       # URDF-input mode
+                    return self._send_json(_um_components(_um["state"]))
                 from sw2robot.exporter.state import GraphState
                 gs = GraphState.load(
                     os.path.join(cls.pkg_dir, "graph.json"))
@@ -1242,6 +1477,10 @@ class _Handler(http.server.BaseHTTPRequestHandler):
             if path == "/api/collision/init":
                 if not cls.pkg_dir:
                     return self._send_json({"error": "no package open"}, 400)
+                # NOTE: in URDF-input mode this reads the pristine on-disk URDF,
+                # not the live overlay -- collision against unsaved type/axis
+                # edits is a known limitation (these optional skrobot/fcl features
+                # need async-safe materialization; tracked for a follow-up).
                 urdf_path = os.path.join(cls.pkg_dir, cls.urdf_rel)
                 key = (urdf_path, os.path.getmtime(urdf_path))
                 with _coll_lock:
@@ -1264,6 +1503,9 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 # Started ASYNC so the page can poll /api/auto_limits/status for
                 # per-joint progress while it runs (the sweep is in the child
                 # process, so polling no longer thrashes its GIL).  One at a time.
+                # NOTE: like /api/collision/init, the sweep reads the pristine
+                # on-disk URDF in URDF-input mode (not the live overlay) -- a
+                # known limitation tracked for a follow-up.
                 if not cls.pkg_dir:
                     return self._send_json({"error": "no package open"}, 400)
                 # parse BEFORE claiming the job, so a bad step/max can't wedge
@@ -1339,7 +1581,14 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                     return self._send_json({"error": str(e)}, 400)
                 cls.pkg_dir, cls.urdf_rel = pkg, rel
                 cls.robot_name = os.path.splitext(os.path.basename(rel))[0]
-                print(f"[sw2robot.web] open: {cls.robot_name} ({pkg})")
+                # plain URDF (no CAD graph) -> load the in-memory edit overlay;
+                # a CAD package uses the joints.yaml + build() path (no overlay)
+                if _cad_mode(pkg):
+                    _um["state"] = None
+                else:
+                    _um_load(pkg, rel)
+                print(f"[sw2robot.web] open: {cls.robot_name} ({pkg})"
+                      f"{'' if _cad_mode(pkg) else ' [urdf-input mode]'}")
                 _preconvert_meshes(pkg)
                 return self._send_json(self._info())
             if path == "/api/export/zip":
@@ -1358,12 +1607,17 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 pkg_name = (query.get("name") or [""])[0].strip() or None
                 urdf_name = (query.get("urdf") or [""])[0].strip() or None
                 try:
-                    pkg, data = _export_zip(cls.pkg_dir, cls.robot_name, fmt,
-                                            ros_version=ros_version,
-                                            pkg_name=pkg_name,
-                                            urdf_name=urdf_name,
-                                            colors=_read_colors(
-                                                cls.pkg_dir, cls.urdf_rel))
+                    # URDF-input mode keeps the on-disk URDF pristine and serves
+                    # edits live; materialize them so the exporter picks them up
+                    colors = (_read_colors(cls.pkg_dir, cls.urdf_rel)
+                              if _cad_mode(cls.pkg_dir)
+                              else _um_colors(_um["state"]))
+                    with _um_materialized(cls.pkg_dir, cls.urdf_rel):
+                        pkg, data = _export_zip(cls.pkg_dir, cls.robot_name, fmt,
+                                                ros_version=ros_version,
+                                                pkg_name=pkg_name,
+                                                urdf_name=urdf_name,
+                                                colors=colors)
                 except ValueError as e:
                     return self._send_json({"error": str(e)}, 400)
                 fname = (f"{cls.robot_name}_glb.zip" if fmt == "glb"
@@ -1379,7 +1633,18 @@ class _Handler(http.server.BaseHTTPRequestHandler):
             if path.startswith("/pkg/"):
                 if not cls.pkg_dir:
                     return self.send_error(404, "no package open")
-                full = self._resolve(cls.pkg_dir, path[len("/pkg/"):])
+                rel = path[len("/pkg/"):]
+                # URDF-input mode: the URDF URL is the overlay-applied URDF,
+                # computed on the fly so the on-disk file stays the pristine base
+                # (decode first -- urdf_rel is decoded, but the URL may carry %20)
+                if (urllib.parse.unquote(rel) == cls.urdf_rel
+                        and _um["state"] is not None
+                        and not _cad_mode(cls.pkg_dir)):
+                    from . import core
+                    return self._send_bytes(
+                        core.build_urdf(_um["state"], sanitize=False)
+                        .encode("utf-8"), "application/xml")
+                full = self._resolve(cls.pkg_dir, rel)
                 if full is None or not os.path.isfile(full):
                     return self.send_error(404)
                 if full.lower().endswith(".3dxml") \
@@ -1434,6 +1699,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 limits = body.get("limits") or []
                 if not cls.pkg_dir:
                     return self._send_json({"error": "no package open"}, 400)
+                if not _cad_mode(cls.pkg_dir):
+                    return self._um_reply(_um_set_limits, limits)
                 name = os.path.splitext(os.path.basename(cls.urdf_rel))[0]
                 yml = os.path.join(cls.pkg_dir, name + ".joints.yaml")
                 if not os.path.exists(yml):
@@ -1476,6 +1743,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 names = body.get("joints") or []
                 if not cls.pkg_dir:
                     return self._send_json({"error": "no package open"}, 400)
+                if not _cad_mode(cls.pkg_dir):
+                    return self._um_reply(_um_set_axis, names)
                 applied, missed = [], []
                 for jn in names:
                     try:
@@ -1494,6 +1763,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 changes = body.get("changes") or []
                 if not cls.pkg_dir:
                     return self._send_json({"error": "no package open"}, 400)
+                if not _cad_mode(cls.pkg_dir):
+                    return self._um_reply(_um_set_types, changes)
                 name = os.path.splitext(os.path.basename(cls.urdf_rel))[0]
                 yml = os.path.join(cls.pkg_dir, name + ".joints.yaml")
                 if not os.path.exists(yml):
@@ -1546,6 +1817,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 changes = body.get("changes") or []
                 if not cls.pkg_dir:
                     return self._send_json({"error": "no package open"}, 400)
+                if not _cad_mode(cls.pkg_dir):
+                    return self._um_reply(_um_set_mimic, changes)
                 name = os.path.splitext(os.path.basename(cls.urdf_rel))[0]
                 yml = os.path.join(cls.pkg_dir, name + ".joints.yaml")
                 if not os.path.exists(yml):
@@ -1845,6 +2118,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 color = body.get("color")         # None / '' removes the override
                 if not cls.pkg_dir or not link:
                     return self._send_json({"error": "no package/link"}, 400)
+                if not _cad_mode(cls.pkg_dir):
+                    return self._um_reply(_um_set_color, link, color)
                 norm = None
                 if color:
                     h = str(color).strip().lstrip("#").lower()
@@ -1879,6 +2154,20 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                     f.write(txt)
                 print(f"[sw2robot.web] set_color: {comp} -> {norm}")
                 return self._send_json({"link": comp, "color": norm})
+            if parsed.path == "/api/set_inertial":
+                # per-link inertial override (mass / com / inertia).  URDF-input
+                # mode only: a CAD package derives inertia from the mesh + density
+                # at build time, so it has no overlay to write to here.
+                cls = type(self)
+                n = int(self.headers.get("Content-Length", 0))
+                body = json.loads(self.rfile.read(n) or b"{}")
+                if not cls.pkg_dir:
+                    return self._send_json({"error": "no package open"}, 400)
+                if _cad_mode(cls.pkg_dir):
+                    return self._send_json(
+                        {"error": "inertial editing is only available in "
+                                  "URDF-input mode"}, 400)
+                return self._um_reply(_um_set_inertial, body)
             if parsed.path == "/api/rename":
                 # rename a link or joint to a user-chosen name.  Stored as a
                 # component->display overlay in joints.yaml (link_names /
@@ -1900,6 +2189,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                     return self._send_json(
                         {"error": f"invalid name '{new}' -- letters / digits / "
                                   f"underscore, not starting with a digit"}, 400)
+                if not _cad_mode(cls.pkg_dir):
+                    return self._um_reply(_um_rename, kind, old, new)
                 pkg = os.path.splitext(os.path.basename(cls.urdf_rel))[0]
                 yml = os.path.join(cls.pkg_dir, pkg + ".joints.yaml")
                 if not os.path.exists(yml):
@@ -2091,6 +2382,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 cls = type(self)
                 if not cls.pkg_dir:
                     return self._send_json({"error": "no package open"}, 400)
+                if not _cad_mode(cls.pkg_dir):
+                    return self._um_reply(_um_reset_names)
                 pkg = os.path.splitext(os.path.basename(cls.urdf_rel))[0]
                 yml = os.path.join(cls.pkg_dir, pkg + ".joints.yaml")
                 if not os.path.exists(yml):
@@ -2197,7 +2490,10 @@ def serve(package_dir=None, root_dir=None, port=8090, open_browser=True):
         pkg, rel = _resolve_package(package_dir)
         _Handler.pkg_dir, _Handler.urdf_rel = pkg, rel
         _Handler.robot_name = os.path.splitext(os.path.basename(rel))[0]
-        print(f"[sw2robot.web] serving '{_Handler.robot_name}' from {pkg}")
+        if not _cad_mode(pkg):           # plain URDF -> overlay editing mode
+            _um_load(pkg, rel)
+        print(f"[sw2robot.web] serving '{_Handler.robot_name}' from {pkg}"
+              f"{'' if _cad_mode(pkg) else ' [urdf-input mode]'}")
     else:
         print(f"[sw2robot.web] no package yet -- pick one in the browser "
               f"(root: {_Handler.root_dir})")

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -270,6 +270,15 @@ def _um_joint_by_child(state, child):
     return next((j["name"] for j in state.joints if j["childLink"] == child), None)
 
 
+def _rewrite_package_urls(urdf_text):
+    """Rewrite mesh ``package://<pkg>/<rest>`` URIs to the server's ``/pkg/``
+    root (where the opened package is served) so the viewer can fetch them:
+    ``package://<pkg>/<rest>`` -> ``/pkg/<rest>``.  Applied ONLY to the URDF
+    served to the viewer in URDF-input mode -- the on-disk file (and therefore
+    the ROS export) keep their original ``package://`` references."""
+    return re.sub(r'(filename=")package://[^/"]+/', r'\1/pkg/', urdf_text)
+
+
 def _um_colors(state):
     """``{link -> '#RRGGBB'}`` from the overlay -- the ROS exporter uses this to
     repaint converted meshes (URDF mode has no joints.yaml ``colors:`` block)."""
@@ -1813,9 +1822,10 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                         and _um["state"] is not None
                         and not _cad_mode(cls.pkg_dir)):
                     from . import core
-                    return self._send_bytes(
-                        core.build_urdf(_um["state"], sanitize=False)
-                        .encode("utf-8"), "application/xml")
+                    served = _rewrite_package_urls(
+                        core.build_urdf(_um["state"], sanitize=False))
+                    return self._send_bytes(served.encode("utf-8"),
+                                            "application/xml")
                 full = self._resolve(cls.pkg_dir, rel)
                 if full is None or not os.path.isfile(full):
                     return self.send_error(404)

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -844,6 +844,113 @@ def _flip_axis_in_urdf(pkg_dir, urdf_rel, joint_name):
     return na
 
 
+def _set_attr_in_tag(seg, attr, val):
+    """Set/replace one attribute in a single (self-closing) tag string."""
+    import re
+    if re.search(rf'\b{attr}="', seg):
+        return re.sub(rf'\b{attr}="[^"]*"', f'{attr}="{val}"', seg)
+    return re.sub(r'\s*/?>\s*$', f' {attr}="{val}"/>', seg, count=1)
+
+
+def _edit_joint_block(pkg_dir, urdf_rel, child, edit):
+    """Find the ``<joint>`` whose child link is ``child`` in the served URDF and
+    rewrite its (head, body) via ``edit(head, body) -> (head, body)`` IN PLACE --
+    the same instant, build-skipping pattern as :func:`_flip_axis_in_urdf` /
+    :func:`_rename_in_urdf`, but matched by child link (what the limits/mimic UI
+    sends).  Comments + formatting are preserved (regex, not an XML round-trip).
+    Returns True if a joint was edited."""
+    import re
+    parsed = _parse_urdf(pkg_dir, urdf_rel)
+    if not parsed:
+        return False
+    jname = next((j["name"] for j in parsed["joints"]
+                  if j["childLink"] == child), None)
+    if jname is None:
+        return False
+    path = os.path.join(pkg_dir, urdf_rel)
+    with open(path, encoding="utf-8") as f:
+        txt = f.read()
+    jpat = re.compile(
+        r'(<joint\b[^>]*\bname="' + re.escape(jname) + r'"[^>]*>)(.*?)(</joint>)',
+        re.DOTALL)
+    m = jpat.search(txt)
+    if not m:
+        return False
+    head, body = edit(m.group(1), m.group(2))
+    if head is None:
+        return False                     # edit declined (e.g. wrong joint type)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(txt[:m.start()] + head + body + m.group(3) + txt[m.end():])
+    return True
+
+
+def _append_into_body(body, line):
+    """Insert ``line`` (an indented element + newline) just before the body's
+    trailing indentation (the run before ``</joint>``)."""
+    import re
+    cut = re.search(r'[ \t]*$', body).start()
+    return body[:cut] + line + body[cut:]
+
+
+def _body_indent(body):
+    import re
+    m = re.search(r'\n([ \t]+)<', body)
+    return m.group(1) if m else "    "
+
+
+def _set_limit_in_urdf(pkg_dir, urdf_rel, child, lower, upper, continuous):
+    """Set a joint's ``<limit>`` (or make it continuous) directly in the served
+    URDF, found by child link.  Skips the inertia-recomputing build (joints.yaml
+    still persists the value).  Returns True if applied."""
+    import re
+
+    def edit(head, body):
+        if continuous:
+            head = re.sub(r'(\btype=")[^"]*(")', r'\1continuous\2', head)
+            # continuous carries no lower/upper -- drop them, keep effort/velocity
+            body = re.sub(
+                r'<limit\b[^>]*?>',
+                lambda mm: re.sub(r'\s*\b(?:lower|upper)="[^"]*"', '', mm.group(0)),
+                body)
+            return head, body
+        tm = re.search(r'\btype="([^"]*)"', head)
+        if tm and tm.group(1) not in ("revolute", "prismatic"):
+            return None, None            # a limit only applies to revolute/prismatic
+        lo, hi = _fmt_num(lower), _fmt_num(upper)
+        lm = re.search(r'<limit\b[^>]*?>', body)
+        if lm:
+            seg = _set_attr_in_tag(lm.group(0), "lower", lo)
+            seg = _set_attr_in_tag(seg, "upper", hi)
+            body = body[:lm.start()] + seg + body[lm.end():]
+        else:
+            pad = _body_indent(body)
+            body = _append_into_body(
+                body, f'{pad}<limit lower="{lo}" upper="{hi}" '
+                      f'effort="10" velocity="3.14"/>\n')
+        return head, body
+
+    return _edit_joint_block(pkg_dir, urdf_rel, child, edit)
+
+
+def _set_mimic_in_urdf(pkg_dir, urdf_rel, child, master, multiplier, offset, clear):
+    """Add / replace / remove a joint's ``<mimic>`` directly in the served URDF,
+    found by child link (build-skipping; joints.yaml still persists it).  Returns
+    True if the joint was found."""
+    import re
+
+    def edit(head, body):
+        body = re.sub(r'[ \t]*<mimic\b[^>]*?>[ \t]*\n?', '', body)  # drop existing
+        if not clear and master:
+            pad = _body_indent(body)
+            body = _append_into_body(
+                body, f'{pad}<mimic joint="{master}" '
+                      f'multiplier="{_fmt_num(multiplier)}" '
+                      f'offset="{_fmt_num(offset)}"/>\n')
+        return head, body
+
+    return _edit_joint_block(pkg_dir, urdf_rel, child, edit)
+
+
 def _urdf_names(pkg_dir, urdf_rel, tag):
     """Current ``<link>``/``<joint>`` names in the served URDF (the source of
     truth for what's on screen), for the rename collision check + root detect."""
@@ -1775,25 +1882,25 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                     txt = f.read()
                 linv = _link_names_inverse(txt)   # display -> component
                 applied, missed = [], []
+                changed_yaml = False
                 for lm in limits:
-                    c = linv.get(lm.get("child"), lm.get("child"))
-                    if not c:
-                        continue
-                    txt, k = _set_joint_limit(
-                        txt, c, float(lm.get("lower", 0.0)),
-                        float(lm.get("upper", 0.0)),
-                        bool(lm.get("continuous")))
-                    (applied if k else missed).append(c)
-                if applied:
-                    _snapshot(cls.pkg_dir, yml, f"auto limits x{len(applied)}")
+                    child = lm.get("child")
+                    lo = float(lm.get("lower", 0.0))
+                    hi = float(lm.get("upper", 0.0))
+                    cont = bool(lm.get("continuous"))
+                    # persist to joints.yaml (survives re-extract / undo) ...
+                    txt, ky = _set_joint_limit(txt, linv.get(child, child),
+                                               lo, hi, cont)
+                    changed_yaml = changed_yaml or bool(ky)
+                    # ... but apply it INSTANTLY by editing the served URDF in
+                    # place, skipping the inertia-recomputing full build()
+                    ok = _set_limit_in_urdf(cls.pkg_dir, cls.urdf_rel,
+                                            child, lo, hi, cont)
+                    (applied if ok else missed).append(child)
+                if changed_yaml:
+                    _snapshot(cls.pkg_dir, yml, f"limits x{len(applied)}")
                     with open(yml, "w", encoding="utf-8") as f:
                         f.write(txt)
-                    from sw2robot.exporter.export import build
-                    try:
-                        build(cls.pkg_dir, config_path=yml)
-                    except Exception as e:
-                        return self._send_json(
-                            {"error": f"rebuild failed: {e}"}, 500)
                 print(f"[sw2robot.web] set_limits: {len(applied)} applied, "
                       f"{len(missed)} not matched")
                 return self._send_json({"applied": applied, "missed": missed})
@@ -1894,27 +2001,28 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                     txt = f.read()
                 linv = _link_names_inverse(txt)   # display -> component
                 applied, missed = [], []
+                changed_yaml = False
                 for ch in changes:
-                    child = linv.get(ch.get("child"), ch.get("child"))
+                    child = ch.get("child")
                     master = ch.get("master")
                     clear = bool(ch.get("clear"))
                     if not child or (not clear and not master):
                         missed.append(ch)
                         continue
-                    txt, ok = _set_mimic_yaml(
-                        txt, child, master,
-                        ch.get("multiplier", 1.0), ch.get("offset", 0.0), clear)
+                    mult = float(ch.get("multiplier", 1.0))
+                    off = float(ch.get("offset", 0.0))
+                    # persist to joints.yaml ...
+                    txt, ky = _set_mimic_yaml(txt, linv.get(child, child),
+                                              master, mult, off, clear)
+                    changed_yaml = changed_yaml or bool(ky)
+                    # ... and apply instantly in the served URDF (no rebuild)
+                    ok = _set_mimic_in_urdf(cls.pkg_dir, cls.urdf_rel, child,
+                                            master, mult, off, clear)
                     (applied if ok else missed).append(ch)
-                if applied:
+                if changed_yaml:
                     _snapshot(cls.pkg_dir, yml, f"mimic x{len(applied)}")
                     with open(yml, "w", encoding="utf-8") as f:
                         f.write(txt)
-                    from sw2robot.exporter.export import build
-                    try:
-                        build(cls.pkg_dir, config_path=yml)
-                    except Exception as e:
-                        return self._send_json(
-                            {"error": f"rebuild failed: {e}"}, 500)
                 print(f"[sw2robot.web] set_mimic: {len(applied)} applied, "
                       f"{len(missed)} not matched")
                 return self._send_json(

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1380,15 +1380,20 @@ class _Handler(http.server.BaseHTTPRequestHandler):
 
     def _info(self):
         cls = type(self)
-        return {"name": cls.robot_name, "urdf": "/pkg/" + cls.urdf_rel} \
-            if cls.urdf_rel else {"name": None, "urdf": None}
+        if not cls.urdf_rel:
+            return {"name": None, "urdf": None, "mode": None}
+        # 'cad' = joints.yaml + build() path; 'urdf' = direct overlay editing
+        # (the frontend gates URDF-only controls such as inertial editing on this)
+        return {"name": cls.robot_name, "urdf": "/pkg/" + cls.urdf_rel,
+                "mode": "cad" if _cad_mode(cls.pkg_dir) else "urdf"}
 
     def _um_reply(self, fn, *args):
-        """Run a URDF-mode edit and JSON-reply, turning a validation error into a
-        400 the editor surfaces (rather than the generic 500)."""
+        """Run a URDF-mode edit and JSON-reply, turning a bad-input error into a
+        400 the editor surfaces (rather than the generic 500) -- TypeError covers
+        a malformed body, e.g. a null in the com/inertia arrays."""
         try:
             return self._send_json(fn(_um["state"], *args))
-        except ValueError as e:
+        except (ValueError, TypeError) as e:
             return self._send_json({"error": str(e)}, 400)
 
     # -- routes -----------------------------------------------------------

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -144,8 +144,10 @@ def _resolve_package(path):
         for sub in ("urdf", "."):
             d = os.path.normpath(os.path.join(path, sub))
             if os.path.isdir(d):
+                # skip dotfiles -- e.g. the hidden .<name>.live.urdf overlay copy
                 urdfs = sorted(f for f in os.listdir(d)
-                               if f.lower().endswith(".urdf"))
+                               if f.lower().endswith(".urdf")
+                               and not f.startswith("."))
                 if urdfs:
                     rel = os.path.relpath(os.path.join(d, urdfs[0]), path)
                     return path, rel.replace("\\", "/")
@@ -161,7 +163,10 @@ def _resolve_package(path):
 # the headless CLI uses.  The URDF URL is served as build_urdf(state), so the
 # on-disk .urdf stays the pristine base: the declarative overlay re-applies
 # cleanly on every request and survives a restart via the .sw2robot.json sidecar.
-_um = {"state": None}     # RobotCompilerState for the current URDF-mode package
+# ``rev`` bumps on every edit so on-disk readers (collision / auto-limits) can
+# cache against a stable (path, mtime) -- the live URDF is only rewritten when
+# ``rev`` actually changed (see _um_live_urdf).
+_um = {"state": None, "rev": 0, "live_rev": -1}
 
 
 def _cad_mode(pkg_dir):
@@ -177,15 +182,57 @@ def _um_load(pkg_dir, urdf_rel):
     state = core.load_module(os.path.join(pkg_dir, urdf_rel), package_dir=pkg_dir)
     core.load_edits(state)            # restore a prior session's edits, if any
     _um["state"] = state
+    _um["rev"], _um["live_rev"] = 0, -1
     return state
 
 
 def _um_save(state):
     from . import core
+    _um["rev"] += 1                   # invalidate the live URDF / disk caches
     try:
         core.save_state(state)
     except OSError:
         pass                          # persistence is best-effort
+
+
+def _um_live_urdf(pkg_dir, urdf_rel):
+    """``(abs_path, rel)`` of a hidden, overlay-applied copy of the URDF kept in
+    sync with the in-memory edits -- for on-disk readers that take a URDF path
+    (the self-collision build, the auto-limit subprocess).  In CAD mode (or with
+    no overlay) returns the package URDF itself.  Regenerated only when edits
+    changed, so a caller's ``(path, mtime)`` cache key stays stable across polls;
+    sits next to the base so the relative ``../meshes`` references still resolve."""
+    if _cad_mode(pkg_dir) or _um["state"] is None:
+        return os.path.join(pkg_dir, *urdf_rel.split("/")), urdf_rel
+    from . import core
+    d, base = posixpath.dirname(urdf_rel), posixpath.basename(urdf_rel)
+    stem = base[:-len(".urdf")] if base.lower().endswith(".urdf") else base
+    live_rel = posixpath.join(d, f".{stem}.live.urdf") if d else f".{stem}.live.urdf"
+    live_path = os.path.join(pkg_dir, *live_rel.split("/"))
+    if _um["live_rev"] != _um["rev"] or not os.path.exists(live_path):
+        # atomic replace: an async reader (collision / auto-limits) holding this
+        # path must never see a truncated file mid-rewrite.  The temp also starts
+        # with '.' so a concurrent _resolve_package never picks it as the URDF.
+        data = core.build_urdf(_um["state"], sanitize=False)
+        fd, tmp = tempfile.mkstemp(dir=os.path.dirname(live_path) or ".",
+                                   prefix=".live", suffix=".urdf")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(data)
+            os.replace(tmp, live_path)
+            _um["live_rev"] = _um["rev"]
+        except OSError:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            # tolerate a transient failure (e.g. a Windows lock from a reader)
+            # ONLY when a previous valid live copy remains -- it is at worst one
+            # revision stale and refreshes on the next call; with no copy at all
+            # there is nothing usable to hand out, so signal the failure
+            if not os.path.exists(live_path):
+                raise
+    return live_path, live_rel
 
 
 @contextlib.contextmanager
@@ -1477,11 +1524,9 @@ class _Handler(http.server.BaseHTTPRequestHandler):
             if path == "/api/collision/init":
                 if not cls.pkg_dir:
                     return self._send_json({"error": "no package open"}, 400)
-                # NOTE: in URDF-input mode this reads the pristine on-disk URDF,
-                # not the live overlay -- collision against unsaved type/axis
-                # edits is a known limitation (these optional skrobot/fcl features
-                # need async-safe materialization; tracked for a follow-up).
-                urdf_path = os.path.join(cls.pkg_dir, cls.urdf_rel)
+                # URDF-input mode: collide against the live overlay (type/axis
+                # edits included), not the pristine on-disk base
+                urdf_path, _ = _um_live_urdf(cls.pkg_dir, cls.urdf_rel)
                 key = (urdf_path, os.path.getmtime(urdf_path))
                 with _coll_lock:
                     if _coll["key"] != key or (
@@ -1503,18 +1548,23 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 # Started ASYNC so the page can poll /api/auto_limits/status for
                 # per-joint progress while it runs (the sweep is in the child
                 # process, so polling no longer thrashes its GIL).  One at a time.
-                # NOTE: like /api/collision/init, the sweep reads the pristine
-                # on-disk URDF in URDF-input mode (not the live overlay) -- a
-                # known limitation tracked for a follow-up.
                 if not cls.pkg_dir:
                     return self._send_json({"error": "no package open"}, 400)
-                # parse BEFORE claiming the job, so a bad step/max can't wedge
-                # the "running" flag (no worker would start to clear it)
+                # parse + materialize BEFORE claiming the job, so a bad step/max
+                # or a live-URDF write failure can't wedge the "running" flag
+                # (no worker would start to clear it)
                 try:
                     step = float((query.get("step") or ["10"])[0])
                     mx = float((query.get("max") or ["360"])[0])  # ±2π
                 except ValueError:
                     return self._send_json({"error": "bad step/max"}, 400)
+                # URDF-input mode: sweep the live overlay (type edits included)
+                try:
+                    pkg = cls.pkg_dir
+                    _, rel = _um_live_urdf(cls.pkg_dir, cls.urdf_rel)
+                except Exception as e:
+                    return self._send_json(
+                        {"error": f"could not prepare URDF: {e}"}, 500)
                 with _limjob_lock:
                     if _limjob["running"]:
                         return self._send_json(
@@ -1522,7 +1572,6 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                     _limjob.update(running=True, log=[], error=None,
                                    results=None, n=0, total=0, joint=None,
                                    phase="loading")
-                pkg, rel = cls.pkg_dir, cls.urdf_rel
 
                 # NB: must NOT be named `_job` -- that shadows the module-global
                 # `_job` (the extraction job) across this whole method and breaks
@@ -1606,6 +1655,17 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 ros_version = int(ros)
                 pkg_name = (query.get("name") or [""])[0].strip() or None
                 urdf_name = (query.get("urdf") or [""])[0].strip() or None
+                # the ROS exporter hardcodes the urdf/<robot_name>.urdf + meshes/
+                # layout; in URDF-input mode the opened file may sit elsewhere, so
+                # fail clearly instead of with a confusing missing-file 500
+                if not _cad_mode(cls.pkg_dir) \
+                        and os.path.normpath(os.path.join(cls.pkg_dir, cls.urdf_rel)) \
+                        != os.path.normpath(os.path.join(
+                            cls.pkg_dir, "urdf", cls.robot_name + ".urdf")):
+                    return self._send_json(
+                        {"error": "export needs the standard "
+                         "<pkg>/urdf/<name>.urdf + <pkg>/meshes/ layout; open the "
+                         "URDF from inside a urdf/ folder"}, 400)
                 try:
                     # URDF-input mode keeps the on-disk URDF pristine and serves
                     # edits live; materialize them so the exporter picks them up

--- a/sw2robot/exporter/ros_export.py
+++ b/sw2robot/exporter/ros_export.py
@@ -35,12 +35,15 @@ from .urdf_writer import (
 )
 
 # extensions we convert; anything else (already .dae/.stl, abs URLs) is left alone
-_CONVERTIBLE = (".3dxml", ".glb")
+# source mesh formats we can load + reconvert: CAD output (.3dxml mm, .glb m)
+# plus the common URDF mesh formats (.stl/.dae/.obj, already in metres), so a
+# URDF opened for re-export ships as a normal <name>_description package too.
+_CONVERTIBLE = (".3dxml", ".glb", ".stl", ".dae", ".obj")
 
 
 def _load_mesh_metres(src):
-    """Load a ``.3dxml`` (mm) or ``.glb`` (m) mesh, flatten any scene to a single
-    geometry, and return it pinned to metres."""
+    """Load a mesh (``.3dxml`` is mm, everything else is already metres), flatten
+    any scene to a single geometry, and return it pinned to metres."""
     import trimesh
 
     loaded = trimesh.load(src)
@@ -165,26 +168,103 @@ def _collada_meshes(mesh):
     return out
 
 
-def _resolve_mesh(pkg_dir, ref):
+def _dae_sidecar_images(dae_path):
+    """Relative sidecar image paths a COLLADA ``.dae`` references via
+    ``<init_from>`` (textures), so a verbatim copy can ship them too.  Best
+    effort: ``[]`` on any parse trouble."""
+    try:
+        root = ET.parse(dae_path).getroot()
+    except Exception:
+        return []
+    out = []
+    for el in root.iter():
+        if not el.tag.endswith("init_from"):
+            continue
+        ref = (el.text or "").strip()
+        if not ref:                              # COLLADA 1.5 nests <ref>
+            child = next((c for c in el if c.tag.endswith("ref")), None)
+            ref = (child.text or "").strip() if child is not None else ""
+        ref = ref.replace("\\", "/")
+        if ref.startswith("file://"):
+            ref = ref[len("file://"):]
+        # only relative sidecars next to the mesh; skip absolute (incl. Windows
+        # drive), URL and parent-escaping refs
+        if (ref and "://" not in ref and not ref.startswith("/")
+                and not re.match(r"^[A-Za-z]:", ref) and ".." not in ref):
+            out.append(ref)
+    return out
+
+
+def _own_pkg_names(pkg_dir):
+    """The names by which the opened package may refer to its OWN meshes: the
+    ROS manifest ``<name>`` (authoritative) plus the directory basename (a
+    fallback / second accepted alias).  A ``package://<name>/...`` ref counts as
+    ours only when ``<name>`` is one of these."""
+    names = {os.path.basename(os.path.normpath(pkg_dir))}
+    mani = os.path.join(pkg_dir, "package.xml")
+    if os.path.exists(mani):
+        try:
+            n = ET.parse(mani).getroot().findtext("name")
+            if n and n.strip():
+                names.add(n.strip())
+        except Exception:
+            pass
+    return names
+
+
+def _resolve_mesh(pkg_dir, ref, own_pkgs=None):
     """``(base, source_path, ext)`` for a URDF mesh ref, or ``(None, ...)`` when it
     is not one of our convertible meshes; ``source_path`` is None if the file is
-    missing."""
-    if not ref or "://" in ref:
+    missing.
+
+    Resolve the ref to a path-within-the-package, preserving subdirectories:
+      - package://<pkg>/<rest>      -> <rest>  (a URDF opened for re-export)
+      - relative '../meshes/x.dae'  -> 'meshes/x.dae'  (the CAD working URDF)
+    Other schemes (http://, file://) are external -- left untouched.  A
+    ``package://<pkg>`` ref is only treated as ours when ``<pkg>`` is in
+    ``own_pkgs`` (the opened package's names); a ref to ANOTHER ROS package is an
+    external dependency and is left as-is even if a same-named file happens to
+    exist here.
+    """
+    if not ref:
         return None, None, None
-    base, ext = os.path.splitext(os.path.basename(ref))
+    ref = ref.replace("\\", "/")           # tolerate Windows-style separators
+    is_pkg = "://" in ref
+    root = os.path.normpath(pkg_dir)
+    if is_pkg:
+        if not ref.startswith("package://"):
+            return None, None, None
+        ref_pkg, _, rel = ref.split("://", 1)[1].partition("/")
+        if own_pkgs is not None and ref_pkg not in own_pkgs:
+            return None, None, None        # another package's mesh -- leave it
+        base_dir = root                    # package:// is relative to the pkg root
+    else:
+        if ref.startswith("/") or re.match(r"^[A-Za-z]:", ref):
+            return None, None, None        # absolute path -> external, leave it
+        rel = ref                          # keep '../' so the escape check is real
+        base_dir = os.path.join(root, "urdf")   # the CAD/working URDF lives here
+    base, ext = os.path.splitext(os.path.basename(rel))
     if ext.lower() not in _CONVERTIBLE:
         return None, None, None
-    meshes = os.path.join(pkg_dir, "meshes")
-    src = os.path.join(meshes, base + ext)
+    src = os.path.normpath(os.path.join(base_dir, *rel.split("/")))
+    try:
+        escapes = os.path.commonpath([root, src]) != root
+    except ValueError:                     # different drive (Windows) -> external
+        escapes = True
+    if escapes:
+        return None, None, None            # a '..' escaping the package -> external
     if not os.path.exists(src):
         # the URDF may name one extension while only the other was produced
         # (a sub-assembly composed to .glb, say); accept whichever exists
+        stem = os.path.splitext(src)[0]
         for alt_ext in _CONVERTIBLE:
-            alt = os.path.join(meshes, base + alt_ext)
-            if os.path.exists(alt):
-                src = alt
+            if os.path.exists(stem + alt_ext):
+                src = stem + alt_ext
                 break
         else:
+            # external refs were already returned above; reaching here means an
+            # OWN mesh (relative, or package:// matching own_pkg) is missing -- a
+            # real error the caller surfaces as 'no source mesh'
             return base, None, ext
     return base, src, ext
 
@@ -261,39 +341,75 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
         raise ValueError(f"unsupported ros_version: {ros_version}")
     pkg = ros_pkg_name(robot_name, pkg_name)
     urdf_stem = ros_urdf_stem(pkg, urdf_name)
+    # the opened package's own name(s) -- only package:// refs to one of these
+    # are vendored/repointed; refs to other ROS packages are left untouched
+    own_pkgs = _own_pkg_names(pkg_dir)
     urdf_path = os.path.join(pkg_dir, "urdf", robot_name + ".urdf")
     root = ET.parse(urdf_path).getroot()
     colors = colors or {}
 
     files = []
-    done = {}          # (base, fmt) -> arcname  (instances + visual/collision share)
+    # keyed by the SOURCE mesh (+fmt), so one source converted once is reused,
+    # but two DISTINCT sources that happen to share a basename get distinct output
+    # names instead of silently overwriting each other (e.g. a visual part.dae and
+    # a collision part.stl both targeting part.glb).
+    done = {}          # (abs_src, fmt, color) -> output mesh name ('part.glb')
+    used_names = set()
     errors = []
 
-    def _emit(base, src, fmt):
-        if (base, fmt) in done:
-            return
+    def _emit(base, src, fmt, color):
+        # key on colour too: the same source reused by two links with DIFFERENT
+        # colour overrides must emit two distinct (differently-coloured) meshes
+        key = (os.path.abspath(src), fmt, color)
+        if key in done:
+            return done[key]
+        name, i = f"{base}.{fmt}", 1
+        while name in used_names:              # distinct source, same basename
+            i += 1
+            name = f"{base}_{i}.{fmt}"
         try:
-            data = _CONVERT[fmt](src, color=colors.get(base))
+            if src.lower().endswith(f".{fmt}") and not color:
+                # already the target format and no colour override: copy the mesh
+                # verbatim (a URDF re-export shipping its own .dae/.stl) -- avoids
+                # a lossy + sometimes-failing trimesh round-trip
+                with open(src, "rb") as f:
+                    data = f.read()
+                if fmt == "dae":             # ship the .dae's sidecar textures too
+                    dae_dir = os.path.dirname(src)
+                    for rel in _dae_sidecar_images(src):
+                        img = os.path.normpath(os.path.join(dae_dir, rel))
+                        arc = f"{pkg}/meshes/{rel}"
+                        if os.path.exists(img) and arc not in used_names:
+                            with open(img, "rb") as f:
+                                files.append((arc, f.read()))
+                            used_names.add(arc)
+            else:
+                data = _CONVERT[fmt](src, color=color)
         except Exception as e:
             errors.append(f"{base}: {fmt} convert failed ({e!r})")
-            return
-        arc = f"{pkg}/meshes/{base}.{fmt}"
-        files.append((arc, data))
-        done[(base, fmt)] = arc
+            return None
+        used_names.add(name)
+        files.append((f"{pkg}/meshes/{name}", data))
+        done[key] = name
+        return name
 
     for link in root.findall("link"):
+        # colour overrides are keyed by LINK name in URDF-input mode and by the
+        # component/mesh basename in the CAD path -- accept either
+        link_color = colors.get(link.get("name"))
         for ctx, fmt in ctx_fmt:
             for block in link.findall(ctx):
                 for mesh in block.iter("mesh"):
-                    base, src, _ext = _resolve_mesh(pkg_dir, mesh.get("filename"))
+                    base, src, _ext = _resolve_mesh(pkg_dir, mesh.get("filename"),
+                                                    own_pkgs=own_pkgs)
                     if base is None:
                         continue           # not a convertible ref -- leave as-is
                     if src is None:
                         errors.append(f"no source mesh for '{base}'")
                         continue
-                    _emit(base, src, fmt)
-                    mesh.set("filename",
-                             f"package://{pkg}/meshes/{base}.{fmt}")
+                    name = _emit(base, src, fmt, link_color or colors.get(base))
+                    if name is not None:
+                        mesh.set("filename", f"package://{pkg}/meshes/{name}")
 
     if errors:
         raise RuntimeError("ROS description export failed: " + "; ".join(errors))

--- a/tests/e2e/fixtures/boxbot/urdf/boxbot.urdf
+++ b/tests/e2e/fixtures/boxbot/urdf/boxbot.urdf
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<robot name="boxbot">
+  <link name="base_link">
+    <visual><geometry><box size="0.1 0.1 0.1"/></geometry></visual>
+  </link>
+  <link name="tip">
+    <visual><geometry><box size="0.05 0.05 0.2"/></geometry></visual>
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.3"/>
+      <inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
+    </inertial>
+  </link>
+  <joint name="j" type="revolute">
+    <origin xyz="0 0 0.1" rpy="0 0 0"/>
+    <parent link="base_link"/><child link="tip"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-1" upper="1" effort="10" velocity="3"/>
+  </joint>
+</robot>

--- a/tests/e2e/run.mjs
+++ b/tests/e2e/run.mjs
@@ -86,11 +86,18 @@ const sel = await page.evaluate(() => {
   return { bar: document.getElementById('selbar').style.display === 'flex',
            shown: r.width > 50 && r.height > 30,
            x: Math.round(r.x), y: Math.round(r.y),
-           text: li.textContent.length };
+           text: li.textContent.length,
+           // the card must be interactive so it can SCROLL to controls below the
+           // fold (a tall per-link panel) -- pointer-events:none let scroll pass
+           // through to the 3D view, stranding the colour/inertial editors
+           pe: getComputedStyle(li).pointerEvents,
+           overflow: getComputedStyle(li).overflowY };
 });
 check('select: selbar visible', sel.bar);
 check('select: info card rendered top-left', sel.shown && sel.x < 50 && sel.y < 200,
       `rect=(${sel.x},${sel.y}) chars=${sel.text}`);
+check('select: info card is scrollable (interactive)',
+      sel.pe === 'auto' && sel.overflow === 'auto', `pe=${sel.pe} of=${sel.overflow}`);
 
 // ---- 3. selbar eye toggles the link's meshes -------------------------------
 const meshState = () => page.evaluate(t => {

--- a/tests/e2e/verify_inertial.mjs
+++ b/tests/e2e/verify_inertial.mjs
@@ -1,0 +1,113 @@
+// Browser E2E for URDF-input mode inertial editing, against a box-geometry URDF
+// (no meshes, so no glb-conversion deps -- the viewer renders the boxes itself).
+//
+// Prereqs:
+//   1. server:  uv run python -m sw2robot.editor.webserver \
+//                 tests/e2e/fixtures/boxbot --port 8099
+//   2. once:    cd tests/e2e && npm i
+// Run:
+//   node tests/e2e/verify_inertial.mjs [url]
+import puppeteer from 'puppeteer-core';
+
+const BASE = process.argv[2] ?? 'http://127.0.0.1:8099';
+const CHROME = process.env.CHROME_PATH
+  ?? 'C:/Program Files/Google/Chrome/Application/chrome.exe';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+let fails = 0;
+const check = (n, ok, d = '') => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${n}${d ? '  -- ' + d : ''}`);
+  if (!ok) { fails += 1; }
+};
+
+// CI (headless Linux) passes --no-sandbox etc. via CHROME_ARGS; local runs leave
+// it unset and keep the default flags.
+const EXTRA_ARGS = (process.env.CHROME_ARGS ?? '')
+  .split(',').map(s => s.trim()).filter(Boolean);
+const browser = await puppeteer.launch({
+  executablePath: CHROME, headless: 'new',
+  args: ['--disable-gpu', ...EXTRA_ARGS] });
+const page = await browser.newPage();
+const errs = [];
+page.on('pageerror', e => errs.push(e.message.split('\n')[0]));
+
+await page.goto(BASE + '?lang=en', { waitUntil: 'domcontentloaded', timeout: 60000 });
+await page.waitForFunction(
+  () => document.getElementById('viewer')?.robot?.links?.tip,
+  { timeout: 60000 }).catch(() => {});
+await sleep(1000);
+check('no page errors', errs.length === 0, errs[0] ?? '');
+
+const mode = await page.evaluate(async () =>
+  (await (await fetch('/api/info')).json()).mode);
+check('info.mode == urdf', mode === 'urdf', `mode=${mode}`);
+
+// select link 'tip' by clicking joint j's row (selects the child link)
+await page.evaluate(() => {
+  [...document.querySelectorAll('.joint:not(.root)')]
+    .find(r => r.querySelector('.jname')?.textContent === 'tip')
+    .querySelector('.jname').click();
+});
+await sleep(700);
+
+const ui = await page.evaluate(() => ({
+  mass: document.getElementById('li_mass')?.value,
+  hasApply: !!document.getElementById('li_inertial_apply'),
+  hasIxx: !!document.getElementById('li_ixx'),
+  cz: document.getElementById('li_cz')?.value,
+}));
+check('inertial editor rendered', ui.hasApply && ui.hasIxx, JSON.stringify(ui));
+check('mass prefilled from URDF', ui.mass === '0.3', `mass=${ui.mass}`);
+
+// edit mass + CoM, then apply
+await page.evaluate(() => {
+  document.getElementById('li_mass').value = '0.75';
+  document.getElementById('li_cz').value = '0.05';
+});
+await page.click('#li_inertial_apply');
+await sleep(2500);                       // loadRobot rebuild + reselect
+
+const urdf = await page.evaluate(async () => {
+  const i = await (await fetch('/api/info')).json();
+  return await (await fetch(i.urdf)).text();
+});
+check('served URDF carries the new mass', /value="0\.75"/.test(urdf),
+      (urdf.match(/<mass[^>]*>/g) ?? []).join(' '));
+check('served URDF carries the new CoM',
+      /xyz="0 0 0\.05"/.test(urdf),
+      (urdf.match(/<origin[^>]*xyz="[^"]*"[^>]*\/>/g) ?? []).slice(-1)[0] ?? '');
+
+// empty-field guard: clearing a field must not 500
+await page.evaluate(() => {
+  [...document.querySelectorAll('.joint:not(.root)')]
+    .find(r => r.querySelector('.jname')?.textContent === 'tip')
+    .querySelector('.jname').click();
+});
+await sleep(600);
+await page.evaluate(() => { document.getElementById('li_ixx').value = ''; });
+await page.click('#li_inertial_apply');
+await sleep(800);
+const logTxt = await page.evaluate(() =>
+  [...document.querySelectorAll('#log div')].map(d => d.textContent).join('\n'));
+check('empty field caught client-side', /must be a number/.test(logTxt),
+      logTxt.split('\n').slice(-2).join(' | '));
+
+// restore the fixture's pristine inertial (like run.mjs, leave no edits behind)
+// so a re-run against the same checkout still starts from mass 0.3
+await page.evaluate(() => {
+  [...document.querySelectorAll('.joint:not(.root)')]
+    .find(r => r.querySelector('.jname')?.textContent === 'tip')
+    .querySelector('.jname').click();
+});
+await sleep(500);
+await page.evaluate(() => {
+  const set = (id, v) => { document.getElementById(id).value = v; };
+  set('li_mass', '0.3'); set('li_cx', '0'); set('li_cy', '0'); set('li_cz', '0');
+  set('li_ixx', '0.001'); set('li_ixy', '0'); set('li_ixz', '0');
+  set('li_iyy', '0.001'); set('li_iyz', '0'); set('li_izz', '0.001');
+});
+await page.click('#li_inertial_apply');
+await sleep(1500);
+
+await browser.close();
+console.log(fails ? `\n${fails} CHECK(S) FAILED` : '\nALL CHECKS PASS');
+process.exit(fails ? 1 : 0);

--- a/tests/golden/fingertip_base.urdf
+++ b/tests/golden/fingertip_base.urdf
@@ -13,11 +13,7 @@
         <mesh filename="../meshes/fingertip_back_1.3dxml"/>
       </geometry>
     </collision>
-    <inertial>
-      <origin xyz="0 0 0" rpy="0 0 0"/>
-      <mass value="0.1"/>
-      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
-    </inertial>
+    <inertial/>
   </link>
   <link name="base_link">
     <visual>
@@ -32,11 +28,7 @@
         <mesh filename="../meshes/fingertip_front_2.3dxml"/>
       </geometry>
     </collision>
-    <inertial>
-      <origin xyz="0 0 0" rpy="0 0 0"/>
-      <mass value="0.1"/>
-      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
-    </inertial>
+    <inertial/>
   </link>
   <link name="screwlock_male_hard_jointbase_v4_1">
     <visual>
@@ -51,11 +43,7 @@
         <mesh filename="../meshes/screwlock_male_hard_jointbase_v4_1.3dxml"/>
       </geometry>
     </collision>
-    <inertial>
-      <origin xyz="0 0 0" rpy="0 0 0"/>
-      <mass value="0.1"/>
-      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
-    </inertial>
+    <inertial/>
   </link>
   <joint name="fingertip_front_2__screwlock_male_hard_jointbase_v4_1" type="fixed">
     <origin xyz="7.0484173e-18 -0.0155 0.038" rpy="1.5707963 -3.3306691e-16 -3.1415927"/>

--- a/tests/golden/fingertip_base.urdf
+++ b/tests/golden/fingertip_base.urdf
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<robot name="fingertip">
+  <link name="fingertip_back_1">
+    <visual>
+      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 -5.5511151e-17 3.1415927"/>
+      <geometry>
+        <mesh filename="../meshes/fingertip_back_1.3dxml"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 -5.5511151e-17 3.1415927"/>
+      <geometry>
+        <mesh filename="../meshes/fingertip_back_1.3dxml"/>
+      </geometry>
+    </collision>
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.1"/>
+      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
+    </inertial>
+  </link>
+  <link name="base_link">
+    <visual>
+      <origin xyz="3.8518599e-34 0 0" rpy="0 -0 -4.4572704e-33"/>
+      <geometry>
+        <mesh filename="../meshes/fingertip_front_2.3dxml"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="3.8518599e-34 0 0" rpy="0 -0 -4.4572704e-33"/>
+      <geometry>
+        <mesh filename="../meshes/fingertip_front_2.3dxml"/>
+      </geometry>
+    </collision>
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.1"/>
+      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
+    </inertial>
+  </link>
+  <link name="screwlock_male_hard_jointbase_v4_1">
+    <visual>
+      <origin xyz="0 0 -1.540744e-33" rpy="5.0814364e-33 2.4652673e-34 -6.3441378e-33"/>
+      <geometry>
+        <mesh filename="../meshes/screwlock_male_hard_jointbase_v4_1.3dxml"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="0 0 -1.540744e-33" rpy="5.0814364e-33 2.4652673e-34 -6.3441378e-33"/>
+      <geometry>
+        <mesh filename="../meshes/screwlock_male_hard_jointbase_v4_1.3dxml"/>
+      </geometry>
+    </collision>
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.1"/>
+      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
+    </inertial>
+  </link>
+  <joint name="fingertip_front_2__screwlock_male_hard_jointbase_v4_1" type="fixed">
+    <origin xyz="7.0484173e-18 -0.0155 0.038" rpy="1.5707963 -3.3306691e-16 -3.1415927"/>
+    <parent link="base_link"/>
+    <child link="screwlock_male_hard_jointbase_v4_1"/>
+    <axis xyz="-0 -0 1"/>
+    <!-- mates: CONCENTRIC, COINCIDENT, PARALLEL, CONCENTRIC, COINCIDENT, PARALLEL -->
+  </joint>
+  <joint name="fingertip_front_2__fingertip_back_1" type="revolute">
+    <origin xyz="0.021039487 -0.0155 0.031" rpy="3.1415927 8.2450846e-17 8.2450846e-17"/>
+    <parent link="base_link"/>
+    <child link="fingertip_back_1"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-3.14159" upper="3.14159" effort="10" velocity="3.14"/>
+    <!-- mates: COINCIDENT, COINCIDENT, COINCIDENT, COINCIDENT -->
+  </joint>
+</robot>

--- a/tests/golden/fingertip_edit.joints.yaml
+++ b/tests/golden/fingertip_edit.joints.yaml
@@ -1,0 +1,26 @@
+# Characterization fixture for the CAD->URDF edit pipeline (Step 0 golden).
+# Exercises the edits that will migrate to the unified overlay: rename
+# (link_names/joint_names), type override, per-joint limits, mimic, colors.
+base: fingertip_front_2
+root_link_name: base_link
+link_names:
+  fingertip_back_1: tip
+joint_names:
+  fingertip_front_2__fingertip_back_1: bend
+colors:
+  fingertip_back_1: '#ff0000'
+joints:
+  - parent: fingertip_front_2
+    child: screwlock_male_hard_jointbase_v4_1
+    type: revolute
+    lower: -0.5
+    upper: 0.5
+  - parent: fingertip_front_2
+    child: fingertip_back_1
+    type: revolute
+    lower: -1.0
+    upper: 1.5
+    mimic:
+      joint: fingertip_front_2__screwlock_male_hard_jointbase_v4_1
+      multiplier: 0.5
+      offset: 0.1

--- a/tests/golden/fingertip_edited.urdf
+++ b/tests/golden/fingertip_edited.urdf
@@ -13,11 +13,7 @@
         <mesh filename="../meshes/fingertip_back_1.3dxml"/>
       </geometry>
     </collision>
-    <inertial>
-      <origin xyz="0 0 0" rpy="0 0 0"/>
-      <mass value="0.1"/>
-      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
-    </inertial>
+    <inertial/>
   </link>
   <link name="base_link">
     <visual>
@@ -32,11 +28,7 @@
         <mesh filename="../meshes/fingertip_front_2.3dxml"/>
       </geometry>
     </collision>
-    <inertial>
-      <origin xyz="0 0 0" rpy="0 0 0"/>
-      <mass value="0.1"/>
-      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
-    </inertial>
+    <inertial/>
   </link>
   <link name="screwlock_male_hard_jointbase_v4_1">
     <visual>
@@ -51,11 +43,7 @@
         <mesh filename="../meshes/screwlock_male_hard_jointbase_v4_1.3dxml"/>
       </geometry>
     </collision>
-    <inertial>
-      <origin xyz="0 0 0" rpy="0 0 0"/>
-      <mass value="0.1"/>
-      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
-    </inertial>
+    <inertial/>
   </link>
   <joint name="fingertip_front_2__screwlock_male_hard_jointbase_v4_1" type="revolute">
     <origin xyz="4.2862638e-18 0.0015 0.035" rpy="3.1415927 8.2450846e-17 8.2450846e-17"/>

--- a/tests/golden/fingertip_edited.urdf
+++ b/tests/golden/fingertip_edited.urdf
@@ -1,0 +1,77 @@
+<?xml version="1.0"?>
+<robot name="fingertip">
+  <link name="tip">
+    <visual>
+      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 -5.5511151e-17 3.1415927"/>
+      <geometry>
+        <mesh filename="../meshes/fingertip_back_1.3dxml"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 -5.5511151e-17 3.1415927"/>
+      <geometry>
+        <mesh filename="../meshes/fingertip_back_1.3dxml"/>
+      </geometry>
+    </collision>
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.1"/>
+      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
+    </inertial>
+  </link>
+  <link name="base_link">
+    <visual>
+      <origin xyz="3.8518599e-34 0 0" rpy="0 -0 -4.4572704e-33"/>
+      <geometry>
+        <mesh filename="../meshes/fingertip_front_2.3dxml"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="3.8518599e-34 0 0" rpy="0 -0 -4.4572704e-33"/>
+      <geometry>
+        <mesh filename="../meshes/fingertip_front_2.3dxml"/>
+      </geometry>
+    </collision>
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.1"/>
+      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
+    </inertial>
+  </link>
+  <link name="screwlock_male_hard_jointbase_v4_1">
+    <visual>
+      <origin xyz="1.1131366e-18 0.017 -0.003" rpy="-1.5707963 2.5061606e-16 -3.1415927"/>
+      <geometry>
+        <mesh filename="../meshes/screwlock_male_hard_jointbase_v4_1.3dxml"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="1.1131366e-18 0.017 -0.003" rpy="-1.5707963 2.5061606e-16 -3.1415927"/>
+      <geometry>
+        <mesh filename="../meshes/screwlock_male_hard_jointbase_v4_1.3dxml"/>
+      </geometry>
+    </collision>
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.1"/>
+      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
+    </inertial>
+  </link>
+  <joint name="fingertip_front_2__screwlock_male_hard_jointbase_v4_1" type="revolute">
+    <origin xyz="4.2862638e-18 0.0015 0.035" rpy="3.1415927 8.2450846e-17 8.2450846e-17"/>
+    <parent link="base_link"/>
+    <child link="screwlock_male_hard_jointbase_v4_1"/>
+    <axis xyz="0 -1 -0"/>
+    <limit lower="-0.5" upper="0.5" effort="10" velocity="3.14"/>
+    <!-- mates: CONCENTRIC, COINCIDENT, PARALLEL, CONCENTRIC, COINCIDENT, PARALLEL -->
+  </joint>
+  <joint name="bend" type="revolute">
+    <origin xyz="0.021039487 -0.0155 0.031" rpy="3.1415927 8.2450846e-17 8.2450846e-17"/>
+    <parent link="base_link"/>
+    <child link="tip"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-1" upper="1.5" effort="10" velocity="3.14"/>
+    <mimic joint="fingertip_front_2__screwlock_male_hard_jointbase_v4_1" multiplier="0.5" offset="0.1"/>
+    <!-- mates: COINCIDENT, COINCIDENT, COINCIDENT, COINCIDENT -->
+  </joint>
+</robot>

--- a/tests/golden/fingertip_flip.urdf
+++ b/tests/golden/fingertip_flip.urdf
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<robot name="fingertip">
+  <link name="fingertip_back_1">
+    <visual>
+      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 -5.5511151e-17 3.1415927"/>
+      <geometry>
+        <mesh filename="../meshes/fingertip_back_1.3dxml"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 -5.5511151e-17 3.1415927"/>
+      <geometry>
+        <mesh filename="../meshes/fingertip_back_1.3dxml"/>
+      </geometry>
+    </collision>
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.1"/>
+      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
+    </inertial>
+  </link>
+  <link name="base_link">
+    <visual>
+      <origin xyz="3.8518599e-34 0 0" rpy="0 -0 -4.4572704e-33"/>
+      <geometry>
+        <mesh filename="../meshes/fingertip_front_2.3dxml"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="3.8518599e-34 0 0" rpy="0 -0 -4.4572704e-33"/>
+      <geometry>
+        <mesh filename="../meshes/fingertip_front_2.3dxml"/>
+      </geometry>
+    </collision>
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.1"/>
+      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
+    </inertial>
+  </link>
+  <link name="screwlock_male_hard_jointbase_v4_1">
+    <visual>
+      <origin xyz="0 0 -1.540744e-33" rpy="5.0814364e-33 2.4652673e-34 -6.3441378e-33"/>
+      <geometry>
+        <mesh filename="../meshes/screwlock_male_hard_jointbase_v4_1.3dxml"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="0 0 -1.540744e-33" rpy="5.0814364e-33 2.4652673e-34 -6.3441378e-33"/>
+      <geometry>
+        <mesh filename="../meshes/screwlock_male_hard_jointbase_v4_1.3dxml"/>
+      </geometry>
+    </collision>
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.1"/>
+      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
+    </inertial>
+  </link>
+  <joint name="fingertip_front_2__screwlock_male_hard_jointbase_v4_1" type="fixed">
+    <origin xyz="7.0484173e-18 -0.0155 0.038" rpy="1.5707963 -3.3306691e-16 -3.1415927"/>
+    <parent link="base_link"/>
+    <child link="screwlock_male_hard_jointbase_v4_1"/>
+    <axis xyz="-0 -0 1"/>
+    <!-- mates: CONCENTRIC, COINCIDENT, PARALLEL, CONCENTRIC, COINCIDENT, PARALLEL -->
+  </joint>
+  <joint name="fingertip_front_2__fingertip_back_1" type="revolute">
+    <origin xyz="0.021039487 -0.0155 0.031" rpy="3.1415927 8.2450846e-17 8.2450846e-17"/>
+    <parent link="base_link"/>
+    <child link="fingertip_back_1"/>
+    <axis xyz="0 -1 0"/>
+    <limit lower="-3.14159" upper="3.14159" effort="10" velocity="3.14"/>
+    <!-- mates: COINCIDENT, COINCIDENT, COINCIDENT, COINCIDENT -->
+  </joint>
+</robot>

--- a/tests/golden/fingertip_flip.urdf
+++ b/tests/golden/fingertip_flip.urdf
@@ -13,11 +13,7 @@
         <mesh filename="../meshes/fingertip_back_1.3dxml"/>
       </geometry>
     </collision>
-    <inertial>
-      <origin xyz="0 0 0" rpy="0 0 0"/>
-      <mass value="0.1"/>
-      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
-    </inertial>
+    <inertial/>
   </link>
   <link name="base_link">
     <visual>
@@ -32,11 +28,7 @@
         <mesh filename="../meshes/fingertip_front_2.3dxml"/>
       </geometry>
     </collision>
-    <inertial>
-      <origin xyz="0 0 0" rpy="0 0 0"/>
-      <mass value="0.1"/>
-      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
-    </inertial>
+    <inertial/>
   </link>
   <link name="screwlock_male_hard_jointbase_v4_1">
     <visual>
@@ -51,11 +43,7 @@
         <mesh filename="../meshes/screwlock_male_hard_jointbase_v4_1.3dxml"/>
       </geometry>
     </collision>
-    <inertial>
-      <origin xyz="0 0 0" rpy="0 0 0"/>
-      <mass value="0.1"/>
-      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
-    </inertial>
+    <inertial/>
   </link>
   <joint name="fingertip_front_2__screwlock_male_hard_jointbase_v4_1" type="fixed">
     <origin xyz="7.0484173e-18 -0.0155 0.038" rpy="1.5707963 -3.3306691e-16 -3.1415927"/>

--- a/tests/golden/fingertip_rename_direct.urdf
+++ b/tests/golden/fingertip_rename_direct.urdf
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<robot name="fingertip">
+  <link name="tip">
+    <visual>
+      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 -5.5511151e-17 3.1415927"/>
+      <geometry>
+        <mesh filename="../meshes/fingertip_back_1.3dxml"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 -5.5511151e-17 3.1415927"/>
+      <geometry>
+        <mesh filename="../meshes/fingertip_back_1.3dxml"/>
+      </geometry>
+    </collision>
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.1"/>
+      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
+    </inertial>
+  </link>
+  <link name="base_link">
+    <visual>
+      <origin xyz="3.8518599e-34 0 0" rpy="0 -0 -4.4572704e-33"/>
+      <geometry>
+        <mesh filename="../meshes/fingertip_front_2.3dxml"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="3.8518599e-34 0 0" rpy="0 -0 -4.4572704e-33"/>
+      <geometry>
+        <mesh filename="../meshes/fingertip_front_2.3dxml"/>
+      </geometry>
+    </collision>
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.1"/>
+      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
+    </inertial>
+  </link>
+  <link name="screwlock_male_hard_jointbase_v4_1">
+    <visual>
+      <origin xyz="0 0 -1.540744e-33" rpy="5.0814364e-33 2.4652673e-34 -6.3441378e-33"/>
+      <geometry>
+        <mesh filename="../meshes/screwlock_male_hard_jointbase_v4_1.3dxml"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="0 0 -1.540744e-33" rpy="5.0814364e-33 2.4652673e-34 -6.3441378e-33"/>
+      <geometry>
+        <mesh filename="../meshes/screwlock_male_hard_jointbase_v4_1.3dxml"/>
+      </geometry>
+    </collision>
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.1"/>
+      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
+    </inertial>
+  </link>
+  <joint name="fingertip_front_2__screwlock_male_hard_jointbase_v4_1" type="fixed">
+    <origin xyz="7.0484173e-18 -0.0155 0.038" rpy="1.5707963 -3.3306691e-16 -3.1415927"/>
+    <parent link="base_link"/>
+    <child link="screwlock_male_hard_jointbase_v4_1"/>
+    <axis xyz="-0 -0 1"/>
+    <!-- mates: CONCENTRIC, COINCIDENT, PARALLEL, CONCENTRIC, COINCIDENT, PARALLEL -->
+  </joint>
+  <joint name="bend" type="revolute">
+    <origin xyz="0.021039487 -0.0155 0.031" rpy="3.1415927 8.2450846e-17 8.2450846e-17"/>
+    <parent link="base_link"/>
+    <child link="tip"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-3.14159" upper="3.14159" effort="10" velocity="3.14"/>
+    <!-- mates: COINCIDENT, COINCIDENT, COINCIDENT, COINCIDENT -->
+  </joint>
+</robot>

--- a/tests/golden/fingertip_rename_direct.urdf
+++ b/tests/golden/fingertip_rename_direct.urdf
@@ -13,11 +13,7 @@
         <mesh filename="../meshes/fingertip_back_1.3dxml"/>
       </geometry>
     </collision>
-    <inertial>
-      <origin xyz="0 0 0" rpy="0 0 0"/>
-      <mass value="0.1"/>
-      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
-    </inertial>
+    <inertial/>
   </link>
   <link name="base_link">
     <visual>
@@ -32,11 +28,7 @@
         <mesh filename="../meshes/fingertip_front_2.3dxml"/>
       </geometry>
     </collision>
-    <inertial>
-      <origin xyz="0 0 0" rpy="0 0 0"/>
-      <mass value="0.1"/>
-      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
-    </inertial>
+    <inertial/>
   </link>
   <link name="screwlock_male_hard_jointbase_v4_1">
     <visual>
@@ -51,11 +43,7 @@
         <mesh filename="../meshes/screwlock_male_hard_jointbase_v4_1.3dxml"/>
       </geometry>
     </collision>
-    <inertial>
-      <origin xyz="0 0 0" rpy="0 0 0"/>
-      <mass value="0.1"/>
-      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
-    </inertial>
+    <inertial/>
   </link>
   <joint name="fingertip_front_2__screwlock_male_hard_jointbase_v4_1" type="fixed">
     <origin xyz="7.0484173e-18 -0.0155 0.038" rpy="1.5707963 -3.3306691e-16 -3.1415927"/>

--- a/tests/test_cad_mode_webserver.py
+++ b/tests/test_cad_mode_webserver.py
@@ -1,0 +1,176 @@
+"""Integration tests for the CAD-mode edit endpoints that were migrated off the
+full ``build()`` rebuild onto an instant in-place URDF edit (set_limits,
+set_mimic) -- the same pattern flip/rename already use.  joints.yaml is still
+written (persistence / re-extract / undo); the served URDF reflects the edit
+without recomputing inertia.
+
+Drives a real in-process HTTP server against a freshly-built copy of the
+committed fingertip example (which HAS a graph.json, so it is a CAD package).
+"""
+
+import json
+import shutil
+import threading
+import urllib.request
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FINGERTIP = REPO_ROOT / "examples" / "fingertip"
+
+REV_JOINT = "fingertip_front_2__fingertip_back_1"
+FIXED_JOINT = "fingertip_front_2__screwlock_male_hard_jointbase_v4_1"
+TIP_LINK = "fingertip_back_1"
+SCREW_LINK = "screwlock_male_hard_jointbase_v4_1"
+
+
+def _require_fixture():
+    if not (FINGERTIP / "graph.json").is_file():
+        pytest.skip("missing fingertip fixture")
+
+
+@pytest.fixture(scope="module")
+def _built_cad(tmp_path_factory):
+    """Build the fingertip CAD package ONCE (graph.json + meshes + urdf +
+    joints.yaml)."""
+    _require_fixture()
+    from sw2robot.exporter.export import build
+
+    pkg = tmp_path_factory.mktemp("cad")
+    (pkg / "meshes").mkdir()
+    shutil.copy2(FINGERTIP / "graph.json", pkg / "graph.json")
+    for f in (FINGERTIP / "meshes").iterdir():
+        if f.is_file():
+            shutil.copy2(f, pkg / "meshes" / f.name)
+    build(str(pkg))
+    return pkg
+
+
+@pytest.fixture
+def server(_built_cad, tmp_path):
+    from sw2robot.editor import webserver
+
+    pkg = tmp_path / "pkg"
+    shutil.copytree(_built_cad, pkg)
+    httpd, port = webserver._bind_free_port(webserver._Handler, _free_port())
+    httpd.daemon_threads = True
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{port}"
+    try:
+        r = _get_json(base, f"/api/open?path={pkg}")
+        assert r.get("mode") == "cad"             # CAD package (has graph.json)
+        yield base, pkg
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        webserver._um["state"] = None
+
+
+def _free_port():
+    import socket
+    s = socket.socket()
+    s.bind(("", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def _get(base, path):
+    with urllib.request.urlopen(base + path) as r:
+        return r.read().decode("utf-8")
+
+
+def _get_json(base, path):
+    return json.loads(_get(base, path))
+
+
+def _post(base, path, body):
+    req = urllib.request.Request(
+        base + path, data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"}, method="POST")
+    try:
+        with urllib.request.urlopen(req) as r:
+            return r.status, json.loads(r.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read().decode("utf-8"))
+
+
+def _served_urdf(base):
+    return ET.fromstring(_get(base, _get_json(base, "/api/info")["urdf"]))
+
+
+def _joint(root, name):
+    return next(j for j in root.findall("joint") if j.get("name") == name)
+
+
+def _joints_yaml(pkg):
+    return (pkg / "fingertip.joints.yaml").read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------------- set_limits
+def test_set_limits_reflected_without_rebuild(server):
+    base, pkg = server
+    # capture the link inertia before, to confirm the edit did NOT recompute it
+    tip_inertia = next(l.find("inertial/inertia").attrib
+                       for l in _served_urdf(base).findall("link")
+                       if l.get("name") == TIP_LINK)
+
+    code, r = _post(base, "/api/set_limits",
+                    {"limits": [{"child": TIP_LINK, "lower": -0.3,
+                                 "upper": 0.7, "continuous": False}]})
+    assert code == 200 and r["applied"] == [TIP_LINK]
+
+    lim = _joint(_served_urdf(base), REV_JOINT).find("limit")
+    assert float(lim.get("lower")) == -0.3 and float(lim.get("upper")) == 0.7
+    # inertia untouched -> the slow build() rebuild was skipped
+    after_inertia = next(l.find("inertial/inertia").attrib
+                         for l in _served_urdf(base).findall("link")
+                         if l.get("name") == TIP_LINK)
+    assert after_inertia == tip_inertia
+    # joints.yaml persisted the limit (survives re-extract / undo)
+    assert "-0.30000" in _joints_yaml(pkg) and "0.70000" in _joints_yaml(pkg)
+
+
+def test_set_limits_then_undo(server):
+    """Undo still works across the new instant edit: it restores joints.yaml and
+    rebuilds, so the original limit comes back in the served URDF."""
+    base, _pkg = server
+    orig_lo = _joint(_served_urdf(base), REV_JOINT).find("limit").get("lower")
+
+    _post(base, "/api/set_limits",
+          {"limits": [{"child": TIP_LINK, "lower": -0.3, "upper": 0.7,
+                       "continuous": False}]})
+    assert float(_joint(_served_urdf(base), REV_JOINT)
+                 .find("limit").get("lower")) == -0.3
+
+    code, r = _post(base, "/api/undo", {})
+    assert code == 200 and r.get("done") == "undo"
+    assert _joint(_served_urdf(base), REV_JOINT).find("limit").get("lower") == orig_lo
+
+
+# --------------------------------------------------------------- set_mimic
+def test_set_mimic_reflected_without_rebuild(server):
+    base, pkg = server
+    # make the fixed joint movable first (set_types still uses build() in CAD --
+    # type changes can re-derive the axis), so it can drive a mimic
+    code, _ = _post(base, "/api/set_types",
+                    {"changes": [{"child": SCREW_LINK, "type": "revolute"}]})
+    assert code == 200
+
+    code, r = _post(base, "/api/set_mimic",
+                    {"changes": [{"child": TIP_LINK, "master": FIXED_JOINT,
+                                  "multiplier": 0.5, "offset": 0.1}]})
+    assert code == 200 and r["applied"] == [TIP_LINK]
+    mim = _joint(_served_urdf(base), REV_JOINT).find("mimic")
+    assert mim is not None
+    assert mim.get("joint") == FIXED_JOINT
+    assert float(mim.get("multiplier")) == 0.5 and float(mim.get("offset")) == 0.1
+    assert "mimic" in _joints_yaml(pkg)
+
+    # unlink removes it again
+    code, r = _post(base, "/api/set_mimic",
+                    {"changes": [{"child": TIP_LINK, "clear": True}]})
+    assert code == 200
+    assert _joint(_served_urdf(base), REV_JOINT).find("mimic") is None

--- a/tests/test_golden_cad_pipeline.py
+++ b/tests/test_golden_cad_pipeline.py
@@ -22,10 +22,23 @@ To intentionally re-baseline after a deliberate output change, run with
 """
 
 import os
+import re
 import shutil
 from pathlib import Path
 
 import pytest
+
+# mass / CoM / inertia are recomputed by build() from the mesh (trimesh) -- they
+# are NOT what the edit-overlay refactor touches, and their exact values vary
+# with platform / optional-dep availability (scipy, the 3dxml loader).  Collapse
+# the <inertial> block so the golden stays stable and focuses on the edit-driven
+# structure (names / types / limits / axis / mimic).  The inertia maths has its
+# own tests (test_autoinit, test_sw_inertia).
+_INERTIAL = re.compile(r"<inertial>.*?</inertial>", re.DOTALL)
+
+
+def _normalize(urdf_text):
+    return _INERTIAL.sub("<inertial/>", urdf_text)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 GOLDEN = REPO_ROOT / "tests" / "golden"
@@ -55,8 +68,10 @@ def _fresh_pkg(tmp_path):
 
 
 def _assert_golden(name, actual):
-    """Compare ``actual`` text to ``tests/golden/<name>`` byte for byte (line
-    list, for a readable assert), or re-baseline it under SW2ROBOT_UPDATE_GOLDEN."""
+    """Compare ``actual`` (with its <inertial> blocks normalized away) to
+    ``tests/golden/<name>`` line for line, or re-baseline under
+    SW2ROBOT_UPDATE_GOLDEN."""
+    actual = _normalize(actual)
     golden = GOLDEN / name
     if os.environ.get("SW2ROBOT_UPDATE_GOLDEN"):
         golden.write_text(actual, encoding="utf-8")

--- a/tests/test_golden_cad_pipeline.py
+++ b/tests/test_golden_cad_pipeline.py
@@ -1,0 +1,139 @@
+"""Golden (characterization) tests that PIN the current CAD->URDF edit output.
+
+These do not assert that the output is *correct* -- they assert it does not
+*change*.  They exist as the safety net for the planned refactor that unifies
+the two parallel edit systems (the joints.yaml + ``build()`` rebuild used by the
+web server, and the ``JointEdit`` overlay + ``build_urdf`` used by core.py) onto
+a single overlay applied directly to the URDF.  Every edit that will migrate is
+locked here against the committed ``tests/golden`` snapshots, so the refactor is
+verified by "the bytes are identical".
+
+Coverage (all on the committed ``examples/fingertip`` package, headless -- no
+SolidWorks):
+  * base build                      -> fingertip_base.urdf
+  * config build (rename/type/      -> fingertip_edited.urdf
+    limits/mimic)
+  * _flip_axis_in_urdf (axis flip)  -> fingertip_flip.urdf
+  * _rename_in_urdf (direct rename) -> fingertip_rename_direct.urdf
+  * colors: round-trip through joints.yaml -> _read_colors
+
+To intentionally re-baseline after a deliberate output change, run with
+``SW2ROBOT_UPDATE_GOLDEN=1`` and review the diff before committing.
+"""
+
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GOLDEN = REPO_ROOT / "tests" / "golden"
+FINGERTIP = REPO_ROOT / "examples" / "fingertip"
+URDF_REL = "urdf/fingertip.urdf"
+
+# joint / link names in the committed fingertip fixture
+REV_JOINT = "fingertip_front_2__fingertip_back_1"
+TIP_LINK = "fingertip_back_1"
+
+
+def _require_fixture():
+    if not (FINGERTIP / "graph.json").is_file():
+        pytest.skip(f"missing fixture graph: {FINGERTIP / 'graph.json'}")
+
+
+def _fresh_pkg(tmp_path):
+    """A throwaway copy of the fingertip package (graph.json + meshes) so a build
+    never dirties the committed fixture."""
+    work = tmp_path / "pkg"
+    (work / "meshes").mkdir(parents=True)
+    shutil.copy2(FINGERTIP / "graph.json", work / "graph.json")
+    for f in (FINGERTIP / "meshes").iterdir():
+        if f.is_file():
+            shutil.copy2(f, work / "meshes" / f.name)
+    return work
+
+
+def _assert_golden(name, actual):
+    """Compare ``actual`` text to ``tests/golden/<name>`` byte for byte (line
+    list, for a readable assert), or re-baseline it under SW2ROBOT_UPDATE_GOLDEN."""
+    golden = GOLDEN / name
+    if os.environ.get("SW2ROBOT_UPDATE_GOLDEN"):
+        golden.write_text(actual, encoding="utf-8")
+        pytest.skip(f"re-baselined {name}")
+    assert golden.is_file(), f"missing golden {golden} (run SW2ROBOT_UPDATE_GOLDEN=1)"
+    expected = golden.read_text(encoding="utf-8")
+    assert actual.splitlines() == expected.splitlines(), (
+        f"{name} drifted from the committed golden -- the edit pipeline changed "
+        f"its URDF output.  If intentional, re-baseline with "
+        f"SW2ROBOT_UPDATE_GOLDEN=1 and review the diff."
+    )
+
+
+def test_golden_base_build(tmp_path):
+    """build() with no config -> the baseline URDF."""
+    _require_fixture()
+    from sw2robot.exporter.export import build
+
+    work = _fresh_pkg(tmp_path)
+    urdf = build(str(work))
+    _assert_golden("fingertip_base.urdf", Path(urdf).read_text(encoding="utf-8"))
+
+
+def test_golden_edited_build(tmp_path):
+    """build() with the edit config -> rename + type override + limits + mimic
+    all baked into the URDF (the edits that migrate to the overlay)."""
+    _require_fixture()
+    from sw2robot.exporter.export import build
+
+    work = _fresh_pkg(tmp_path)
+    cfg = GOLDEN / "fingertip_edit.joints.yaml"
+    urdf = build(str(work), config_path=str(cfg))
+    _assert_golden("fingertip_edited.urdf", Path(urdf).read_text(encoding="utf-8"))
+
+
+def test_golden_flip_axis_direct(tmp_path):
+    """_flip_axis_in_urdf negates the revolute joint's axis directly in the
+    served URDF (no rebuild) -- the existing URDF-direct edit path."""
+    _require_fixture()
+    from sw2robot.editor.webserver import _flip_axis_in_urdf
+    from sw2robot.exporter.export import build
+
+    work = _fresh_pkg(tmp_path)
+    build(str(work))
+    flipped = _flip_axis_in_urdf(str(work), URDF_REL, REV_JOINT)
+    assert flipped == 1, "expected exactly one axis flipped"
+    _assert_golden("fingertip_flip.urdf",
+                   (work / "urdf" / "fingertip.urdf").read_text(encoding="utf-8"))
+
+
+def test_golden_rename_direct(tmp_path):
+    """_rename_in_urdf renames a link and a joint (and their references) directly
+    in the served URDF -- the existing URDF-direct edit path."""
+    _require_fixture()
+    from sw2robot.editor.webserver import _rename_in_urdf
+    from sw2robot.exporter.export import build
+
+    work = _fresh_pkg(tmp_path)
+    build(str(work))
+    n_link = _rename_in_urdf(str(work), URDF_REL, "link", TIP_LINK, "tip")
+    n_joint = _rename_in_urdf(str(work), URDF_REL, "joint", REV_JOINT, "bend")
+    assert (n_link, n_joint) == (2, 1), "rename touched an unexpected ref count"
+    _assert_golden("fingertip_rename_direct.urdf",
+                   (work / "urdf" / "fingertip.urdf").read_text(encoding="utf-8"))
+
+
+def test_color_config_round_trips(tmp_path):
+    """A per-link colour stored in the package's <name>.joints.yaml `colors:`
+    block is read back verbatim by _read_colors (the colour storage/read contract
+    the refactor must preserve)."""
+    _require_fixture()
+    from sw2robot.editor.webserver import _read_colors
+    from sw2robot.exporter.export import build
+
+    work = _fresh_pkg(tmp_path)
+    # the web server keys the config off the URDF stem; mirror that layout so
+    # _read_colors (which reads <stem>.joints.yaml) finds the colours block
+    shutil.copy2(GOLDEN / "fingertip_edit.joints.yaml", work / "fingertip.joints.yaml")
+    build(str(work), config_path=str(work / "fingertip.joints.yaml"))
+    assert _read_colors(str(work), URDF_REL) == {TIP_LINK: "#ff0000"}

--- a/tests/test_link_edits.py
+++ b/tests/test_link_edits.py
@@ -166,6 +166,46 @@ def test_unknown_link_raises(state):
         c.set_inertial(state, "nope", mass=1.0)
 
 
+def test_build_urdf_sanitize_false_preserves_unsafe_names(tmp_path):
+    """URDF-input mode keeps the user's own names verbatim (sanitize=False); the
+    CAD default (sanitize=True) would rewrite hyphen/dot names."""
+    urdf = ('<robot name="r"><link name="a-b"/><link name="c.d"/>'
+            '<joint name="j-1" type="fixed"><parent link="a-b"/>'
+            '<child link="c.d"/></joint></robot>')
+    p = tmp_path / "urdf" / "r.urdf"
+    p.parent.mkdir(parents=True)
+    p.write_text(urdf, encoding="utf-8")
+    st = c.load_module(str(p))
+
+    kept = [l.get("name") for l in ET.fromstring(c.build_urdf(st, sanitize=False))
+            .findall("link")]
+    assert "a-b" in kept and "c.d" in kept
+    cleaned = [l.get("name") for l in ET.fromstring(c.build_urdf(st, sanitize=True))
+               .findall("link")]
+    assert "a-b" not in cleaned and "c.d" not in cleaned
+
+
+def test_type_change_to_movable_adds_axis_and_limit(tmp_path):
+    """Changing a fixed joint to revolute must yield a VALID URDF: build_urdf
+    backfills the URDF-required <axis> and <limit> the edit didn't supply."""
+    urdf = ('<robot name="r"><link name="a"/><link name="b"/>'
+            '<joint name="j" type="fixed"><parent link="a"/>'
+            '<child link="b"/></joint></robot>')
+    p = tmp_path / "urdf" / "r.urdf"
+    p.parent.mkdir(parents=True)
+    p.write_text(urdf, encoding="utf-8")
+    st = c.load_module(str(p))
+    c.set_joint_type(st, "j", "revolute")
+    j = next(x for x in ET.fromstring(c.build_urdf(st, sanitize=False))
+             .findall("joint") if x.get("name") == "j")
+    assert j.get("type") == "revolute"
+    assert j.find("axis") is not None
+    lim = j.find("limit")
+    assert lim is not None
+    assert lim.get("effort") and lim.get("velocity")
+    assert lim.get("lower") and lim.get("upper")
+
+
 def test_no_link_edits_leaves_urdf_structurally_unchanged(state):
     """build_urdf with an empty link overlay must not invent <material> or change
     inertials -- the existing joint-only behaviour is preserved."""

--- a/tests/test_link_edits.py
+++ b/tests/test_link_edits.py
@@ -206,6 +206,22 @@ def test_type_change_to_movable_adds_axis_and_limit(tmp_path):
     assert lim.get("lower") and lim.get("upper")
 
 
+def test_reverse_direction_no_degenerate_limit_on_continuous(tmp_path):
+    """Reversing a continuous (limit-less) joint flips the axis but must NOT
+    write a degenerate [0, 0] limit into the overlay."""
+    urdf = ('<robot name="r"><link name="a"/><link name="b"/>'
+            '<joint name="j" type="continuous"><parent link="a"/>'
+            '<child link="b"/><axis xyz="0 0 1"/></joint></robot>')
+    p = tmp_path / "urdf" / "r.urdf"
+    p.parent.mkdir(parents=True)
+    p.write_text(urdf, encoding="utf-8")
+    st = c.load_module(str(p))
+    c.reverse_direction(st, "j")
+    e = st.edits["j"]
+    assert e.flip_axis is True
+    assert e.lower is None and e.upper is None     # no fabricated [0,0] range
+
+
 def test_flip_axis_on_just_converted_joint(tmp_path):
     """Flipping a joint in the same edit that first makes it movable must take:
     build_urdf backfills the <axis> before applying the flip."""

--- a/tests/test_link_edits.py
+++ b/tests/test_link_edits.py
@@ -1,0 +1,204 @@
+"""Unit tests for the per-link overlay (colour + inertial) added to the unified
+edit model: ``LinkEdit`` / ``set_color`` / ``set_inertial`` and how
+``build_urdf`` bakes them into the URDF.
+
+Self-contained: a tiny hand-written URDF is loaded with ``core.load_module`` so
+the tests need neither SolidWorks nor a graph.json cache.
+"""
+
+import xml.etree.ElementTree as ET
+
+import pytest
+
+import sw2robot.editor.core as c
+
+MINI_URDF = """<?xml version="1.0"?>
+<robot name="mini">
+  <link name="base">
+    <visual>
+      <geometry><box size="1 1 1"/></geometry>
+    </visual>
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.1"/>
+      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
+    </inertial>
+  </link>
+  <link name="tip">
+    <visual>
+      <geometry><box size="1 1 1"/></geometry>
+    </visual>
+  </link>
+  <link name="ghost"/>
+  <joint name="j" type="revolute">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <parent link="base"/>
+    <child link="tip"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-1" upper="1" effort="10" velocity="3"/>
+  </joint>
+</robot>
+"""
+
+
+@pytest.fixture
+def state(tmp_path):
+    p = tmp_path / "urdf" / "mini.urdf"
+    p.parent.mkdir(parents=True)
+    p.write_text(MINI_URDF, encoding="utf-8")
+    return c.load_module(str(p))
+
+
+def _link(urdf_str, name):
+    return next(l for l in ET.fromstring(urdf_str).findall("link")
+               if l.get("name") == name)
+
+
+# --------------------------------------------------------------- colour
+def test_set_color_bakes_material(state):
+    c.set_color(state, "base", "#ff0000")
+    mat = _link(c.build_urdf(state), "base").find("visual/material")
+    assert mat is not None
+    assert mat.find("color").get("rgba") == "1 0 0 1"
+
+
+def test_set_color_accepts_bare_hex_and_normalizes(state):
+    c.set_color(state, "base", "00FF00")     # no '#', upper case
+    assert state.link_edits["base"].color == "#00ff00"
+    rgba = _link(c.build_urdf(state), "base").find("visual/material/color").get("rgba")
+    assert rgba == "0 1 0 1"
+
+
+def test_set_color_none_clears(state):
+    c.set_color(state, "base", "#ff0000")
+    c.set_color(state, "base", None)
+    assert state.link_edits["base"].color is None
+    assert _link(c.build_urdf(state), "base").find("visual/material") is None
+
+
+def test_set_color_invalid_raises(state):
+    with pytest.raises(ValueError):
+        c.set_color(state, "base", "#12")
+    with pytest.raises(ValueError):
+        c.set_color(state, "base", "nothex0")
+
+
+def test_set_color_link_without_visual_is_noop(state):
+    c.set_color(state, "ghost", "#ff0000")     # ghost has no <visual>
+    assert _link(c.build_urdf(state), "ghost").find("visual") is None
+
+
+# --------------------------------------------------------------- inertial
+def test_set_inertial_full_on_link_without_inertial(state):
+    c.set_inertial(state, "tip", mass=2.0, com=[1, 2, 3],
+                   inertia=[3, 0.1, 0.2, 4, 0.3, 5])
+    ine = _link(c.build_urdf(state), "tip").find("inertial")
+    assert ine is not None
+    assert float(ine.find("mass").get("value")) == 2.0
+    assert ine.find("origin").get("xyz") == "1 2 3"
+    I = ine.find("inertia")
+    assert (I.get("ixx"), I.get("iyy"), I.get("izz")) == ("3", "4", "5")
+    assert (I.get("ixy"), I.get("ixz"), I.get("iyz")) == ("0.1", "0.2", "0.3")
+
+
+def test_set_inertial_rejects_nonphysical_tensor(state):
+    """A right-length but physically impossible tensor must be rejected (the same
+    physics check the exporter applies to generated inertials)."""
+    with pytest.raises(ValueError):
+        c.set_inertial(state, "base", inertia=[-1, 0, 0, 1, 0, 1])   # not pos-def
+    with pytest.raises(ValueError):
+        c.set_inertial(state, "base", inertia=[1, 0, 0, 1, 0, 10])   # I1+I2 < I3
+    # a rejected tensor leaves no partial override behind
+    assert state.link_edits.get("base") is None \
+        or state.link_edits["base"].inertia is None
+
+
+def test_set_inertial_partial_keeps_existing(state):
+    # base already has mass 0.1 and inertia 1e-4 on the diagonal
+    c.set_inertial(state, "base", mass=5.0)
+    ine = _link(c.build_urdf(state), "base").find("inertial")
+    assert float(ine.find("mass").get("value")) == 5.0
+    # untouched fields preserved
+    assert ine.find("inertia").get("ixx") == "0.0001"
+    assert ine.find("origin").get("xyz") == "0 0 0"
+
+
+def test_set_inertial_partial_on_link_without_inertial_is_valid_urdf(state):
+    """A partial edit (mass only) on a link with NO base <inertial> must still
+    emit a complete, valid block -- the missing <inertia> is backfilled."""
+    c.set_inertial(state, "tip", mass=1.0)     # tip has no <inertial>
+    ine = _link(c.build_urdf(state), "tip").find("inertial")
+    assert float(ine.find("mass").get("value")) == 1.0
+    tensor = ine.find("inertia")
+    assert tensor is not None and tensor.get("ixx") == "0.0001"
+
+
+def test_set_inertial_rejects_bad_shapes(state):
+    with pytest.raises(ValueError):
+        c.set_inertial(state, "base", mass=0)          # must be > 0
+    with pytest.raises(ValueError):
+        c.set_inertial(state, "base", com=[1, 2])      # need 3
+    with pytest.raises(ValueError):
+        c.set_inertial(state, "base", inertia=[1, 2, 3])   # need 6
+
+
+def test_set_inertial_rejects_nonfinite(state):
+    for bad in (float("nan"), float("inf")):
+        with pytest.raises(ValueError):
+            c.set_inertial(state, "base", mass=bad)
+        with pytest.raises(ValueError):
+            c.set_inertial(state, "base", com=[0, 0, bad])
+
+
+# --------------------------------------------------------------- guards
+def test_set_inertial_invalid_leaves_no_partial_state(state):
+    """A rejected request must not have applied any of its fields."""
+    with pytest.raises(ValueError):
+        c.set_inertial(state, "base", mass=1.0, com=[1, 2])   # mass ok, com bad
+    assert state.link_edits.get("base") is None \
+        or state.link_edits["base"].mass is None
+
+
+def test_unknown_link_raises(state):
+    with pytest.raises(ValueError):
+        c.set_color(state, "nope", "#ffffff")
+    with pytest.raises(ValueError):
+        c.set_inertial(state, "nope", mass=1.0)
+
+
+def test_no_link_edits_leaves_urdf_structurally_unchanged(state):
+    """build_urdf with an empty link overlay must not invent <material> or change
+    inertials -- the existing joint-only behaviour is preserved."""
+    out = c.build_urdf(state)
+    assert _link(out, "base").find("visual/material") is None
+    assert _link(out, "tip").find("inertial") is None
+    assert _link(out, "ghost").find("inertial") is None
+
+
+def test_link_edits_survive_json_roundtrip(state, tmp_path):
+    c.set_color(state, "base", "#abcdef")
+    c.set_inertial(state, "tip", mass=1.5, com=[0, 0, 0.1])
+    path = c.save_state(state, tmp_path / "s.json")
+    reloaded = c.load_state(path)
+    assert reloaded.link_edits["base"].color == "#abcdef"
+    assert reloaded.link_edits["tip"].mass == 1.5
+    assert reloaded.link_edits["tip"].com == [0, 0, 0.1]
+
+
+def test_load_edits_merges_link_overlay(state, tmp_path):
+    """A saved sidecar's link_edits must be re-applied on the refresh path
+    (load_edits), not just the joint edits -- else colours/inertials vanish on
+    every rebuild."""
+    c.set_color(state, "base", "#abcdef")
+    c.set_inertial(state, "tip", mass=2.0)
+    c.set_limits(state, "j", -0.5, 0.5)
+    sidecar = c.save_state(state, tmp_path / "side.json")
+
+    # a fresh state for the same module (as if just rebuilt) starts edit-free
+    fresh = c.load_module(state.urdf_path)
+    assert fresh.link_edits == {} and fresh.edits == {}
+    n = c.load_edits(fresh, sidecar)
+    assert n == 3                                  # 1 joint + 2 link edits
+    assert fresh.link_edits["base"].color == "#abcdef"
+    assert fresh.link_edits["tip"].mass == 2.0
+    assert fresh.edits["j"].lower == -0.5

--- a/tests/test_link_edits.py
+++ b/tests/test_link_edits.py
@@ -206,6 +206,24 @@ def test_type_change_to_movable_adds_axis_and_limit(tmp_path):
     assert lim.get("lower") and lim.get("upper")
 
 
+def test_flip_axis_on_just_converted_joint(tmp_path):
+    """Flipping a joint in the same edit that first makes it movable must take:
+    build_urdf backfills the <axis> before applying the flip."""
+    urdf = ('<robot name="r"><link name="a"/><link name="b"/>'
+            '<joint name="j" type="fixed"><parent link="a"/>'
+            '<child link="b"/></joint></robot>')
+    p = tmp_path / "urdf" / "r.urdf"
+    p.parent.mkdir(parents=True)
+    p.write_text(urdf, encoding="utf-8")
+    st = c.load_module(str(p))
+    c.set_joint_type(st, "j", "revolute")
+    c.set_axis_flip(st, "j", True)
+    j = next(x for x in ET.fromstring(c.build_urdf(st, sanitize=False))
+             .findall("joint") if x.get("name") == "j")
+    xyz = [float(v) for v in j.find("axis").get("xyz").split()]
+    assert xyz == [0.0, 0.0, -1.0]      # backfilled 0 0 1, then flipped
+
+
 def test_no_link_edits_leaves_urdf_structurally_unchanged(state):
     """build_urdf with an empty link overlay must not invent <material> or change
     inertials -- the existing joint-only behaviour is preserved."""

--- a/tests/test_urdf_mode_webserver.py
+++ b/tests/test_urdf_mode_webserver.py
@@ -10,6 +10,7 @@ The CAD path is untouched and is guarded separately by the golden + e2e suites.
 """
 
 import json
+import re
 import shutil
 import threading
 import urllib.request
@@ -306,9 +307,17 @@ def test_package_uris_rewritten_for_viewer(tmp_path):
         info = _get_json(base, f"/api/open?path={pkg}")
         assert info["mode"] == "urdf"
         served = _get(base, info["urdf"])
-        assert 'filename="/pkg/meshes/part.stl"' in served
         assert "package://" not in served
-        code, _ = _get_status(base, "/pkg/meshes/part.stl")   # actually fetchable
+        # the rewritten mesh path is RELATIVE to the URDF url (that is how
+        # urdf-loaders resolves it), and resolving + normalizing it the way the
+        # browser does must land on the package-served path
+        fn = re.search(r'filename="([^"]+\.stl)"', served).group(1)
+        assert not fn.startswith("/")                  # relative, not absolute
+        import posixpath as _pp
+        urdf_url = info["urdf"]                         # e.g. /pkg/urdf/robot.urdf
+        resolved = _pp.normpath(_pp.join(_pp.dirname(urdf_url), fn))
+        assert resolved == "/pkg/meshes/part.stl", resolved
+        code, _ = _get_status(base, resolved)           # actually fetchable
         assert code == 200
     finally:
         httpd.shutdown()

--- a/tests/test_urdf_mode_webserver.py
+++ b/tests/test_urdf_mode_webserver.py
@@ -1,0 +1,286 @@
+"""Integration tests for URDF-input editing mode in the web server.
+
+A package with NO graph.json is a plain URDF the user opened directly; the
+server then holds the core edit overlay in memory, serves build_urdf(state) for
+the URDF URL, and routes every edit through the core setters.  These tests drive
+a real in-process HTTP server (no browser) against a graph-less copy of the
+committed fingertip example.
+
+The CAD path is untouched and is guarded separately by the golden + e2e suites.
+"""
+
+import json
+import shutil
+import threading
+import urllib.request
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FINGERTIP = REPO_ROOT / "examples" / "fingertip"
+
+REV_JOINT = "fingertip_front_2__fingertip_back_1"     # child = fingertip_back_1
+FIXED_JOINT = "fingertip_front_2__screwlock_male_hard_jointbase_v4_1"
+TIP_LINK = "fingertip_back_1"
+SCREW_LINK = "screwlock_male_hard_jointbase_v4_1"
+
+
+def _require_fixture():
+    if not (FINGERTIP / "graph.json").is_file():
+        pytest.skip("missing fingertip fixture")
+
+
+def _urdf_only_pkg(tmp_path):
+    """Build the fingertip example, then copy ONLY urdf/ + meshes/ into a fresh
+    dir (no graph.json / joints.yaml) -- a plain URDF package."""
+    from sw2robot.exporter.export import build
+
+    cad = tmp_path / "cad"
+    (cad / "meshes").mkdir(parents=True)
+    shutil.copy2(FINGERTIP / "graph.json", cad / "graph.json")
+    for f in (FINGERTIP / "meshes").iterdir():
+        if f.is_file():
+            shutil.copy2(f, cad / "meshes" / f.name)
+    build(str(cad))
+
+    pkg = tmp_path / "urdf_only"
+    (pkg / "urdf").mkdir(parents=True)
+    (pkg / "meshes").mkdir()
+    shutil.copy2(cad / "urdf" / "fingertip.urdf", pkg / "urdf" / "fingertip.urdf")
+    for f in (cad / "meshes").iterdir():
+        if f.is_file():
+            shutil.copy2(f, pkg / "meshes" / f.name)
+    assert not (pkg / "graph.json").exists()
+    return pkg
+
+
+@pytest.fixture(scope="module")
+def _built_template(tmp_path_factory):
+    """Build the URDF-only package ONCE for the module (build() dominates the
+    per-test cost); each test gets a fresh copy for isolation."""
+    _require_fixture()
+    return _urdf_only_pkg(tmp_path_factory.mktemp("tmpl"))
+
+
+@pytest.fixture
+def server(_built_template, tmp_path):
+    """A running web server with a fresh URDF-only fingertip package opened."""
+    from sw2robot.editor import webserver
+
+    pkg = tmp_path / "pkg"
+    shutil.copytree(_built_template, pkg)
+    httpd, port = webserver._bind_free_port(webserver._Handler,
+                                            _free_port())
+    httpd.daemon_threads = True
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    base = f"http://127.0.0.1:{port}"
+    try:
+        r = _get_json(base, f"/api/open?path={pkg}")
+        assert r.get("name") == "fingertip"
+        assert webserver._um["state"] is not None     # URDF mode engaged
+        yield base
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        webserver._um["state"] = None
+
+
+def _free_port():
+    import socket
+    s = socket.socket()
+    s.bind(("", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def _get(base, path):
+    with urllib.request.urlopen(base + path) as r:
+        return r.read().decode("utf-8")
+
+
+def _get_json(base, path):
+    return json.loads(_get(base, path))
+
+
+def _post(base, path, body):
+    req = urllib.request.Request(
+        base + path, data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"}, method="POST")
+    try:
+        with urllib.request.urlopen(req) as r:
+            return r.status, json.loads(r.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read().decode("utf-8"))
+
+
+def _served_urdf(base):
+    info = _get_json(base, "/api/info")
+    return ET.fromstring(_get(base, info["urdf"]))
+
+
+def _joint(root, name):
+    return next(j for j in root.findall("joint") if j.get("name") == name)
+
+
+def _link(root, name):
+    return next(l for l in root.findall("link") if l.get("name") == name)
+
+
+# --------------------------------------------------------------- tests
+def test_serves_base_urdf_unedited(server):
+    _require_fixture()
+    root = _served_urdf(server)
+    assert root.get("name") == "fingertip"
+    assert _link(root, TIP_LINK).find("visual/material") is None
+
+
+def test_set_color_reflected_in_served_urdf(server):
+    code, r = _post(server, "/api/set_color", {"link": TIP_LINK, "color": "#ff0000"})
+    assert code == 200 and r["color"] == "#ff0000"
+    mat = _link(_served_urdf(server), TIP_LINK).find("visual/material/color")
+    assert mat.get("rgba") == "1 0 0 1"
+
+
+def test_set_color_invalid_is_400(server):
+    code, r = _post(server, "/api/set_color", {"link": TIP_LINK, "color": "nope"})
+    assert code == 400 and "error" in r
+
+
+def test_set_inertial(server):
+    code, r = _post(server, "/api/set_inertial",
+                    {"link": TIP_LINK, "mass": 2.5, "com": [0.01, 0, 0]})
+    assert code == 200 and r["mass"] == 2.5
+    ine = _link(_served_urdf(server), TIP_LINK).find("inertial")
+    assert float(ine.find("mass").get("value")) == 2.5
+    assert ine.find("origin").get("xyz") == "0.01 0 0"
+
+
+def test_set_inertial_nonphysical_is_400(server):
+    code, r = _post(server, "/api/set_inertial",
+                    {"link": TIP_LINK, "inertia": [1, 0, 0, 1, 0, 10]})
+    assert code == 400 and "error" in r
+
+
+def test_set_limits(server):
+    code, r = _post(server, "/api/set_limits",
+                    {"limits": [{"child": TIP_LINK, "lower": -0.3,
+                                 "upper": 0.7, "continuous": False}]})
+    assert code == 200 and r["applied"] == [TIP_LINK]
+    lim = _joint(_served_urdf(server), REV_JOINT).find("limit")
+    assert float(lim.get("lower")) == -0.3 and float(lim.get("upper")) == 0.7
+
+
+def test_set_type_then_mimic(server):
+    # make the fixed joint movable so it can drive a mimic
+    code, _ = _post(server, "/api/set_types",
+                    {"changes": [{"child": SCREW_LINK, "type": "revolute"}]})
+    assert code == 200
+    changed = _joint(_served_urdf(server), FIXED_JOINT)
+    assert changed.get("type") == "revolute"
+    assert changed.find("limit") is not None     # valid URDF: limit backfilled
+
+    code, r = _post(server, "/api/set_mimic",
+                    {"changes": [{"child": TIP_LINK, "master": FIXED_JOINT,
+                                  "multiplier": 0.5, "offset": 0.1}]})
+    assert code == 200 and r["applied"] == [TIP_LINK]
+    mim = _joint(_served_urdf(server), REV_JOINT).find("mimic")
+    assert mim.get("joint") == FIXED_JOINT
+    assert mim.get("multiplier") == "0.5" and mim.get("offset") == "0.1"
+
+
+def test_flip_axis(server):
+    base_axis = _joint(_served_urdf(server), REV_JOINT).find("axis").get("xyz")
+    code, r = _post(server, "/api/set_axis", {"joints": [REV_JOINT]})
+    assert code == 200 and r["applied"] == [REV_JOINT]
+    flipped = _joint(_served_urdf(server), REV_JOINT).find("axis").get("xyz")
+    assert flipped != base_axis
+    # self-inverse: flipping again restores the original axis
+    _post(server, "/api/set_axis", {"joints": [REV_JOINT]})
+    assert _joint(_served_urdf(server), REV_JOINT).find("axis").get("xyz") == base_axis
+
+
+def test_flip_after_rename(server):
+    """The flip endpoint accepts the CURRENT (renamed) joint name."""
+    _post(server, "/api/rename", {"kind": "joint", "old": REV_JOINT, "new": "bend"})
+    code, r = _post(server, "/api/set_axis", {"joints": ["bend"]})
+    assert code == 200 and r["applied"] == ["bend"]
+
+
+def test_export_colors_come_from_overlay(server):
+    """URDF mode has no joints.yaml colours block; the exporter's repaint map is
+    built from the overlay instead."""
+    from sw2robot.editor import webserver
+
+    _post(server, "/api/set_color", {"link": TIP_LINK, "color": "#abcdef"})
+    assert webserver._um_colors(webserver._um["state"]) == {TIP_LINK: "#abcdef"}
+
+
+def test_reset_names_clears_joint_renames(server):
+    _post(server, "/api/rename", {"kind": "joint", "old": REV_JOINT, "new": "bend"})
+    assert "bend" in [j.get("name") for j in _served_urdf(server).findall("joint")]
+    code, r = _post(server, "/api/reset_names", {})
+    assert code == 200 and r["ok"] and r["reset"] == 1
+    names = [j.get("name") for j in _served_urdf(server).findall("joint")]
+    assert REV_JOINT in names and "bend" not in names
+
+
+def test_components_lists_links_with_overlay_colour(server):
+    _post(server, "/api/set_color", {"link": TIP_LINK, "color": "#00ff00"})
+    comp = _get_json(server, "/api/components")
+    assert TIP_LINK in comp["links"]
+    assert comp["colors"][TIP_LINK] == "#00ff00"
+
+
+def test_edits_persist_to_sidecar(server, tmp_path):
+    from sw2robot.editor import core, webserver
+
+    _post(server, "/api/set_color", {"link": TIP_LINK, "color": "#123456"})
+    _post(server, "/api/set_limits",
+          {"limits": [{"child": TIP_LINK, "lower": -1, "upper": 1}]})
+    # a fresh state loaded from disk must see the persisted overlay
+    state = webserver._um["state"]
+    reloaded = core.load_module(state.urdf_path, package_dir=state.package_dir)
+    assert core.load_edits(reloaded) >= 2
+    assert reloaded.link_edits[TIP_LINK].color == "#123456"
+    assert reloaded.edits[REV_JOINT].lower == -1
+
+
+def test_mimic_master_after_rename(server):
+    """A mimic whose driver was renamed must still link: the UI sends the new
+    name, which the server maps back to the original before validating."""
+    _post(server, "/api/set_types",
+          {"changes": [{"child": SCREW_LINK, "type": "revolute"}]})
+    code, _ = _post(server, "/api/rename",
+                    {"kind": "joint", "old": FIXED_JOINT, "new": "driver"})
+    assert code == 200
+    names = [j.get("name") for j in _served_urdf(server).findall("joint")]
+    assert "driver" in names and FIXED_JOINT not in names
+
+    code, r = _post(server, "/api/set_mimic",
+                    {"changes": [{"child": TIP_LINK, "master": "driver",
+                                  "multiplier": 1.0, "offset": 0.0}]})
+    assert code == 200 and r["applied"] == [TIP_LINK]
+    assert _joint(_served_urdf(server), REV_JOINT).find("mimic").get("joint") \
+        == "driver"
+
+
+def test_export_materializes_overlay_then_restores(server):
+    """The on-disk URDF stays pristine while serving live, but the export window
+    temporarily materializes the overlay so the ROS exporter picks edits up."""
+    import os
+
+    from sw2robot.editor import webserver
+
+    _post(server, "/api/set_color", {"link": TIP_LINK, "color": "#ff0000"})
+    state = webserver._um["state"]
+    disk = Path(state.urdf_path)
+    rel = os.path.relpath(state.urdf_path, state.package_dir).replace("\\", "/")
+
+    assert "material" not in disk.read_text(encoding="utf-8")   # pristine on disk
+    with webserver._um_materialized(state.package_dir, rel):
+        assert "<material" in disk.read_text(encoding="utf-8")  # edits visible
+    assert "material" not in disk.read_text(encoding="utf-8")   # restored

--- a/tests/test_urdf_mode_webserver.py
+++ b/tests/test_urdf_mode_webserver.py
@@ -612,17 +612,22 @@ def test_package_uris_rewritten_for_viewer(tmp_path):
     """A URDF that references meshes via package:// is served to the viewer with
     /pkg/ paths (so the browser fetches them from the package server instead of
     404-ing on http://host/<pkgname>/meshes/...)."""
+    import posixpath as _pp
+
     from sw2robot.editor import webserver
 
-    pkg = tmp_path / "pkgpkg"
+    pkg = tmp_path / "weird_folder"    # folder name need NOT match the URI package
     (pkg / "urdf").mkdir(parents=True)
     (pkg / "meshes").mkdir()
     (pkg / "meshes" / "part.stl").write_text("solid x\nendsolid x\n", encoding="utf-8")
     (pkg / "urdf" / "robot.urdf").write_text(
-        '<?xml version="1.0"?><robot name="robot">'
-        '<link name="base_link"><visual><geometry>'
+        '<?xml version="1.0"?><robot name="robot"><link name="base_link">'
+        '<visual><geometry>'                # own mesh exists here -> rewritten
         '<mesh filename="package://robot_description/meshes/part.stl"/>'
-        '</geometry></visual></link></robot>', encoding="utf-8")
+        '</geometry></visual>'
+        '<collision><geometry>'             # not in this package -> left as-is
+        '<mesh filename="package://other_pkg/meshes/absent.stl"/>'
+        '</geometry></collision></link></robot>', encoding="utf-8")
 
     httpd, port = webserver._bind_free_port(webserver._Handler, _free_port())
     threading.Thread(target=httpd.serve_forever, daemon=True).start()
@@ -631,18 +636,54 @@ def test_package_uris_rewritten_for_viewer(tmp_path):
         info = _get_json(base, f"/api/open?path={pkg}")
         assert info["mode"] == "urdf"
         served = _get(base, info["urdf"])
-        assert "package://" not in served
-        # the rewritten mesh path is RELATIVE to the URDF url (that is how
-        # urdf-loaders resolves it), and resolving + normalizing it the way the
-        # browser does must land on the package-served path
-        fn = re.search(r'filename="([^"]+\.stl)"', served).group(1)
-        assert not fn.startswith("/")                  # relative, not absolute
-        import posixpath as _pp
-        urdf_url = info["urdf"]                         # e.g. /pkg/urdf/robot.urdf
-        resolved = _pp.normpath(_pp.join(_pp.dirname(urdf_url), fn))
+        # own mesh (exists here) rewritten to a relative path that resolves
+        # (browser-style) to the package-served mesh; the absent external ref is
+        # left as package:// (not mis-pointed to a local same-named file)
+        assert "package://other_pkg/meshes/absent.stl" in served
+        fns = re.findall(r'filename="([^"]+)"', served)
+        own = next(f for f in fns if not f.startswith("package://"))
+        assert not own.startswith("/")
+        resolved = _pp.normpath(_pp.join(_pp.dirname(info["urdf"]), own))
         assert resolved == "/pkg/meshes/part.stl", resolved
-        code, _ = _get_status(base, resolved)           # actually fetchable
+        code, _ = _get_status(base, resolved)
         assert code == 200
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        webserver._um["state"] = None
+
+
+def test_urdf_mode_undo_redo(tmp_path):
+    """URDF-mode edits are undoable/redoable via the in-memory overlay stack."""
+    from sw2robot.editor import webserver
+
+    pkg = tmp_path / "robotpkg"
+    (pkg / "urdf").mkdir(parents=True)
+    (pkg / "urdf" / "robot.urdf").write_text(
+        '<?xml version="1.0"?><robot name="robot">'
+        '<link name="a"/><link name="b"/>'
+        '<joint name="j" type="revolute"><parent link="a"/><child link="b"/>'
+        '<axis xyz="0 0 1"/><limit lower="-1" upper="1" effort="1" velocity="1"/>'
+        '</joint></robot>', encoding="utf-8")
+    httpd, port = webserver._bind_free_port(webserver._Handler, _free_port())
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{port}"
+
+    def _limit():
+        return _joint(_served_urdf(base), "j").find("limit").get("lower")
+
+    try:
+        _get_json(base, f"/api/open?path={pkg}")
+        assert _limit() == "-1"
+        _post(base, "/api/set_limits",
+              {"limits": [{"child": "b", "lower": -0.5, "upper": 0.5}]})
+        assert float(_limit()) == -0.5
+        assert _get_json(base, "/api/history")["undo"]          # has an entry
+        code, r = _post(base, "/api/undo", {})
+        assert code == 200 and r["done"] == "undo"
+        assert _limit() == "-1"                                 # reverted
+        code, r = _post(base, "/api/redo", {})
+        assert code == 200 and float(_limit()) == -0.5          # reapplied
     finally:
         httpd.shutdown()
         httpd.server_close()

--- a/tests/test_urdf_mode_webserver.py
+++ b/tests/test_urdf_mode_webserver.py
@@ -653,6 +653,64 @@ def test_package_uris_rewritten_for_viewer(tmp_path):
         webserver._um["state"] = None
 
 
+def _mini_urdf_pkg(parent, name, body):
+    p = parent / name
+    (p / "urdf").mkdir(parents=True)
+    (p / "urdf" / "r.urdf").write_text(
+        f'<?xml version="1.0"?><robot name="r">{body}</robot>', encoding="utf-8")
+    return p
+
+
+def test_um_reset_on_cad_open(tmp_path):
+    """Opening a CAD package clears the URDF-mode overlay + undo history."""
+    from sw2robot.editor import webserver
+
+    urdfpkg = _mini_urdf_pkg(
+        tmp_path, "u",
+        '<link name="a"/><link name="b"/>'
+        '<joint name="j" type="revolute"><parent link="a"/><child link="b"/>'
+        '<axis xyz="0 0 1"/><limit lower="-1" upper="1" effort="1" velocity="1"/>'
+        '</joint>')
+    cadpkg = _mini_urdf_pkg(tmp_path, "c", '<link name="a"/>')
+    (cadpkg / "graph.json").write_text("{}", encoding="utf-8")   # marks CAD mode
+    base, httpd = _start(urdfpkg)
+    try:
+        _post(base, "/api/set_limits",
+              {"limits": [{"child": "b", "lower": -0.5, "upper": 0.5}]})
+        assert webserver._um["undo"]
+        info = _get_json(base, f"/api/open?path={cadpkg}")
+        assert info["mode"] == "cad"
+        assert webserver._um["state"] is None and not webserver._um["undo"]
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        webserver._um["state"] = None
+
+
+def test_mimic_on_fixed_joint_is_missed(tmp_path):
+    """A fixed joint can't follow a mimic -- the request is reported missed,
+    not falsely applied."""
+    from sw2robot.editor import webserver
+
+    pkg = _mini_urdf_pkg(
+        tmp_path, "p",
+        '<link name="a"/><link name="b"/><link name="c"/>'
+        '<joint name="jr" type="revolute"><parent link="a"/><child link="b"/>'
+        '<axis xyz="0 0 1"/><limit lower="-1" upper="1" effort="1" velocity="1"/>'
+        '</joint>'
+        '<joint name="jf" type="fixed"><parent link="a"/><child link="c"/></joint>')
+    base, httpd = _start(pkg)
+    try:
+        code, r = _post(base, "/api/set_mimic",
+                        {"changes": [{"child": "c", "master": "jr",
+                                      "multiplier": 1.0, "offset": 0.0}]})
+        assert code == 200 and r["applied"] == [] and r["missed"] == ["c"]
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        webserver._um["state"] = None
+
+
 def test_urdf_mode_undo_redo(tmp_path):
     """URDF-mode edits are undoable/redoable via the in-memory overlay stack."""
     from sw2robot.editor import webserver

--- a/tests/test_urdf_mode_webserver.py
+++ b/tests/test_urdf_mode_webserver.py
@@ -284,6 +284,330 @@ def test_live_urdf_reflects_edits_and_is_cache_stable(server):
     assert not os.path.basename(picked).startswith(".")
 
 
+_TRI_STL = ("solid t\n facet normal 0 0 1\n  outer loop\n"
+            "   vertex 0 0 0\n   vertex 0.1 0 0\n   vertex 0 0.1 0\n"
+            "  endloop\n endfacet\nendsolid t\n")
+
+
+def test_reexport_of_imported_package_urdf(tmp_path):
+    """Import a URDF that uses package:// mesh refs, then re-export it: the ROS
+    ZIP must actually CONTAIN the converted meshes and point at the NEW package
+    (regression: package:// refs were dropped -> no meshes, stale refs)."""
+    import io
+    import zipfile
+
+    import trimesh
+
+    from sw2robot.editor import webserver
+
+    pkg = tmp_path / "oldpkg"      # dir name == the self-ref package name
+    (pkg / "urdf").mkdir(parents=True)
+    (pkg / "meshes").mkdir()
+    # feetech-style meshes: a .dae visual + a .stl collision, plus a .stl-only
+    # link to exercise BOTH passthrough (same format) and conversion (.stl->.dae)
+    (pkg / "meshes" / "part.stl").write_text(_TRI_STL, encoding="utf-8")
+    (pkg / "meshes" / "part.dae").write_bytes(
+        trimesh.creation.box((0.1, 0.1, 0.1)).export(file_type="dae"))
+    # refs use a DIFFERENT package name ('oldpkg') so the rewrite is observable
+    (pkg / "urdf" / "robot.urdf").write_text(
+        '<?xml version="1.0"?><robot name="robot">'
+        '<link name="base_link">'
+        '<visual><geometry>'
+        '<mesh filename="package://oldpkg/meshes/part.dae"/></geometry></visual>'
+        '<collision><geometry>'
+        '<mesh filename="package://oldpkg/meshes/part.stl"/></geometry></collision>'
+        '</link>'
+        '<link name="tip">'
+        '<visual><geometry>'
+        '<mesh filename="package://oldpkg/meshes/part.stl"/></geometry></visual>'
+        '</link>'
+        '<joint name="j" type="fixed"><parent link="base_link"/>'
+        '<child link="tip"/></joint>'
+        '</robot>', encoding="utf-8")
+
+    httpd, port = webserver._bind_free_port(webserver._Handler, _free_port())
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{port}"
+    try:
+        assert _get_json(base, f"/api/open?path={pkg}")["mode"] == "urdf"
+        code, data = _get_status(base, "/api/export/zip?ros=1&meshes=dae")
+        assert code == 200, data[:300]
+        zf = zipfile.ZipFile(io.BytesIO(data))
+        names = zf.namelist()
+        # the meshes are actually shipped: .dae visual (passthrough + the
+        # .stl->.dae conversion) and the .stl collision (passthrough)
+        assert "robot_description/meshes/part.dae" in names, names
+        assert "robot_description/meshes/part.stl" in names, names
+        # the exported URDF points at the NEW package, not the stale 'oldpkg'
+        urdf = zf.read(next(n for n in names if n.endswith(".urdf"))).decode()
+        assert "package://oldpkg/" not in urdf
+        assert "package://robot_description/meshes/part.dae" in urdf
+        assert "package://robot_description/meshes/part.stl" in urdf
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        webserver._um["state"] = None
+
+
+def _start(pkg):
+    """Start a server on `pkg`, open it, return (base, httpd)."""
+    from sw2robot.editor import webserver
+    httpd, port = webserver._bind_free_port(webserver._Handler, _free_port())
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{port}"
+    _get_json(base, f"/api/open?path={pkg}")
+    return base, httpd
+
+
+def test_reexport_nested_mesh_path(tmp_path):
+    """A package:// ref into a SUBDIRECTORY (meshes/collision/part.stl) still
+    resolves to its source -- not flattened to meshes/part.stl and lost."""
+    import io
+    import zipfile
+
+    from sw2robot.editor import webserver
+
+    pkg = tmp_path / "oldpkg"      # dir name == the self-ref package name
+    (pkg / "urdf").mkdir(parents=True)
+    (pkg / "meshes" / "collision").mkdir(parents=True)
+    (pkg / "meshes" / "collision" / "part.stl").write_text(_TRI_STL, encoding="utf-8")
+    (pkg / "urdf" / "robot.urdf").write_text(
+        '<?xml version="1.0"?><robot name="robot"><link name="base_link">'
+        '<collision><geometry>'
+        '<mesh filename="package://oldpkg/meshes/collision/part.stl"/>'
+        '</geometry></collision></link></robot>', encoding="utf-8")
+    base, httpd = _start(pkg)
+    try:
+        code, data = _get_status(base, "/api/export/zip?ros=1&meshes=dae")
+        assert code == 200, data[:300]
+        names = zipfile.ZipFile(io.BytesIO(data)).namelist()
+        assert any(n.endswith("/meshes/part.stl") for n in names), names
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        webserver._um["state"] = None
+
+
+def test_reexport_glb_distinct_meshes_same_basename(tmp_path):
+    """visual part.dae + collision part.stl exported to glb must NOT collapse to
+    one part.glb -- distinct sources get distinct output names."""
+    import io
+    import zipfile
+
+    import trimesh
+
+    from sw2robot.editor import webserver
+
+    pkg = tmp_path / "oldpkg"      # dir name == the self-ref package name
+    (pkg / "urdf").mkdir(parents=True)
+    (pkg / "meshes").mkdir()
+    (pkg / "meshes" / "part.stl").write_text(_TRI_STL, encoding="utf-8")
+    (pkg / "meshes" / "part.dae").write_bytes(
+        trimesh.creation.box((0.1, 0.1, 0.1)).export(file_type="dae"))
+    (pkg / "urdf" / "robot.urdf").write_text(
+        '<?xml version="1.0"?><robot name="robot"><link name="base_link">'
+        '<visual><geometry>'
+        '<mesh filename="package://oldpkg/meshes/part.dae"/></geometry></visual>'
+        '<collision><geometry>'
+        '<mesh filename="package://oldpkg/meshes/part.stl"/></geometry></collision>'
+        '</link></robot>', encoding="utf-8")
+    base, httpd = _start(pkg)
+    try:
+        code, data = _get_status(base, "/api/export/zip?ros=1&meshes=glb")
+        assert code == 200, data[:300]
+        zf = zipfile.ZipFile(io.BytesIO(data))
+        glbs = [n for n in zf.namelist() if n.endswith(".glb")]
+        assert len(glbs) == 2, glbs            # both meshes shipped, not collapsed
+        urdf = zf.read(next(n for n in zf.namelist() if n.endswith(".urdf"))).decode()
+        # visual and collision reference DIFFERENT glb files
+        refs = re.findall(r'filename="([^"]+\.glb)"', urdf)
+        assert len(set(refs)) == 2, refs
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        webserver._um["state"] = None
+
+
+def test_reexport_keeps_external_package_refs(tmp_path):
+    """A mesh from ANOTHER ROS package (not vendored here) must be left untouched
+    -- export should not abort with 'no source mesh' on an external dependency."""
+    import io
+    import zipfile
+
+    from sw2robot.editor import webserver
+
+    pkg = tmp_path / "oldpkg"      # dir name == the self-ref package name
+    (pkg / "urdf").mkdir(parents=True)
+    (pkg / "meshes").mkdir()
+    (pkg / "meshes" / "own.stl").write_text(_TRI_STL, encoding="utf-8")
+    (pkg / "urdf" / "robot.urdf").write_text(
+        '<?xml version="1.0"?><robot name="robot"><link name="base_link">'
+        '<visual><geometry>'           # own mesh -> converted
+        '<mesh filename="package://oldpkg/meshes/own.stl"/></geometry></visual>'
+        '<collision><geometry>'        # external dep -> left as-is
+        '<mesh filename="package://common_meshes/meshes/shared.stl"/>'
+        '</geometry></collision></link></robot>', encoding="utf-8")
+    base, httpd = _start(pkg)
+    try:
+        code, data = _get_status(base, "/api/export/zip?ros=1&meshes=dae")
+        assert code == 200, data[:300]      # did NOT abort on the external ref
+        zf = zipfile.ZipFile(io.BytesIO(data))
+        urdf = zf.read(next(n for n in zf.namelist()
+                            if n.endswith(".urdf"))).decode()
+        # own mesh repackaged; external dep untouched
+        assert "package://robot_description/meshes/own.dae" in urdf
+        assert "package://common_meshes/meshes/shared.stl" in urdf
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        webserver._um["state"] = None
+
+
+def test_reexport_dae_sidecar_textures(tmp_path):
+    """A passthrough .dae that references a sidecar texture ships the texture in
+    the exported package too (otherwise the visual breaks)."""
+    import io
+    import zipfile
+
+    from sw2robot.editor import webserver
+
+    pkg = tmp_path / "oldpkg"
+    (pkg / "urdf").mkdir(parents=True)
+    (pkg / "meshes").mkdir()
+    (pkg / "meshes" / "tex.png").write_bytes(b"\x89PNG\r\n fake-image")
+    (pkg / "meshes" / "part.dae").write_text(
+        '<?xml version="1.0"?>'
+        '<COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" '
+        'version="1.4.1"><library_images><image id="t">'
+        '<init_from>tex.png</init_from></image></library_images></COLLADA>',
+        encoding="utf-8")
+    (pkg / "urdf" / "robot.urdf").write_text(
+        '<?xml version="1.0"?><robot name="robot"><link name="base_link">'
+        '<visual><geometry>'
+        '<mesh filename="package://oldpkg/meshes/part.dae"/></geometry></visual>'
+        '</link></robot>', encoding="utf-8")
+    base, httpd = _start(pkg)
+    try:
+        code, data = _get_status(base, "/api/export/zip?ros=1&meshes=dae")
+        assert code == 200, data[:200]
+        names = zipfile.ZipFile(io.BytesIO(data)).namelist()
+        assert "robot_description/meshes/part.dae" in names, names
+        assert "robot_description/meshes/tex.png" in names, names   # sidecar shipped
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        webserver._um["state"] = None
+
+
+def test_export_recolors_mesh_by_link_name(tmp_path):
+    """A colour edit keyed by LINK name reaches the mesh converter even when the
+    link name differs from the mesh basename (the URDF-input keying)."""
+    import io
+    import zipfile
+
+    from sw2robot.editor import webserver
+
+    pkg = tmp_path / "oldpkg"
+    (pkg / "urdf").mkdir(parents=True)
+    (pkg / "meshes").mkdir()
+    (pkg / "meshes" / "chassis.stl").write_text(_TRI_STL, encoding="utf-8")
+    (pkg / "urdf" / "robot.urdf").write_text(             # link != mesh basename
+        '<?xml version="1.0"?><robot name="robot"><link name="base_link">'
+        '<visual><geometry>'
+        '<mesh filename="package://oldpkg/meshes/chassis.stl"/></geometry></visual>'
+        '</link></robot>', encoding="utf-8")
+
+    def _dae(base):
+        code, data = _get_status(base, "/api/export/zip?ros=1&meshes=dae")
+        assert code == 200, data[:200]
+        zf = zipfile.ZipFile(io.BytesIO(data))
+        return zf.read(next(n for n in zf.namelist()
+                            if n.endswith("chassis.dae")))
+
+    base, httpd = _start(pkg)
+    try:
+        plain = _dae(base)
+        _post(base, "/api/set_color", {"link": "base_link", "color": "#ff0000"})
+        coloured = _dae(base)
+        # the colour (keyed by the link name) changed the converted mesh
+        assert coloured != plain
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        webserver._um["state"] = None
+
+
+def test_export_shared_mesh_distinct_per_link_colors(tmp_path):
+    """Two links sharing ONE source mesh but with different colour edits export
+    as two distinct coloured meshes (the cache keys on colour)."""
+    import io
+    import zipfile
+
+    from sw2robot.editor import webserver
+
+    pkg = tmp_path / "oldpkg"
+    (pkg / "urdf").mkdir(parents=True)
+    (pkg / "meshes").mkdir()
+    (pkg / "meshes" / "shared.stl").write_text(_TRI_STL, encoding="utf-8")
+    mesh = '<mesh filename="package://oldpkg/meshes/shared.stl"/>'
+    (pkg / "urdf" / "robot.urdf").write_text(
+        f'<?xml version="1.0"?><robot name="robot">'
+        f'<link name="a"><visual><geometry>{mesh}</geometry></visual></link>'
+        f'<link name="b"><visual><geometry>{mesh}</geometry></visual></link>'
+        f'<joint name="j" type="fixed"><parent link="a"/><child link="b"/></joint>'
+        f'</robot>', encoding="utf-8")
+    base, httpd = _start(pkg)
+    try:
+        _post(base, "/api/set_color", {"link": "a", "color": "#ff0000"})
+        _post(base, "/api/set_color", {"link": "b", "color": "#0000ff"})
+        code, data = _get_status(base, "/api/export/zip?ros=1&meshes=dae")
+        assert code == 200, data[:200]
+        zf = zipfile.ZipFile(io.BytesIO(data))
+        daes = [n for n in zf.namelist() if n.endswith(".dae")]
+        assert len(daes) == 2, daes                 # two distinct coloured meshes
+        assert zf.read(daes[0]) != zf.read(daes[1])
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        webserver._um["state"] = None
+
+
+def test_reexport_owner_from_manifest_name(tmp_path):
+    """Own meshes are vendored when package.xml <name> matches the ref, even if
+    the containing FOLDER is named differently."""
+    import io
+    import zipfile
+
+    from sw2robot.editor import webserver
+
+    pkg = tmp_path / "weird_folder_name"          # folder != package name
+    (pkg / "urdf").mkdir(parents=True)
+    (pkg / "meshes").mkdir()
+    (pkg / "meshes" / "part.stl").write_text(_TRI_STL, encoding="utf-8")
+    (pkg / "package.xml").write_text(
+        '<?xml version="1.0"?><package format="2"><name>oldpkg</name></package>',
+        encoding="utf-8")
+    (pkg / "urdf" / "robot.urdf").write_text(
+        '<?xml version="1.0"?><robot name="robot"><link name="base_link">'
+        '<visual><geometry>'
+        '<mesh filename="package://oldpkg/meshes/part.stl"/></geometry></visual>'
+        '</link></robot>', encoding="utf-8")
+    base, httpd = _start(pkg)
+    try:
+        code, data = _get_status(base, "/api/export/zip?ros=1&meshes=dae")
+        assert code == 200, data[:300]
+        zf = zipfile.ZipFile(io.BytesIO(data))
+        assert "robot_description/meshes/part.dae" in zf.namelist()
+        urdf = zf.read(next(n for n in zf.namelist()
+                            if n.endswith(".urdf"))).decode()
+        assert "package://oldpkg/" not in urdf
+        assert "package://robot_description/meshes/part.dae" in urdf
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        webserver._um["state"] = None
+
+
 def test_package_uris_rewritten_for_viewer(tmp_path):
     """A URDF that references meshes via package:// is served to the viewer with
     /pkg/ paths (so the browser fetches them from the package server instead of

--- a/tests/test_urdf_mode_webserver.py
+++ b/tests/test_urdf_mode_webserver.py
@@ -139,6 +139,11 @@ def _link(root, name):
 
 
 # --------------------------------------------------------------- tests
+def test_info_reports_urdf_mode(server):
+    """The frontend gates URDF-only controls (inertial editing) on info.mode."""
+    assert _get_json(server, "/api/info")["mode"] == "urdf"
+
+
 def test_serves_base_urdf_unedited(server):
     _require_fixture()
     root = _served_urdf(server)
@@ -170,6 +175,14 @@ def test_set_inertial(server):
 def test_set_inertial_nonphysical_is_400(server):
     code, r = _post(server, "/api/set_inertial",
                     {"link": TIP_LINK, "inertia": [1, 0, 0, 1, 0, 10]})
+    assert code == 400 and "error" in r
+
+
+def test_set_inertial_malformed_body_is_400(server):
+    """A null in the com/inertia arrays (e.g. an empty UI field) is a 400, not a
+    500 -- the bad-input guard covers TypeError too."""
+    code, r = _post(server, "/api/set_inertial",
+                    {"link": TIP_LINK, "com": [None, 0, 0]})
     assert code == 400 and "error" in r
 
 

--- a/tests/test_urdf_mode_webserver.py
+++ b/tests/test_urdf_mode_webserver.py
@@ -117,6 +117,14 @@ def _post(base, path, body):
         return e.code, json.loads(e.read().decode("utf-8"))
 
 
+def _get_status(base, path):
+    try:
+        with urllib.request.urlopen(base + path) as r:
+            return r.status, r.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read()
+
+
 def _served_urdf(base):
     info = _get_json(base, "/api/info")
     return ET.fromstring(_get(base, info["urdf"]))
@@ -233,6 +241,59 @@ def test_components_lists_links_with_overlay_colour(server):
     comp = _get_json(server, "/api/components")
     assert TIP_LINK in comp["links"]
     assert comp["colors"][TIP_LINK] == "#00ff00"
+
+
+def test_live_urdf_reflects_edits_and_is_cache_stable(server):
+    """collision / auto-limits read a hidden live URDF that tracks the overlay
+    but only rewrites when edits change (so their (path, mtime) cache holds)."""
+    import os
+
+    from sw2robot.editor import webserver
+
+    state = webserver._um["state"]
+    pkg = state.package_dir
+    rel = os.path.relpath(state.urdf_path, pkg).replace("\\", "/")
+
+    _post(server, "/api/set_types",
+          {"changes": [{"child": SCREW_LINK, "type": "revolute"}]})
+    live, _ = webserver._um_live_urdf(pkg, rel)
+    assert os.path.basename(live).startswith(".") and live.endswith(".live.urdf")
+    root = ET.fromstring(Path(live).read_text(encoding="utf-8"))
+    assert _joint(root, FIXED_JOINT).get("type") == "revolute"
+
+    m1 = os.path.getmtime(live)
+    again, _ = webserver._um_live_urdf(pkg, rel)        # no edit -> not rewritten
+    assert os.path.getmtime(again) == m1
+
+    # the hidden live copy must never be picked as the package URDF on re-open
+    _, picked = webserver._resolve_package(pkg)
+    assert not os.path.basename(picked).startswith(".")
+
+
+def test_export_rejects_nonstandard_layout(_built_template, tmp_path):
+    """A flat URDF package (urdf at the package root) can't be exported -- the
+    ROS exporter needs urdf/<name>.urdf + meshes/; fail with a clear message."""
+    from sw2robot.editor import webserver
+
+    flat = tmp_path / "flat"
+    (flat / "meshes").mkdir(parents=True)
+    shutil.copy2(_built_template / "urdf" / "fingertip.urdf", flat / "fingertip.urdf")
+    for f in (_built_template / "meshes").iterdir():
+        if f.is_file():
+            shutil.copy2(f, flat / "meshes" / f.name)
+
+    httpd, port = webserver._bind_free_port(webserver._Handler, _free_port())
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{port}"
+    try:
+        _get_json(base, f"/api/open?path={flat}")
+        code, body = _get_status(base, "/api/export/zip?ros=1&meshes=dae")
+        assert code == 400
+        assert b"layout" in body.lower()
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        webserver._um["state"] = None
 
 
 def test_edits_persist_to_sidecar(server, tmp_path):

--- a/tests/test_urdf_mode_webserver.py
+++ b/tests/test_urdf_mode_webserver.py
@@ -283,6 +283,39 @@ def test_live_urdf_reflects_edits_and_is_cache_stable(server):
     assert not os.path.basename(picked).startswith(".")
 
 
+def test_package_uris_rewritten_for_viewer(tmp_path):
+    """A URDF that references meshes via package:// is served to the viewer with
+    /pkg/ paths (so the browser fetches them from the package server instead of
+    404-ing on http://host/<pkgname>/meshes/...)."""
+    from sw2robot.editor import webserver
+
+    pkg = tmp_path / "pkgpkg"
+    (pkg / "urdf").mkdir(parents=True)
+    (pkg / "meshes").mkdir()
+    (pkg / "meshes" / "part.stl").write_text("solid x\nendsolid x\n", encoding="utf-8")
+    (pkg / "urdf" / "robot.urdf").write_text(
+        '<?xml version="1.0"?><robot name="robot">'
+        '<link name="base_link"><visual><geometry>'
+        '<mesh filename="package://robot_description/meshes/part.stl"/>'
+        '</geometry></visual></link></robot>', encoding="utf-8")
+
+    httpd, port = webserver._bind_free_port(webserver._Handler, _free_port())
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{port}"
+    try:
+        info = _get_json(base, f"/api/open?path={pkg}")
+        assert info["mode"] == "urdf"
+        served = _get(base, info["urdf"])
+        assert 'filename="/pkg/meshes/part.stl"' in served
+        assert "package://" not in served
+        code, _ = _get_status(base, "/pkg/meshes/part.stl")   # actually fetchable
+        assert code == 200
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        webserver._um["state"] = None
+
+
 def test_export_rejects_nonstandard_layout(_built_template, tmp_path):
     """A flat URDF package (urdf at the package root) can't be exported -- the
     ROS exporter needs urdf/<name>.urdf + meshes/; fail with a clear message."""

--- a/tests/test_urdf_mode_webserver.py
+++ b/tests/test_urdf_mode_webserver.py
@@ -342,6 +342,29 @@ def test_mimic_master_after_rename(server):
         == "driver"
 
 
+def test_export_zip_bakes_colour_and_restores_pristine(server):
+    """Full parity check: in URDF-input mode a colour edit + ROS ZIP export
+    produces a package whose URDF carries the colour, and the on-disk URDF is
+    left pristine afterwards (export only materializes the overlay transiently)."""
+    import io
+    import zipfile
+
+    from sw2robot.editor import webserver
+
+    _post(server, "/api/set_color", {"link": TIP_LINK, "color": "#ff0000"})
+    code, data = _get_status(server, "/api/export/zip?ros=1&meshes=dae")
+    assert code == 200, data[:200]
+    zf = zipfile.ZipFile(io.BytesIO(data))
+    urdf_name = next(n for n in zf.namelist() if n.endswith(".urdf"))
+    exported = zf.read(urdf_name).decode("utf-8")
+    assert 'rgba="1 0 0 1"' in exported          # colour baked into the URDF
+    assert any(n.endswith(".dae") for n in zf.namelist())   # visual meshes exported
+
+    # the on-disk URDF stays pristine (no <material>); edits live in the overlay
+    disk = Path(webserver._um["state"].urdf_path).read_text(encoding="utf-8")
+    assert "material" not in disk
+
+
 def test_export_materializes_overlay_then_restores(server):
     """The on-disk URDF stays pristine while serving live, but the export window
     temporarily materializes the overlay so the ROS exporter picks edits up."""


### PR DESCRIPTION
## Summary

Until now the editor could only open a SolidWorks-derived package (with a cached `graph.json`) and edit it via `joints.yaml` + a full `build()` rebuild. This PR adds a **URDF-input editing mode**: open any plain `.urdf` directly and edit it — colour, inertial, joint limits, mimic, joint type, axis flip, rename — then export a portable ROS package, the same as the CAD flow.

A package **without** `graph.json` is detected as URDF-input mode. There is no CAD graph to rebuild from, so edits run through the same core overlay (`RobotCompilerState` with per-joint `edits` and per-link `link_edits`) the headless CLI uses, applied to the URDF by `build_urdf`. CAD mode is untouched: every edit endpoint gains an `if not _cad_mode(): <overlay branch>` ahead of the existing `joints.yaml` logic.

## Whats included

**Core edit model**
- New `LinkEdit` (colour / mass / CoM / inertia) + `link_edits` on `RobotCompilerState`; `build_urdf` bakes them (`<material>`, `<inertial>`). Inputs validated up front (hex colour; finite mass > 0; physical inertia tensor via the exporters own positive-definite + triangle-inequality check).
- `build_urdf` backfills a URDF-required `<axis>`/`<limit>` when a joint is made movable, so a type change alone never emits invalid URDF; `effective_type` so an overlay type change is seen by mimic validation; `sanitize=` to keep a user-opened URDFs names verbatim.

**URDF-input mode (web server)**
- `/api/open` (and startup) loads the overlay; the URDF URL is served as `build_urdf(state)` on the fly, so the on-disk file stays the pristine base and edits survive a restart via the `.sw2robot.json` sidecar.
- limits / types / mimic / axis-flip / colour / rename + a new `/api/set_inertial`, all routed through the core setters (child-link and renamed names mapped back to overlay keys).
- `package://` mesh refs are rewritten to relative paths for the viewer **only when the mesh exists in this package** (own meshes load even if the folder name differs from the URI package; external/absent refs are left as `package://`).
- collision highlight + auto-limit sweep read a hidden, overlay-synced live URDF; ZIP export materialises the overlay; in-memory undo/redo.

**CAD path improvement**
- `set_limits` / `set_mimic` now edit the served URDF in place (like flip/rename) instead of a full inertia-recomputing `build()` — `joints.yaml` is still written for persistence / re-extract / undo.

**Re-export of imported URDFs** (`ros_export`)
- handles `.stl/.dae/.obj` sources (not just CAD `.3dxml/.glb`); same-format meshes are copied verbatim (incl. `.dae` sidecar textures); `package://<own>/...` and relative refs resolve (subdirs preserved, backslashes tolerated); refs to other ROS packages / absolute / escaping paths are left untouched; mesh dedup keys on `(source, fmt, colour)` so distinct or differently-coloured meshes never overwrite.

**Frontend**
- the link panels mass / CoM / inertia become editable in URDF mode (read-only in CAD), and the panel is now scrollable so the colour/inertial controls are always reachable.

## Tests
- Golden characterisation tests for the CAD→URDF edit pipeline (inertia normalised so theyre platform-stable).
- In-process HTTP integration tests for URDF-input mode (`test_urdf_mode_webserver.py`) and the CAD in-place edits (`test_cad_mode_webserver.py`), unit tests for the overlay (`test_link_edits.py`), and a headless-Chrome e2e for the inertial UI wired into CI (`e2e-urdf` job).
- Full suite green (194 passed) with the full optional deps installed.
@