### PR TITLE
feat(urdf): emit per-link material/density/inertia provenance comment

### DIFF
--- a/sw2robot/editor/core.py
+++ b/sw2robot/editor/core.py
@@ -683,7 +683,15 @@ def build_urdf(state: RobotCompilerState, sanitize: bool = True) -> str:
     of hyphens and other unsafe characters.  Pass ``sanitize=False`` when editing
     a URDF the user opened directly: its names are already its own contract (the
     viewer shows them, edits reference them), so they must be preserved verbatim."""
-    root = ET.fromstring(Path(state.urdf_path).read_text(encoding="utf-8"))
+    # Preserve XML comments on the round trip: a CAD-exported URDF carries
+    # per-link ``<!-- sw2robot material=... density=... inertia=... -->``
+    # provenance, and the user may open / edit / re-export it here.  The default
+    # parser silently drops comments, so use a comment-keeping TreeBuilder; the
+    # comment nodes have a non-string tag, so findall("link")/("joint") below
+    # still ignore them.
+    parser = ET.XMLParser(target=ET.TreeBuilder(insert_comments=True))
+    root = ET.fromstring(Path(state.urdf_path).read_text(encoding="utf-8"),
+                         parser=parser)
     renames = {j: e.rename for j, e in state.edits.items() if e.rename}
 
     for je in root.findall("joint"):

--- a/sw2robot/exporter/ros_export.py
+++ b/sw2robot/exporter/ros_export.py
@@ -345,7 +345,13 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
     # are vendored/repointed; refs to other ROS packages are left untouched
     own_pkgs = _own_pkg_names(pkg_dir)
     urdf_path = os.path.join(pkg_dir, "urdf", robot_name + ".urdf")
-    root = ET.parse(urdf_path).getroot()
+    # Keep XML comments: the default parser drops them, which both loses the
+    # per-link ``<!-- sw2robot ... -->`` provenance and leaves a blank,
+    # whitespace-only line where each comment was (its surrounding indentation
+    # merges into the link's text).  Comment nodes have a non-string tag, so the
+    # findall()/iter() traversals below ignore them.
+    _parser = ET.XMLParser(target=ET.TreeBuilder(insert_comments=True))
+    root = ET.parse(urdf_path, parser=_parser).getroot()
     colors = colors or {}
 
     files = []

--- a/sw2robot/exporter/urdf_writer.py
+++ b/sw2robot/exporter/urdf_writer.py
@@ -32,6 +32,38 @@ def _fmt(v):
     return " ".join(f"{x:.8g}" for x in v)
 
 
+def _comment_safe(text):
+    """Make ``text`` safe to embed inside an XML comment.
+
+    XML comments may not contain ``--`` and may not end with ``-``; collapse any
+    such run so the comment stays well-formed regardless of the material name.
+    """
+    cleaned = str(text).replace("--", "-").strip()
+    return cleaned.rstrip("-")
+
+
+def _provenance_comment(comp, method):
+    """Build the ``<!-- sw2robot ... -->`` provenance line for a link.
+
+    Records the SolidWorks material, its density (kg/m^3) and how the inertial
+    was obtained (``solidworks`` / ``mesh`` / ``hull`` / ``bbox`` /
+    ``placeholder``), so the exported URDF is self-documenting. Returns ``None``
+    when there is nothing worth recording.
+    """
+    fields = []
+    material = getattr(comp, "material", None)
+    density = getattr(comp, "density", None)
+    if material:
+        fields.append(f'material="{_comment_safe(material)}"')
+    if density is not None:
+        fields.append(f'density="{float(density):g}"')  # kg/m^3
+    if method:
+        fields.append(f'inertia="{method}"')
+    if not fields:
+        return None
+    return f'    <!-- sw2robot {" ".join(fields)} -->'
+
+
 def _inertial_xml(comp, mesh_dir, density):
     """Compute and format a link's ``<inertial>``.
 
@@ -131,6 +163,9 @@ def _link_xml(comp, ros_pkg=None, rn=lambda n: n, mesh_dir=None, density=None):
             lines.append("      </geometry>")
             lines.append(f"    </{tag}>")
     inertial_lines, method, problems = _inertial_xml(comp, mesh_dir, density)
+    comment = _provenance_comment(comp, method)
+    if comment is not None:
+        lines.insert(1, comment)  # right after the <link name=...> line
     lines.extend(inertial_lines)
     lines.append("  </link>")
     return "\n".join(lines), method, problems

--- a/tests/golden/fingertip_base.urdf
+++ b/tests/golden/fingertip_base.urdf
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <robot name="fingertip">
   <link name="fingertip_back_1">
+    <!-- sw2robot inertia="hull" -->
     <visual>
       <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 -5.5511151e-17 3.1415927"/>
       <geometry>
@@ -16,6 +17,7 @@
     <inertial/>
   </link>
   <link name="base_link">
+    <!-- sw2robot inertia="hull" -->
     <visual>
       <origin xyz="3.8518599e-34 0 0" rpy="0 -0 -4.4572704e-33"/>
       <geometry>
@@ -31,6 +33,7 @@
     <inertial/>
   </link>
   <link name="screwlock_male_hard_jointbase_v4_1">
+    <!-- sw2robot material="ABS" density="1020" inertia="hull" -->
     <visual>
       <origin xyz="0 0 -1.540744e-33" rpy="5.0814364e-33 2.4652673e-34 -6.3441378e-33"/>
       <geometry>

--- a/tests/golden/fingertip_edited.urdf
+++ b/tests/golden/fingertip_edited.urdf
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <robot name="fingertip">
   <link name="tip">
+    <!-- sw2robot inertia="hull" -->
     <visual>
       <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 -5.5511151e-17 3.1415927"/>
       <geometry>
@@ -16,6 +17,7 @@
     <inertial/>
   </link>
   <link name="base_link">
+    <!-- sw2robot inertia="hull" -->
     <visual>
       <origin xyz="3.8518599e-34 0 0" rpy="0 -0 -4.4572704e-33"/>
       <geometry>
@@ -31,6 +33,7 @@
     <inertial/>
   </link>
   <link name="screwlock_male_hard_jointbase_v4_1">
+    <!-- sw2robot material="ABS" density="1020" inertia="hull" -->
     <visual>
       <origin xyz="1.1131366e-18 0.017 -0.003" rpy="-1.5707963 2.5061606e-16 -3.1415927"/>
       <geometry>

--- a/tests/golden/fingertip_flip.urdf
+++ b/tests/golden/fingertip_flip.urdf
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <robot name="fingertip">
   <link name="fingertip_back_1">
+    <!-- sw2robot inertia="hull" -->
     <visual>
       <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 -5.5511151e-17 3.1415927"/>
       <geometry>
@@ -16,6 +17,7 @@
     <inertial/>
   </link>
   <link name="base_link">
+    <!-- sw2robot inertia="hull" -->
     <visual>
       <origin xyz="3.8518599e-34 0 0" rpy="0 -0 -4.4572704e-33"/>
       <geometry>
@@ -31,6 +33,7 @@
     <inertial/>
   </link>
   <link name="screwlock_male_hard_jointbase_v4_1">
+    <!-- sw2robot material="ABS" density="1020" inertia="hull" -->
     <visual>
       <origin xyz="0 0 -1.540744e-33" rpy="5.0814364e-33 2.4652673e-34 -6.3441378e-33"/>
       <geometry>

--- a/tests/golden/fingertip_rename_direct.urdf
+++ b/tests/golden/fingertip_rename_direct.urdf
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <robot name="fingertip">
   <link name="tip">
+    <!-- sw2robot inertia="hull" -->
     <visual>
       <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 -5.5511151e-17 3.1415927"/>
       <geometry>
@@ -16,6 +17,7 @@
     <inertial/>
   </link>
   <link name="base_link">
+    <!-- sw2robot inertia="hull" -->
     <visual>
       <origin xyz="3.8518599e-34 0 0" rpy="0 -0 -4.4572704e-33"/>
       <geometry>
@@ -31,6 +33,7 @@
     <inertial/>
   </link>
   <link name="screwlock_male_hard_jointbase_v4_1">
+    <!-- sw2robot material="ABS" density="1020" inertia="hull" -->
     <visual>
       <origin xyz="0 0 -1.540744e-33" rpy="5.0814364e-33 2.4652673e-34 -6.3441378e-33"/>
       <geometry>

--- a/tests/test_urdf_mode_webserver.py
+++ b/tests/test_urdf_mode_webserver.py
@@ -825,9 +825,11 @@ def test_export_zip_bakes_colour_and_restores_pristine(server):
     assert 'rgba="1 0 0 1"' in exported          # colour baked into the URDF
     assert any(n.endswith(".dae") for n in zf.namelist())   # visual meshes exported
 
-    # the on-disk URDF stays pristine (no <material>); edits live in the overlay
+    # the on-disk URDF stays pristine (no <material> colour element); edits live
+    # in the overlay.  (The provenance "<!-- sw2robot material=... -->" comment
+    # legitimately contains the word "material", so match the element, not it.)
     disk = Path(webserver._um["state"].urdf_path).read_text(encoding="utf-8")
-    assert "material" not in disk
+    assert "<material" not in disk
 
 
 def test_export_materializes_overlay_then_restores(server):
@@ -842,7 +844,9 @@ def test_export_materializes_overlay_then_restores(server):
     disk = Path(state.urdf_path)
     rel = os.path.relpath(state.urdf_path, state.package_dir).replace("\\", "/")
 
-    assert "material" not in disk.read_text(encoding="utf-8")   # pristine on disk
+    # match "<material" (the baked colour element), not the word "material":
+    # the provenance "<!-- sw2robot material=... -->" comment carries it too.
+    assert "<material" not in disk.read_text(encoding="utf-8")  # pristine on disk
     with webserver._um_materialized(state.package_dir, rel):
         assert "<material" in disk.read_text(encoding="utf-8")  # edits visible
-    assert "material" not in disk.read_text(encoding="utf-8")   # restored
+    assert "<material" not in disk.read_text(encoding="utf-8")  # restored


### PR DESCRIPTION
Write each link's SolidWorks material, density (kg/m^3) and inertial source (solidworks/mesh/hull/bbox/placeholder) into the URDF as a `<!-- sw2robot ... -->` comment so the exported file is self-documenting. The material name is sanitised so a comment-illegal `--` stays well-formed.

Preserve these comments across the editor re-export paths: both the URDF-input editing mode (build_urdf) and the ROS export now parse with a comment-keeping TreeBuilder. The default parser silently dropped comments, which also left a blank, whitespace-only line where each comment had been.

Re-baseline the golden URDFs and tighten the urdf-mode pristine check to match the `<material>` element rather than the substring "material" (the provenance comment legitimately contains that word).