### PR TITLE
fix(editor): localize 4 UI strings stuck in Japanese under EN

### DIFF
--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -357,7 +357,8 @@
       <button id="posedrag" class="toggle" data-i18n-title="t.posedrag"
               title="OFF: ドラッグで視点回転 / ON: リンクをドラッグして関節を動かす">
         🖐 pose</button>
-      <button id="playmode" class="toggle" data-i18n-title="t.playmode"
+      <button id="playmode" class="toggle" data-i18n="ui.playmode"
+              data-i18n-title="t.playmode"
               title="動かすモード: 右パネルを可動関節のスライダーだけにする（たくさんのリンクを隠してシンプルに動かせる）">
         ▶ 動かす</button>
       <button id="keycast" class="toggle" data-i18n-title="t.keycast"
@@ -432,7 +433,8 @@
          border-radius:6px;padding:5px 12px;font-size:12px;
          box-shadow:0 2px 10px #0006">
       <span id="mimicbartext"></span>
-      <button id="mimicapply" style="background:#6a4fb0;color:#fff;
+      <button id="mimicapply" data-i18n="ui.mimicapply"
+              style="background:#6a4fb0;color:#fff;
               border-color:#9b80e0">適用 (Enter)</button>
       <button id="mimiccancel">✕</button>
     </div>
@@ -454,7 +456,7 @@
     <div id="linkinfo"></div>
     <div id="keyoverlay" aria-hidden="true"></div>
   </div>
-  <div id="resizer" title="ドラッグでパネル幅を調整"></div>
+  <div id="resizer" data-i18n-title="t.resizer" title="ドラッグでパネル幅を調整"></div>
   <div id="panel">
     <div id="langbar" style="display:flex;gap:4px;justify-content:flex-end;
          margin-bottom:2px" data-i18n-title="lang.title" title="display language">
@@ -472,7 +474,8 @@
         🎯 Extract the assembly open in SolidWorks</button>
       <div id="swstat" style="font-size:11px;color:#8a93a3"></div>
       <div style="display:flex;gap:4px">
-        <button id="fsbrowse" style="flex:1" data-i18n-title="t.fsbrowse"
+        <button id="fsbrowse" style="flex:1" data-i18n="ui.fsbrowse"
+                data-i18n-title="t.fsbrowse"
                 title="サーバー側のファイルブラウザ（最近のファイル＋フルパス貼り付け）">
           🗄 開く…</button>
       </div>
@@ -1091,6 +1094,10 @@ skrobot / native-mesh consumers (not RViz-loadable)">⬇ glb</button></a>
     'ui.btRevolute': { en: 'revolute', ja: '回転' },
     'ui.btContinuous': { en: 'continuous', ja: '連続回転' },
     'ui.btPrismatic': { en: 'prismatic', ja: '直動' },
+    'ui.playmode': { en: '▶ play', ja: '▶ 動かす' },
+    'ui.mimicapply': { en: 'Apply (Enter)', ja: '適用 (Enter)' },
+    'ui.fsbrowse': { en: '🗄 Open…', ja: '🗄 開く…' },
+    't.resizer': { en: 'drag to resize the panel', ja: 'ドラッグでパネル幅を調整' },
     'ui.useactive': { en: '🎯 Extract the assembly open in SolidWorks', ja: '🎯 SolidWorksで開いているアセンブリを抽出' },
     't.fsbrowse': { en: 'server-side file browser: recent files + paste a full path',
                     ja: 'サーバー側ファイルブラウザ：最近のファイル＋フルパス貼り付け' },


### PR DESCRIPTION
## Problem
With the display language set to **EN**, a few UI elements still rendered in Japanese.

The editor localizes static chrome through `applyStaticI18n()`, which only swaps the text/title/placeholder of elements carrying a `data-i18n` / `data-i18n-title` / `data-i18n-ph` attribute. Four elements had hardcoded Japanese with **no such attribute**, so they were never translated:

| Element | Leaked string | Kind |
|---|---|---|
| `#playmode` button | `▶ 動かす` | text |
| `#mimicapply` button | `適用 (Enter)` | text |
| `#fsbrowse` button | `🗄 開く…` | text |
| `#resizer` | `ドラッグでパネル幅を調整` | tooltip |

## Fix
Wire each element through the i18n dictionary with new keys: `ui.playmode` (`▶ play`), `ui.mimicapply` (`Apply (Enter)`), `ui.fsbrowse` (`🗄 Open…`), `t.resizer` (`drag to resize the panel`).

## Verification
- Cross-checked **all 61** `data-i18n*` keys referenced in the HTML against the dictionary — every one is defined and has an `en` value (no missing keys).
- Re-scanned the file for Japanese outside the `I18N` dictionary and outside i18n-wired elements — **no remaining leaks** (only the intentional `日本語` language-toggle label and code comments remain).
- The many Japanese `title=` tooltips elsewhere were already wired via `data-i18n-title`, so they correctly switch to English; they were not leaks.
- e2e tests reference `#fsbrowse` by id, so the label change does not affect them.