### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sw2robot"
-version = "0.1.22"
+version = "0.2.0"
 description = "SolidWorks assembly -> URDF exporter with a browser-based editor"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Minor version bump 0.1.22 → 0.2.0.

Ships the in-app self-update feature (#69) and the EN-mode i18n fixes (#70).

Once CI is green this is merged and the matching `v0.2.0` tag is pushed, which triggers the Build & Release workflow.