### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sw2robot"
-version = "0.2.0"
+version = "0.2.1"
 description = "SolidWorks assembly -> URDF exporter with a browser-based editor"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Release 0.2.1.

Cuts a release that includes the CoACD convex-decomposition collision meshes (#72): CLI/web opt-in CoACD `<collision>` export, live self-collision driven by the convex parts, and the macOS CI job.

Merging this and pushing the `v0.2.1` tag triggers the Build & Release workflow, which builds the per-OS PyInstaller binaries (Windows .exe, macOS, Linux) and attaches them to the GitHub Release.