### PR TITLE
feat(export): merge fixed-joint links (fixed-joint lumping)

### DIFF
--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -355,6 +355,9 @@
       <button id="collview" class="toggle" data-i18n="ui.collview"
               data-i18n-title="t.collview"
               title="show/hide the CoACD collision meshes (generate them first with the export panel's ⚙ Generate collision)">▦ coll</button>
+      <button id="mergeview" class="toggle" data-i18n="ui.mergeview"
+              data-i18n-title="t.mergeview"
+              title="display the robot with fixed-joint child links lumped into their parents (one rigid link per moving body); mesh-less coordinate frames are kept">🔗 merge fixed</button>
       <button id="alignmode" class="toggle" data-i18n-title="t.align"
               title="click a face: root origin moves there, +Z = face normal">⊕ align</button>
       <button id="portmode" class="toggle" data-i18n-title="t.port"
@@ -649,6 +652,14 @@ colour-coded) on top of the visual meshes.">
           <span data-i18n="ui.coacdshow">show collision</span>
         </label>
         <span id="coacdprog" style="color:#8a93a3;font-size:11px"></span>
+      </div>
+      <div style="display:flex;gap:6px;align-items:center;margin-bottom:4px;flex-wrap:wrap">
+        <label style="display:flex;gap:4px;align-items:center;color:#8a93a3;cursor:pointer"
+               data-i18n-title="t.mergefixed"
+               title="Lump fixed-joint child links (with geometry) into their parents in the exported URDF -- one rigid link per moving body. Mesh-less coordinate frames are kept. Applies to the ROS1/ROS2 packages.">
+          <input id="mergefixed" type="checkbox">
+          <span data-i18n="ui.mergefixed">merge fixed links</span>
+        </label>
       </div>
       <div style="display:flex;gap:4px;flex-wrap:wrap;align-items:center">
         <a id="expdae" href="/api/export/zip?meshes=dae&ros=1" download>
@@ -1218,6 +1229,16 @@ skrobot / native-mesh consumers (not RViz-loadable)">⬇ glb</button></a>
     'ui.collview': { en: '▦ coll', ja: '▦ 衝突' },
     't.collview': { en: 'show/hide the CoACD collision meshes (generate them first with the export panel’s ⚙ Generate collision)',
                     ja: 'CoACD 衝突メッシュの表示/非表示（先にエクスポート欄の ⚙ 衝突形状を生成 で作成）' },
+    'ui.mergeview': { en: '🔗 merge fixed', ja: '🔗 固定リンク統合' },
+    't.mergeview': { en: 'display the robot with fixed-joint child links lumped into their parents (one rigid link per moving body); mesh-less coordinate frames are kept',
+                     ja: 'fixedジョイントの子リンクを親に統合して表示（可動部ごとに1リンク）。メッシュ無しの座標フレームは保持' },
+    'merge.on': { en: '🔗 merge-fixed view ON (fixed-joint children lumped into parents)',
+                  ja: '🔗 固定リンク統合表示 ON（fixed子リンクを親に統合）' },
+    'merge.off': { en: 'merge-fixed view OFF (showing the full link tree)',
+                   ja: '固定リンク統合表示 OFF（全リンク表示）' },
+    'ui.mergefixed': { en: 'merge fixed links', ja: 'fixedリンクを統合' },
+    't.mergefixed': { en: 'Lump fixed-joint child links (with geometry) into their parents in the exported URDF — one rigid link per moving body. Mesh-less coordinate frames are kept. Applies to the ROS1/ROS2 packages.',
+                      ja: 'エクスポートURDFで、fixedジョイントの子リンク（ジオメトリ有り）を親に統合します（可動部ごとに1リンク）。メッシュ無しの座標フレームは保持。ROS1/ROS2パッケージに適用。' },
     't.coacdshow': { en: 'Overlay the generated convex collision parts (semi-transparent, colour-coded) on top of the visual meshes.',
                      ja: '生成した凸collisionパーツ（半透明・色分け）を visual メッシュの上に重ねて表示します。' },
     'coacd.start': { en: 'starting …', ja: '開始中 …' },
@@ -1546,6 +1567,7 @@ viewer.addEventListener('joint-mouseover', e => {
 });
 let dropMode = false;          // meshes come from dropped blobs, not /pkg/
 let currentInfo = null;        // {name, urdf} of the open server package
+let mergedView = false;        // viewer shows the fixed-joint-lumped URDF
 let compMeta = {};             // link -> {material, density, name, override}
 let linkColors = {};           // URDF/viewer link name -> '#rrggbb' override
 let excludedList = [];         // component names excluded from the URDF
@@ -3923,6 +3945,7 @@ expurdf?.addEventListener('input', () => {
 // (the glb export keeps its uniform-mesh layout).
 const coacdBox = document.getElementById('coacd');
 const cqualitySel = document.getElementById('cquality');
+const mergeFixedBox = document.getElementById('mergefixed');
 
 // ---- CoACD collision preview: generate per-link convex parts in the
 // background, popping each link's mesh into the viewer as it lands, and a toggle
@@ -4120,17 +4143,29 @@ function setCollisionShown(on) {
 coacdShow?.addEventListener('change', () => setCollisionShown(coacdShow.checked));
 collViewBtn?.addEventListener('click',
   () => setCollisionShown(!collViewBtn.classList.contains('active')));
+
+// "merge fixed" view: reload the robot from the fixed-joint-lumped URDF
+// (?merged=1).  Reuses the normal load path, keeping the current pose.
+const mergeViewBtn = document.getElementById('mergeview');
+mergeViewBtn?.addEventListener('click', () => {
+  if (!currentInfo) { return; }
+  mergedView = mergeViewBtn.classList.toggle('active');
+  log(t(mergedView ? 'merge.on' : 'merge.off'));
+  loadRobot(currentInfo, { keepPose: true });
+});
 expLinks.forEach(a => a.addEventListener('click', async ev => {
   ev.preventDefault();
   const base = a.getAttribute('href').split('&name=')[0].split('&urdf=')[0];
   const name = (exppkg?.value || '').trim();
   const urdf = (expurdf?.value || '').trim();
-  // coacd applies to the ROS (.dae) packages, not the uniform glb export
+  // coacd + merge-fixed apply to the ROS (.dae) packages, not the uniform glb
   const coacd = a.id !== 'expglb' && !!coacdBox?.checked;
+  const mergeFixed = a.id !== 'expglb' && !!mergeFixedBox?.checked;
   const url = base
     + (name ? `&name=${encodeURIComponent(name)}` : '')
     + (urdf ? `&urdf=${encodeURIComponent(urdf)}` : '')
-    + (coacd ? `&collision=coacd&cquality=${cqualitySel?.value || 'balanced'}` : '');
+    + (coacd ? `&collision=coacd&cquality=${cqualitySel?.value || 'balanced'}` : '')
+    + (mergeFixed ? '&mergefixed=1' : '');
   const what = a.id === 'expglb' ? 'glb'
     : a.id === 'expros2' ? 'ROS 2' : 'ROS 1';
   showLoadbar(t('export.bar', { what }), { indet: true });
@@ -5491,7 +5526,8 @@ function loadRobot(info, { drop = false, keepPose = false,
   // cached edit-reloads finish before it ever appears)
   showLoadbar(t('urdf.loadingBar', { name: info.name }), { indet: true, delay: 300 });
   // cache-bust so a rebuilt URDF is never served stale by the browser
-  viewer.urdf = drop ? info.urdf : info.urdf + '?v=' + Date.now();
+  viewer.urdf = drop ? info.urdf
+    : info.urdf + '?v=' + Date.now() + (mergedView ? '&merged=1' : '');
 }
 
 // ---- root frame box: +-90 deg buttons + numeric rpy(deg)/xyz(mm) --------

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -511,7 +511,8 @@ def _read_root_pose(txt):
 
 def _export_zip(pkg_dir, robot_name, mesh_fmt="dae", ros_version=1,
                 pkg_name=None, urdf_name=None, colors=None,
-                collision="copy", collision_quality="balanced"):
+                collision="copy", collision_quality="balanced",
+                merge_fixed=False):
     """ZIP a portable ROS package (package:// URLs), named ``pkg_name`` if given
     else ``<robot_name>_description``; the URDF inside is named ``urdf_name`` if
     given, else the package name.
@@ -546,6 +547,7 @@ def _export_zip(pkg_dir, robot_name, mesh_fmt="dae", ros_version=1,
                                                colors=colors,
                                                collision=collision,
                                                collision_quality=collision_quality,
+                                               merge_fixed=merge_fixed,
                                                **kwargs):
             z.writestr(arc, data)
     return pkg, buf.getvalue()
@@ -1938,6 +1940,7 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                     return self._send_json(
                         {"error": f"unsupported collision quality: {cquality}"},
                         400)
+                merge_fixed = (query.get("mergefixed") or ["0"])[0] == "1"
                 pkg_name = (query.get("name") or [""])[0].strip() or None
                 urdf_name = (query.get("urdf") or [""])[0].strip() or None
                 # the ROS exporter hardcodes the urdf/<robot_name>.urdf + meshes/
@@ -1964,7 +1967,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                                                 urdf_name=urdf_name,
                                                 colors=colors,
                                                 collision=collision,
-                                                collision_quality=cquality)
+                                                collision_quality=cquality,
+                                                merge_fixed=merge_fixed)
                 except ValueError as e:
                     return self._send_json({"error": str(e)}, 400)
                 fname = (f"{cls.robot_name}_glb.zip" if fmt == "glb"
@@ -2020,21 +2024,36 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 if not cls.pkg_dir:
                     return self.send_error(404, "no package open")
                 rel = path[len("/pkg/"):]
+                is_urdf = urllib.parse.unquote(rel) == cls.urdf_rel
+                # ?merged=1 -> serve the fixed-joint-lumped URDF (the viewer's
+                # "merge fixed" toggle uses this; mesh refs are unchanged so the
+                # same meshes still resolve)
+                merged = query.get("merged") == ["1"]
+
+                def _maybe_merge(txt):
+                    if not merged:
+                        return txt
+                    from sw2robot.exporter.merge import merge_fixed_links_text
+                    return merge_fixed_links_text(txt)
                 # URDF-input mode: the URDF URL is the overlay-applied URDF,
                 # computed on the fly so the on-disk file stays the pristine base
                 # (decode first -- urdf_rel is decoded, but the URL may carry %20)
-                if (urllib.parse.unquote(rel) == cls.urdf_rel
-                        and _um["state"] is not None
+                if (is_urdf and _um["state"] is not None
                         and not _cad_mode(cls.pkg_dir)):
                     from . import core
                     served = _rewrite_package_urls(
                         core.build_urdf(_um["state"], sanitize=False),
                         cls.urdf_rel, cls.pkg_dir)
-                    return self._send_bytes(served.encode("utf-8"),
+                    return self._send_bytes(_maybe_merge(served).encode("utf-8"),
                                             "application/xml")
                 full = self._resolve(cls.pkg_dir, rel)
                 if full is None or not os.path.isfile(full):
                     return self.send_error(404)
+                if is_urdf and merged:
+                    with open(full, encoding="utf-8") as f:
+                        return self._send_bytes(
+                            _maybe_merge(f.read()).encode("utf-8"),
+                            "application/xml")
                 if full.lower().endswith(".3dxml") \
                         and query.get("glb") == ["1"]:
                     return self._send_file(_convert_3dxml_to_glb(full))

--- a/sw2robot/exporter/export.py
+++ b/sw2robot/exporter/export.py
@@ -159,7 +159,8 @@ def extract(assembly_path, out_dir=None, robot_name=None, visible=False,
 # ---------------------------------------------------------------- build
 def build(pkg_dir, config_path=None, base_hint=None, exclude=None,
           ros_pkg=False, density=None, ros_version=1, ros_pkg_name=None,
-          ros_urdf_name=None, collision="copy", collision_quality="balanced"):
+          ros_urdf_name=None, collision="copy", collision_quality="balanced",
+          merge_fixed=False):
     _tolerant_console()
     graph = GraphState.load(os.path.join(pkg_dir, GRAPH_FILE))
     robot_name = graph.robot_name
@@ -201,7 +202,8 @@ def build(pkg_dir, config_path=None, base_hint=None, exclude=None,
             pkg_dir, robot_name, os.path.dirname(os.path.abspath(pkg_dir)),
             ros_version=ros_version, pkg_name=ros_pkg_name,
             urdf_name=ros_urdf_name, colors=colors,
-            collision=collision, collision_quality=collision_quality)
+            collision=collision, collision_quality=collision_quality,
+            merge_fixed=merge_fixed)
 
     print(f"\nDONE. Package: {pkg_dir}")
     print(f"  URDF:   {urdf_path}")
@@ -218,12 +220,13 @@ def build(pkg_dir, config_path=None, base_hint=None, exclude=None,
 def export(assembly_path, out_dir=None, robot_name=None, visible=False,
            config_path=None, base_hint=None, exclude=None, ros_pkg=False,
            ros_version=1, ros_pkg_name=None, ros_urdf_name=None,
-           collision="copy", collision_quality="balanced"):
+           collision="copy", collision_quality="balanced", merge_fixed=False):
     pkg_dir = extract(assembly_path, out_dir, robot_name, visible)
     return build(pkg_dir, config_path=config_path, base_hint=base_hint,
                  exclude=exclude, ros_pkg=ros_pkg, ros_version=ros_version,
                  ros_pkg_name=ros_pkg_name, ros_urdf_name=ros_urdf_name,
-                 collision=collision, collision_quality=collision_quality)
+                 collision=collision, collision_quality=collision_quality,
+                 merge_fixed=merge_fixed)
 
 
 def _exclude_list(s):
@@ -264,6 +267,10 @@ def main():
                     help="CoACD preset for --collision coacd: 'balanced' "
                          "(default, ~5-6 parts/link, ~8-60s) or 'fine' "
                          "(~8 parts, tighter fit, ~2-3x slower)")
+    ap.add_argument("--merge-fixed", action="store_true",
+                    help="lump fixed-joint child links (with geometry) into "
+                         "their parents in the --ros-pkg URDF -- one rigid link "
+                         "per moving body; mesh-less coordinate frames are kept")
     args = ap.parse_args()
     export(args.assembly, args.out, args.name, args.visible,
            config_path=args.config, base_hint=args.base,
@@ -271,7 +278,8 @@ def main():
            ros_pkg=args.ros_pkg or args.ros2,
            ros_version=2 if args.ros2 else 1,
            ros_pkg_name=args.ros_pkg_name, ros_urdf_name=args.ros_urdf_name,
-           collision=args.collision, collision_quality=args.collision_quality)
+           collision=args.collision, collision_quality=args.collision_quality,
+           merge_fixed=args.merge_fixed)
 
 
 if __name__ == "__main__":

--- a/sw2robot/exporter/merge.py
+++ b/sw2robot/exporter/merge.py
@@ -1,0 +1,210 @@
+"""Fixed-joint lumping for URDF: merge every fixed-joint child that carries
+geometry into its parent, so the exported / displayed URDF has one rigid link
+per moving body instead of a chain of rigidly-attached parts.
+
+Operates on the URDF XML (``xml.etree.ElementTree``) so it works the same in CAD
+and URDF-input mode, and feeds both the export and the viewer.
+
+For each ``<joint type="fixed">`` whose child link has ``<visual>`` /
+``<collision>`` geometry:
+  * the child's ``<visual>`` / ``<collision>`` are moved into the parent link,
+    their ``<origin>`` pre-composed with the fixed-joint origin (parent<-child),
+  * the two ``<inertial>`` blocks are combined (mass add + parallel-axis tensor),
+  * any joint that hung off the child is re-parented to the parent, its
+    ``<origin>`` pre-composed with the fixed transform,
+  * the fixed ``<joint>`` and the child ``<link>`` are removed.
+
+Mesh-LESS fixed children (coordinate frames -- ``dummy_link`` / port markers,
+i.e. links with no ``<visual>`` and no ``<collision>``) are NOT merged: they are
+kept as links so their TF frame survives.  The transform iterates to a fixpoint,
+so chains of fixed joints collapse onto the nearest moving (or root) link.
+"""
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+import numpy as np
+
+from .geometry import matrix_from_rpy, matrix_to_xyz_rpy
+
+
+def _fmt(v):
+    # compact, round-trippable; mirror the writer's style (no sci-notation noise)
+    return f"{float(v):.10g}"
+
+
+def _origin_matrix(el):
+    """4x4 from an ``<origin>`` element (xyz + extrinsic-XYZ rpy), or identity."""
+    if el is None:
+        return np.eye(4)
+    xyz = [float(x) for x in (el.get("xyz") or "0 0 0").split()]
+    rpy = [float(x) for x in (el.get("rpy") or "0 0 0").split()]
+    m = matrix_from_rpy(rpy)
+    m[:3, 3] = xyz[:3]
+    return m
+
+
+def _set_origin(parent_el, M):
+    """Write/overwrite ``parent_el``'s ``<origin>`` from a 4x4 matrix."""
+    xyz, rpy = matrix_to_xyz_rpy(M)
+    o = parent_el.find("origin")
+    if o is None:
+        o = ET.SubElement(parent_el, "origin")
+    o.set("xyz", " ".join(_fmt(v) for v in xyz))
+    o.set("rpy", " ".join(_fmt(v) for v in rpy))
+
+
+def _has_geometry(link_el):
+    """A link is mergeable geometry (not a bare coordinate frame) when it has a
+    visual or collision."""
+    return (link_el.find("visual") is not None
+            or link_el.find("collision") is not None)
+
+
+def _inertia_tensor(inertia_el):
+    def g(k):
+        return float(inertia_el.get(k, "0"))
+    ixx, ixy, ixz = g("ixx"), g("ixy"), g("ixz")
+    iyy, iyz, izz = g("iyy"), g("iyz"), g("izz")
+    return np.array([[ixx, ixy, ixz], [ixy, iyy, iyz], [ixz, iyz, izz]], float)
+
+
+def _parse_inertial(link_el):
+    """``(mass, com(3), I(3x3) about com)`` for a link, or None if no inertial.
+    Inertial ``rpy`` is honoured (rotates the tensor into link axes)."""
+    el = link_el.find("inertial")
+    if el is None:
+        return None
+    mass_el = el.find("mass")
+    mass = float(mass_el.get("value", "0")) if mass_el is not None else 0.0
+    o = el.find("origin")
+    com = np.array([float(x) for x in (o.get("xyz") if o is not None
+                                       and o.get("xyz") else "0 0 0").split()],
+                   float)
+    rpy = [float(x) for x in (o.get("rpy") if o is not None and o.get("rpy")
+                              else "0 0 0").split()]
+    it = el.find("inertia")
+    if it is None:
+        return None
+    inertia = _inertia_tensor(it)
+    if any(rpy):                       # express the tensor in link axes
+        R = matrix_from_rpy(rpy)[:3, :3]
+        inertia = R @ inertia @ R.T
+    return mass, com, inertia
+
+
+def _write_inertial(link_el, mass, com, inertia):
+    """Replace ``link_el``'s ``<inertial>`` with the given mass/com/tensor
+    (axis-aligned: rpy=0)."""
+    old = link_el.find("inertial")
+    if old is not None:
+        link_el.remove(old)
+    el = ET.SubElement(link_el, "inertial")
+    o = ET.SubElement(el, "origin")
+    o.set("xyz", " ".join(_fmt(v) for v in com))
+    o.set("rpy", "0 0 0")
+    ET.SubElement(el, "mass").set("value", _fmt(mass))
+    it = ET.SubElement(el, "inertia")
+    for k, v in (("ixx", inertia[0, 0]), ("ixy", inertia[0, 1]),
+                 ("ixz", inertia[0, 2]), ("iyy", inertia[1, 1]),
+                 ("iyz", inertia[1, 2]), ("izz", inertia[2, 2])):
+        it.set(k, _fmt(v))
+
+
+def _parallel_axis(mass, com, inertia, new_com):
+    """Shift an inertia tensor (about ``com``) to be about ``new_com``."""
+    d = np.asarray(com, float) - np.asarray(new_com, float)
+    return inertia + mass * (float(d @ d) * np.eye(3) - np.outer(d, d))
+
+
+def _combine_inertials(parent_el, child_el, T_pc):
+    """Lump the child link's <inertial> into the parent's, with the child first
+    moved into the parent frame by ``T_pc`` (parent<-child).  No-op if the child
+    has no inertial; seeds the parent if it had none."""
+    ci = _parse_inertial(child_el)
+    if ci is None:
+        return
+    m2, c2, I2 = ci
+    R = T_pc[:3, :3]
+    c2 = (T_pc @ np.append(c2, 1.0))[:3]      # child COM in parent frame
+    I2 = R @ I2 @ R.T                          # child tensor in parent axes
+    pi = _parse_inertial(parent_el)
+    if pi is None or pi[0] <= 0:
+        _write_inertial(parent_el, m2, c2, I2)
+        return
+    m1, c1, I1 = pi
+    m = m1 + m2
+    com = (m1 * c1 + m2 * c2) / m
+    inertia = (_parallel_axis(m1, c1, I1, com)
+               + _parallel_axis(m2, c2, I2, com))
+    _write_inertial(parent_el, m, com, inertia)
+
+
+def merge_fixed_links(root):
+    """Lump fixed-joint children with geometry into their parents, IN PLACE on
+    the URDF ``root`` element.  Returns ``(merged_count, root)``."""
+    # Coordinate frames are the links that have NO geometry of their OWN (snapshot
+    # before any merging).  They are preserved: never merged away as a child, and
+    # never used as a merge target -- otherwise a frame in a chain like
+    # base--fixed-->frame--fixed-->part would receive part's geometry and then get
+    # lumped into base, silently dropping the frame's TF (caught in review).
+    original_frames = {ln.get("name") for ln in root.findall("link")
+                       if not _has_geometry(ln)}
+    merged = 0
+    while True:
+        links = {ln.get("name"): ln for ln in root.findall("link")}
+        joints = root.findall("joint")
+        target = None
+        for j in joints:
+            if j.get("type") != "fixed":
+                continue
+            cp = j.find("parent"), j.find("child")
+            if cp[0] is None or cp[1] is None:
+                continue
+            pname, cname = cp[0].get("link"), cp[1].get("link")
+            cl = links.get(cname)
+            pl = links.get(pname)
+            if cl is None or pl is None or not _has_geometry(cl):
+                continue                       # keep mesh-less frames + danglers
+            if cname in original_frames or pname in original_frames:
+                continue                       # preserve coordinate frames
+            target = (j, pl, cl, pname, cname)
+            break
+        if target is None:
+            break
+        j, parent_link, child_link, pname, cname = target
+        T_pc = _origin_matrix(j.find("origin"))
+
+        # 1) move the child's visual/collision into the parent (compose origin)
+        for vc in list(child_link):
+            if vc.tag not in ("visual", "collision"):
+                continue
+            _set_origin(vc, T_pc @ _origin_matrix(vc.find("origin")))
+            child_link.remove(vc)
+            parent_link.append(vc)
+        # 2) combine inertials
+        _combine_inertials(parent_link, child_link, T_pc)
+        # 3) re-parent every joint that hung off the child onto the parent
+        for k in joints:
+            kp = k.find("parent")
+            if kp is not None and kp.get("link") == cname:
+                kp.set("link", pname)
+                _set_origin(k, T_pc @ _origin_matrix(k.find("origin")))
+        # 4) drop the fixed joint and the (now empty) child link
+        root.remove(j)
+        root.remove(child_link)
+        merged += 1
+    return merged, root
+
+
+def merge_fixed_links_text(urdf_text):
+    """``urdf_text`` -> merged URDF text (XML declaration preserved)."""
+    parser = ET.XMLParser(target=ET.TreeBuilder(insert_comments=True))
+    root = ET.fromstring(urdf_text, parser=parser)
+    merge_fixed_links(root)
+    out = ET.tostring(root, encoding="unicode")
+    if not out.startswith("<?xml"):
+        out = '<?xml version="1.0"?>\n' + out
+    if not out.endswith("\n"):
+        out += "\n"
+    return out

--- a/sw2robot/exporter/ros_export.py
+++ b/sw2robot/exporter/ros_export.py
@@ -578,7 +578,7 @@ def ros_urdf_stem(pkg, urdf_name=None):
 def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
                           ctx_fmt=_CTX_FMT, ros_version=1, pkg_name=None,
                           urdf_name=None, colors=None, collision="copy",
-                          collision_quality="balanced"):
+                          collision_quality="balanced", merge_fixed=False):
     """``pkg_dir`` (a built package) -> ``[(arcname, bytes), ...]`` for a portable
     ROS package, all behind ``package://`` URLs.  The package is named
     ``pkg_name`` if given (validated, see :func:`ros_pkg_name`), else
@@ -639,6 +639,11 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
     # findall()/iter() traversals below ignore them.
     _parser = ET.XMLParser(target=ET.TreeBuilder(insert_comments=True))
     root = ET.parse(urdf_path, parser=_parser).getroot()
+    if merge_fixed:
+        # lump fixed-joint children with geometry into their parents BEFORE the
+        # mesh conversion / collision loop runs over the (now fewer) links
+        from .merge import merge_fixed_links
+        merge_fixed_links(root)
     colors = colors or {}
 
     files = []
@@ -797,19 +802,22 @@ def write_ros_description_package(pkg_dir, robot_name, dest_dir,
                                   email="auto@example.com", ros_version=1,
                                   pkg_name=None, urdf_name=None, colors=None,
                                   collision="copy",
-                                  collision_quality="balanced"):
+                                  collision_quality="balanced",
+                                  merge_fixed=False):
     """Write the ROS package under ``dest_dir`` and return its directory path.
     The package is named ``pkg_name`` if given, else ``<robot_name>_description``;
     the URDF inside is named ``urdf_name`` if given, else the package name.
     ``ros_version`` (1 = catkin, 2 = ament_cmake), ``colors`` (per-link colour
-    overrides) and ``collision`` / ``collision_quality`` (CoACD collision-mesh
-    decomposition) are passed through to :func:`build_ros_description`."""
+    overrides), ``collision`` / ``collision_quality`` (CoACD collision-mesh
+    decomposition) and ``merge_fixed`` (lump fixed-joint children into parents)
+    are passed through to :func:`build_ros_description`."""
     pkg = ros_pkg_name(robot_name, pkg_name)
     files = build_ros_description(pkg_dir, robot_name, email=email,
                                   ros_version=ros_version, pkg_name=pkg,
                                   urdf_name=urdf_name, colors=colors,
                                   collision=collision,
-                                  collision_quality=collision_quality)
+                                  collision_quality=collision_quality,
+                                  merge_fixed=merge_fixed)
     root = os.path.abspath(dest_dir)
     for arc, data in files:
         dst = os.path.join(root, *arc.split("/"))

--- a/tests/test_merge_fixed.py
+++ b/tests/test_merge_fixed.py
@@ -1,0 +1,124 @@
+"""Fixed-joint lumping (sw2robot.exporter.merge): geometry is moved with a
+composed origin, inertials combine (mass + parallel-axis), movable joints
+re-parent, and mesh-less coordinate frames are preserved."""
+import xml.etree.ElementTree as ET
+
+from sw2robot.exporter.merge import merge_fixed_links
+
+_URDF = """<?xml version="1.0"?>
+<robot name="t">
+  <link name="base">
+    <visual><origin xyz="0 0 0" rpy="0 0 0"/><geometry><box size="1 1 1"/></geometry></visual>
+    <inertial><origin xyz="0 0 0" rpy="0 0 0"/><mass value="2"/>
+      <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/></inertial>
+  </link>
+  <joint name="fix_c" type="fixed">
+    <origin xyz="1 0 0" rpy="0 0 0"/>
+    <parent link="base"/><child link="c"/>
+  </joint>
+  <link name="c">
+    <visual><origin xyz="0 0 0" rpy="0 0 0"/><geometry><box size="0.5 0.5 0.5"/></geometry></visual>
+    <inertial><origin xyz="0 0 0" rpy="0 0 0"/><mass value="3"/>
+      <inertia ixx="2" ixy="0" ixz="0" iyy="2" iyz="0" izz="2"/></inertial>
+  </link>
+  <joint name="mov" type="revolute">
+    <origin xyz="0 1 0" rpy="0 0 0"/>
+    <parent link="c"/><child link="g"/>
+    <axis xyz="0 0 1"/><limit lower="-1" upper="1" effort="1" velocity="1"/>
+  </joint>
+  <link name="g"><visual><geometry><box size="0.2 0.2 0.2"/></geometry></visual></link>
+  <joint name="fix_port" type="fixed">
+    <origin xyz="0 0 1" rpy="0 0 0"/>
+    <parent link="base"/><child link="port"/>
+  </joint>
+  <link name="port"/>
+</robot>"""
+
+
+def _f(s):
+    return [float(x) for x in s.split()]
+
+
+def test_merge_lumps_geometry_inertia_and_reparents():
+    root = ET.fromstring(_URDF)
+    n, _ = merge_fixed_links(root)
+    assert n == 1                                   # only 'c' merged
+
+    links = {ln.get("name"): ln for ln in root.findall("link")}
+    joints = {j.get("name"): j for j in root.findall("joint")}
+
+    # child link + its fixed joint are gone; the mesh-less port frame is kept
+    assert "c" not in links and "fix_c" not in joints
+    assert "port" in links and "fix_port" in joints   # coordinate frame survives
+
+    # base now carries its own + the child's visual (composed origin 1 0 0)
+    base = links["base"]
+    vis = base.findall("visual")
+    assert len(vis) == 2
+    moved = [v for v in vis
+             if v.find("origin") is not None
+             and _f(v.find("origin").get("xyz")) == [1, 0, 0]]
+    assert len(moved) == 1
+
+    # the movable joint re-parented onto base, origin composed (0,1,0)+(1,0,0)
+    mov = joints["mov"]
+    assert mov.find("parent").get("link") == "base"
+    assert _f(mov.find("origin").get("xyz")) == [1, 1, 0]
+
+    # inertials combined: m=5, com=(0.6,0,0), I=diag(3, 4.2, 4.2)
+    inertial = base.find("inertial")
+    assert abs(float(inertial.find("mass").get("value")) - 5.0) < 1e-9
+    com = _f(inertial.find("origin").get("xyz"))
+    assert abs(com[0] - 0.6) < 1e-9 and abs(com[1]) < 1e-9 and abs(com[2]) < 1e-9
+    it = inertial.find("inertia")
+    assert abs(float(it.get("ixx")) - 3.0) < 1e-9
+    assert abs(float(it.get("iyy")) - 4.2) < 1e-9
+    assert abs(float(it.get("izz")) - 4.2) < 1e-9
+    assert abs(float(it.get("ixy"))) < 1e-12
+
+
+def test_chain_of_fixed_joints_collapses():
+    urdf = """<?xml version="1.0"?>
+<robot name="c">
+  <link name="a"><visual><geometry><box size="1 1 1"/></geometry></visual></link>
+  <joint name="f1" type="fixed"><origin xyz="1 0 0" rpy="0 0 0"/>
+    <parent link="a"/><child link="b"/></joint>
+  <link name="b"><visual><geometry><box size="1 1 1"/></geometry></visual></link>
+  <joint name="f2" type="fixed"><origin xyz="0 2 0" rpy="0 0 0"/>
+    <parent link="b"/><child link="d"/></joint>
+  <link name="d"><visual><origin xyz="0 0 0" rpy="0 0 0"/><geometry><box size="1 1 1"/></geometry></visual></link>
+</robot>"""
+    root = ET.fromstring(urdf)
+    n, _ = merge_fixed_links(root)
+    assert n == 2
+    links = {ln.get("name") for ln in root.findall("link")}
+    assert links == {"a"}                            # everything collapsed onto a
+    # d's visual lands at the composed (1,0,0)+(0,2,0) = (1,2,0)
+    origins = [v.find("origin").get("xyz")
+               for v in root.find("link").findall("visual")
+               if v.find("origin") is not None]
+    norm = {" ".join(f"{float(x):g}" for x in s.split()) for s in origins}
+    assert "1 2 0" in norm
+
+
+def test_meshless_frame_in_fixed_chain_is_preserved():
+    """Regression: a mesh-less coordinate frame between a real parent and a
+    meshed child must survive -- it must NOT receive the child's geometry and
+    then be lumped away (would silently drop its TF)."""
+    urdf = """<?xml version="1.0"?>
+<robot name="f">
+  <link name="base"><visual><geometry><box size="1 1 1"/></geometry></visual></link>
+  <joint name="to_frame" type="fixed"><origin xyz="0 0 1" rpy="0 0 0"/>
+    <parent link="base"/><child link="frame"/></joint>
+  <link name="frame"/>
+  <joint name="frame_part" type="fixed"><origin xyz="0 0 0.2" rpy="0 0 0"/>
+    <parent link="frame"/><child link="part"/></joint>
+  <link name="part"><visual><geometry><box size="0.3 0.3 0.3"/></geometry></visual></link>
+</robot>"""
+    root = ET.fromstring(urdf)
+    merge_fixed_links(root)
+    links = {ln.get("name") for ln in root.findall("link")}
+    assert "frame" in links                          # the TF frame survives
+    # the frame stays a pure coordinate frame (no geometry dumped into it)
+    frame = next(ln for ln in root.findall("link") if ln.get("name") == "frame")
+    assert frame.find("visual") is None and frame.find("collision") is None

--- a/tests/test_ros_export.py
+++ b/tests/test_ros_export.py
@@ -31,6 +31,97 @@ def _make_pkg(tmp_path, robot="robot"):
     return str(tmp_path)
 
 
+def _make_fixed_pkg(tmp_path, robot="rb"):
+    """A two-link package: parent 'a' + a fixed-joint child 'b', both meshed."""
+    if not os.path.exists(_SAMPLE_MESH):
+        pytest.skip("sample .3dxml mesh not present")
+    (tmp_path / "meshes").mkdir()
+    (tmp_path / "urdf").mkdir()
+    shutil.copy(_SAMPLE_MESH, tmp_path / "meshes" / "part.3dxml")
+    urdf = (
+        f'<?xml version="1.0"?>\n<robot name="{robot}">\n'
+        '  <link name="a"><visual><geometry>'
+        '<mesh filename="../meshes/part.3dxml"/></geometry></visual></link>\n'
+        '  <joint name="a__b" type="fixed">\n'
+        '    <origin xyz="0.1 0 0" rpy="0 0 0"/>\n'
+        '    <parent link="a"/><child link="b"/>\n  </joint>\n'
+        '  <link name="b"><visual><geometry>'
+        '<mesh filename="../meshes/part.3dxml"/></geometry></visual></link>\n'
+        '</robot>\n')
+    (tmp_path / "urdf" / f"{robot}.urdf").write_text(urdf, encoding="utf-8")
+    return str(tmp_path)
+
+
+def test_export_merge_fixed_lumps_child_into_parent(tmp_path):
+    import xml.etree.ElementTree as ET
+
+    from sw2robot.exporter.ros_export import build_ros_description
+
+    pkg_dir = _make_fixed_pkg(tmp_path, robot="rb")
+    files = dict(build_ros_description(pkg_dir, "rb", merge_fixed=True))
+    urdf = files["rb_description/urdf/rb_description.urdf"].decode()
+    root = ET.fromstring(urdf)
+
+    links = {ln.get("name") for ln in root.findall("link")}
+    assert links == {"a"}                       # 'b' lumped into 'a'
+    assert not root.findall("joint")            # the fixed joint is gone
+    # 'a' now carries both meshes (its own + the moved child's)
+    assert len(root.find("link").findall("visual")) == 2
+    # without merge_fixed the two links + fixed joint are preserved
+    plain = dict(build_ros_description(pkg_dir, "rb"))
+    proot = ET.fromstring(plain["rb_description/urdf/rb_description.urdf"].decode())
+    assert {ln.get("name") for ln in proot.findall("link")} == {"a", "b"}
+
+
+def _make_fixed_pkg_with_collision(tmp_path, robot="rc"):
+    """parent 'a' + fixed child 'b', both with visual AND collision meshes."""
+    if not os.path.exists(_SAMPLE_MESH):
+        pytest.skip("sample .3dxml mesh not present")
+    (tmp_path / "meshes").mkdir()
+    (tmp_path / "urdf").mkdir()
+    shutil.copy(_SAMPLE_MESH, tmp_path / "meshes" / "part.3dxml")
+
+    def _link(name):
+        m = '<mesh filename="../meshes/part.3dxml"/>'
+        return (f'  <link name="{name}">'
+                f'<visual><geometry>{m}</geometry></visual>'
+                f'<collision><geometry>{m}</geometry></collision></link>\n')
+    urdf = (f'<?xml version="1.0"?>\n<robot name="{robot}">\n' + _link("a")
+            + '  <joint name="a__b" type="fixed">'
+              '<origin xyz="0.1 0 0" rpy="0 0 0"/>'
+              '<parent link="a"/><child link="b"/></joint>\n'
+            + _link("b") + '</robot>\n')
+    (tmp_path / "urdf" / f"{robot}.urdf").write_text(urdf, encoding="utf-8")
+    return str(tmp_path)
+
+
+def test_merge_fixed_plus_coacd_compose(tmp_path, monkeypatch):
+    """merge_fixed + collision='coacd' together: the child lumps into the parent
+    FIRST, then CoACD decomposes every (now parent-owned) collision block."""
+    import xml.etree.ElementTree as ET
+
+    from sw2robot.exporter import ros_export
+
+    monkeypatch.setattr(ros_export, "coacd_available", lambda: True)
+    monkeypatch.setattr(ros_export, "_run_coacd",
+                        lambda v, f, params: _two_unit_boxes())
+
+    pkg_dir = _make_fixed_pkg_with_collision(tmp_path, robot="rc")
+    files = dict(ros_export.build_ros_description(
+        pkg_dir, "rc", merge_fixed=True, collision="coacd"))
+
+    root = ET.fromstring(
+        files["rc_description/urdf/rc_description.urdf"].decode())
+    assert {ln.get("name") for ln in root.findall("link")} == {"a"}   # merged
+    a = root.find("link")
+    # a held 2 collision blocks after the merge (its own + b's); CoACD split each
+    # into 2 convex parts -> 4 collision blocks, all pointing at coacd part STLs
+    cols = a.findall("collision")
+    assert len(cols) == 4
+    assert all("_collision_" in c.find(".//mesh").get("filename") for c in cols)
+    assert len(a.findall("visual")) == 2                 # both visuals lumped in
+
+
 def test_mesh_to_dae_scale_and_loadable():
     if not os.path.exists(_SAMPLE_MESH):
         pytest.skip("sample .3dxml mesh not present")


### PR DESCRIPTION
## Summary

Adds an optional **fixed-joint lumping** ("merge fixed links") mode: every fixed-joint child link that carries geometry is merged into its parent, so the exported / displayed URDF has one rigid link per moving body instead of a chain of rigidly-attached parts. Mesh-less coordinate frames (ports / dummy frames) are preserved so their TF survives.

## What it does

For each `<joint type="fixed">` whose child link has geometry:
- the child's `<visual>` / `<collision>` move into the parent, their `<origin>` pre-composed with the fixed-joint origin (parent←child);
- the two `<inertial>` blocks combine (mass add + parallel-axis tensor, with the child tensor rotated into the parent frame);
- any joint that hung off the child is re-parented onto the parent, its `<origin>` pre-composed with the fixed transform;
- the fixed joint and the child link are removed.

Fixed chains collapse to a fixpoint. Originally mesh-less frames are never merged away and never used as a merge target.

## Surfaces

- **CLI**: `sw2urdf … --ros-pkg --merge-fixed`.
- **Export (web)**: a `merge fixed links` checkbox on the ROS1/ROS2 export; the exported `<pkg>/urdf/<name>.urdf` reflects the merge. Composes with the CoACD collision option — the merge runs first, then CoACD decomposes the (now parent-owned) collision blocks.
- **Viewer (web)**: a `🔗 merge fixed` toolbar toggle that reloads the robot from the lumped URDF (`?merged=1`), so the displayed merge matches what gets exported.

## Implementation

- New `sw2robot/exporter/merge.py` (`merge_fixed_links` over the URDF ElementTree) — reuses the existing `geometry` transform helpers.
- `ros_export.build_ros_description(merge_fixed=)` applies the transform right after parsing (before mesh conversion / CoACD), threaded through `write_ros_description_package`, `export.build/export`, and the web `_export_zip` + endpoint.
- `/pkg/<urdf>?merged=1` serves the merged URDF (CAD and URDF-input mode).

## Testing
- `tests/test_merge_fixed.py`: exact inertia/origin/re-parent math, chain collapse, and a regression that a mesh-less coordinate frame in a fixed chain is preserved (not silently dropped).
- `tests/test_ros_export.py`: export integration (output URDF changes) and the merge + CoACD combination.
- Reviewed with an external code-review pass; the one issue it raised (a mesh-less frame in a fixed chain could be dropped once it inherited a descendant's geometry) is fixed and covered by the regression test above.
