### PR TITLE
Bump version to 0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sw2robot"
-version = "0.2.1"
+version = "0.2.2"
 description = "SolidWorks assembly -> URDF exporter with a browser-based editor"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Release 0.2.2.

Includes the fixed-joint lumping / "merge fixed links" feature (#74): merge fixed-joint children into their parents for export and the viewer, composing with the CoACD collision option.

Merging this and pushing the `v0.2.2` tag triggers Build & Release, which builds the per-OS PyInstaller binaries (Windows .exe, macOS, Linux) and attaches them to the GitHub Release.