### PR TITLE
Box-select batch ops + robust SolidWorks extract

### DIFF
--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -366,6 +366,10 @@
               title="CAD全体を動かして base_link を世界原点(0,0,0)に合わせる">⌖ origin</button>
       <button id="grid" class="toggle active" data-i18n-title="t.grid"
               title="ground grid at root Z=0">grid</button>
+      <button id="boxselect" class="toggle" data-i18n="ui.boxselect"
+              data-i18n-title="t.boxselect"
+              title="box-select mode: drag a rectangle to select multiple links (Shift+drag works any time too). Then batch-set colour / material / reset from the bar at the bottom.">
+        ⬚ select</button>
       <button id="posedrag" class="toggle" data-i18n-title="t.posedrag"
               title="OFF: ドラッグで視点回転 / ON: リンクをドラッグして関節を動かす">
         🖐 pose</button>
@@ -485,6 +489,18 @@
       <button data-bt="revolute" data-i18n="ui.btRevolute">回転</button>
       <button data-bt="continuous" data-i18n="ui.btContinuous">連続回転</button>
       <button data-bt="prismatic" data-i18n="ui.btPrismatic">直動</button>
+      <span style="color:#8a93a3;border-left:1px solid #567;padding-left:8px"
+            data-i18n="ui.bulkLook">· 見た目:</span>
+      <input id="bulk_color" type="color" value="#3b82f6"
+             data-i18n-title="t.bulkColor" title="set colour on all selected links"
+             style="width:30px;height:22px;padding:0;border:1px solid #444;
+                    background:#15171a;cursor:pointer">
+      <button id="bulk_resetcolor" data-i18n="ui.bulkResetColor"
+              data-i18n-title="t.bulkResetColor">↺ 色</button>
+      <select id="bulk_mat" data-i18n-title="t.bulkMat"
+              title="set material (density) on all selected links"
+              style="background:#15171a;color:#ddd;border:1px solid #444;
+                     border-radius:3px;font-size:11px;max-width:130px"></select>
       <button id="bulkclose" style="margin-left:4px">✕</button>
     </div>
     <div id="linkinfo"></div>
@@ -925,6 +941,30 @@ skrobot / native-mesh consumers (not RViz-loadable)">⬇ glb</button></a>
     'bulk.appliedMissed': { en: a => ` (${a.m} skipped)`, ja: a => ` (${a.m} 件は対象外)` },
     'bulk.reloadUndo': { en: ' — reloading (Ctrl+Z to undo)', ja: ' — reloading (Ctrl+Z で戻せます)' },
     'bulk.fail': { en: a => `bulk set failed: ${a.e}`, ja: a => `一括設定 failed: ${a.e}` },
+    'bulk.colorOk': { en: a => `coloured ${a.n} links ${a.hex} ✓`,
+                      ja: a => `${a.n} 個のリンクを ${a.hex} に変更 ✓` },
+    'bulk.colorReset': { en: a => `reset colour on ${a.n} links ✓`,
+                         ja: a => `${a.n} 個のリンクの色をリセット ✓` },
+    'bulk.densitySet': { en: a => `bulk material: ${a.n} links → ${a.d} + rebuilding …`,
+                         ja: a => `一括素材: ${a.n} links → ${a.d} + 再ビルド中 …` },
+    'bulk.densityOk': { en: a => `bulk material ✓ — ${a.n} links (mass/inertia rebuilt)`,
+                        ja: a => `一括素材 ✓ — ${a.n} links（質量・慣性を再計算）` },
+    'bulk.densityFail': { en: a => `bulk material failed: ${a.e}`,
+                          ja: a => `一括素材 failed: ${a.e}` },
+    'ui.bulkLook': { en: '· look:', ja: '· 見た目:' },
+    't.bulkColor': { en: 'set this colour on every selected link',
+                     ja: '選択中の全リンクをこの色に変更' },
+    'ui.bulkResetColor': { en: '↺ colour', ja: '↺ 色' },
+    't.bulkResetColor': { en: 'clear the colour override on every selected link',
+                          ja: '選択中の全リンクの色上書きを解除' },
+    't.bulkMat': { en: 'set material (density) on every selected link',
+                   ja: '選択中の全リンクに素材（密度）を設定' },
+    'ui.bulkMatPlaceholder': { en: '— set material —', ja: '— 素材を設定 —' },
+    'ui.bulkMatReset': { en: 'back to SW value (clear override)',
+                         ja: 'SW値に戻す (上書き解除)' },
+    'ui.boxselect': { en: '⬚ select', ja: '⬚ 範囲選択' },
+    't.boxselect': { en: 'box-select mode: drag a rectangle to select multiple links (Shift+drag works any time too), then batch-set colour / material / reset from the bottom bar',
+                     ja: '範囲選択モード: ドラッグした矩形内のリンクを複数選択（Shift+ドラッグはいつでも可）。下部バーで色・素材・リセットを一括適用' },
     // type changes
     'types.applying': { en: a => `applying ${a.n} type change(s) + rebuilding URDF …`,
                         ja: a => `${a.n} 件の種類変更を適用して URDF を再ビルド中 …` },
@@ -2734,7 +2774,7 @@ function baseTint(name) {
     if (mimicFollowers.has(name)) { return 'mim'; }
   }
   return collisionLinks.has(name) ? 'col'
-       : (name === selectedLink ? 'sel' : null);
+       : (name === selectedLink || boxSelected.has(name) ? 'sel' : null);
 }
 
 function _tintLink(linkName, kind) {   // kind: 'hov' | 'sel' | null
@@ -4849,8 +4889,8 @@ viewer.addEventListener('pointerup', ev => {
   // can select an occluded joint by clicking its (always-on-top) axis line
   const ax = pickAxis(ev);
   const link = ax ? ax.child : pickLink(ev);
-  if (link) { selectLink(link); }
-  else { selectLink(null); }       // empty space: always clear selection
+  if (link) { clearBoxSelection(); selectLink(link); }
+  else { clearBoxSelection(); selectLink(null); }   // empty space: clear all
 });
 
 let lastPick = 0;
@@ -4938,6 +4978,12 @@ const boxselEl = document.getElementById('boxsel');
 const bulkbarEl = document.getElementById('bulkbar');
 let boxing = null;                 // {x0, y0} while dragging the rectangle
 let boxSelected = new Set();       // link names picked by the box
+let boxSelectMode = false;         // toolbar toggle: plain left-drag box-selects
+const boxSelectBtn = document.getElementById('boxselect');
+boxSelectBtn?.addEventListener('click', () => {
+  boxSelectMode = boxSelectBtn.classList.toggle('active');
+  viewer.style.cursor = boxSelectMode ? 'crosshair' : '';
+});
 
 function drawBox(x, y) {
   const r = viewer.getBoundingClientRect();
@@ -4948,7 +4994,9 @@ function drawBox(x, y) {
 }
 // capture phase: intercept BEFORE OrbitControls / the joint manipulator
 viewer.addEventListener('pointerdown', ev => {
-  if (!ev.shiftKey || ev.button !== 0 || !viewer.robot) { return; }
+  if (!(ev.shiftKey || boxSelectMode) || ev.button !== 0 || !viewer.robot) {
+    return;
+  }
   ev.preventDefault();
   ev.stopImmediatePropagation();
   viewer.controls.enabled = false;
@@ -5004,10 +5052,13 @@ function selectLinksInBox(rect) {
 }
 
 function clearBoxSelection() {
-  for (const n of boxSelected) {
+  // clear the set FIRST: baseTint() now reports box-selected links as 'sel', so
+  // restoring their tint must happen once they are no longer in the set
+  const prev = boxSelected;
+  boxSelected = new Set();
+  for (const n of prev) {
     if (n !== selectedLink) { _tintLink(n, baseTint(n)); }
   }
-  boxSelected = new Set();
   bulkbarEl.style.display = 'none';
 }
 document.getElementById('bulkclose').addEventListener('click', clearBoxSelection);
@@ -5159,6 +5210,102 @@ async function bulkSetType(type) {
 }
 bulkbarEl.querySelectorAll('button[data-bt]').forEach(b =>
   b.addEventListener('click', () => bulkSetType(b.dataset.bt)));
+
+// ---- batch look (colour / material / reset) over the box selection ----------
+// density presets shared with the per-link material picker
+const BULK_MAT = [['PLA', '1240'], ['ABS', '1040'], ['PETG', '1270'],
+  ['Nylon', '1140'], ['POM', '1410'], ['FR4', '1850'],
+  ['Aluminum', '2700'], ['Iron/Steel', '7850'], ['Titanium', '4500'],
+  ['custom', 'custom']];
+const bulkMatSel = document.getElementById('bulk_mat');
+if (bulkMatSel) {
+  bulkMatSel.innerHTML =
+    `<option value="">${t('ui.bulkMatPlaceholder')}</option>`
+    + `<option value="__reset__">${t('ui.bulkMatReset')}</option>`
+    + BULK_MAT.map(([label, val]) =>
+      `<option value="${val}">${val === 'custom' ? label : label + ' ' + val}` +
+      `</option>`).join('');
+}
+
+async function bulkSetColor(hex) {       // colour every selected link (no rebuild)
+  const links = [...boxSelected];
+  if (!links.length) { return; }
+  for (const n of links) {
+    applyLinkColor(n, hex);              // live
+    try {
+      const resp = await fetch('/api/set_color', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ link: n, color: hex }) });
+      const r = await resp.json();
+      if (resp.ok && !r.error) {
+        linkColors[n] = r.color; if (compMeta[n]) { compMeta[n].color = r.color; }
+      }
+    } catch (_e) { /* per-link failure is non-fatal */ }
+  }
+  pushRecentColor(hex);
+  for (const n of boxSelected) { _tintLink(n, 'sel'); }   // keep the box tint
+  log(t('bulk.colorOk', { n: links.length, hex }), 'ok');
+}
+
+async function bulkResetColor() {        // clear the colour override on selection
+  const links = [...boxSelected];
+  if (!links.length) { return; }
+  for (const n of links) {
+    resetLinkColor(n);
+    try {
+      await fetch('/api/set_color', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ link: n, color: null }) });
+    } catch (_e) { /* non-fatal */ }
+    delete linkColors[n]; if (compMeta[n]) { compMeta[n].color = null; }
+  }
+  for (const n of boxSelected) { _tintLink(n, 'sel'); }
+  log(t('bulk.colorReset', { n: links.length }), 'ok');
+}
+
+async function bulkSetDensity(d) {       // set material density on all (rebuilds)
+  const links = [...boxSelected];
+  if (!links.length || !currentInfo) { return; }
+  const ctrls = bulkbarEl.querySelectorAll('button, select, input');
+  ctrls.forEach(e => { e.disabled = true; });
+  log(t('bulk.densitySet', { n: links.length,
+                             d: d == null ? t('li.swValue') : d }));
+  statusEl.textContent = t('status.rebuilding');
+  try {
+    for (const n of links) {
+      const resp = await fetch('/api/set_material', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ link: n, density: d }) });
+      const r = await resp.json();
+      if (!resp.ok || r.error) { throw new Error(r.error ?? resp.status); }
+    }
+    log(t('bulk.densityOk', { n: links.length }), 'ok');
+    clearBoxSelection();
+    loadRobot(currentInfo, { keepPose: true });
+    refreshHistory();
+  } catch (e) {
+    log(t('bulk.densityFail', { e: e.message ?? e }), 'err');
+  } finally {
+    ctrls.forEach(e => { e.disabled = false; });
+  }
+}
+
+document.getElementById('bulk_color')?.addEventListener('change',
+  e => bulkSetColor(e.target.value));
+document.getElementById('bulk_resetcolor')?.addEventListener('click',
+  bulkResetColor);
+bulkMatSel?.addEventListener('change', () => {
+  const v = bulkMatSel.value;
+  bulkMatSel.selectedIndex = 0;          // reset the picker back to placeholder
+  if (v === '') { return; }
+  if (v === '__reset__') { bulkSetDensity(null); return; }
+  if (v === 'custom') {
+    const d = prompt(t('li.densityPrompt'));
+    if (d) { bulkSetDensity(Number(d)); }
+    return;
+  }
+  bulkSetDensity(Number(v));
+});
 window.addEventListener('keydown', ev => {
   const ae = document.activeElement;
   const inField = /INPUT|SELECT|TEXTAREA/.test(ae?.tagName)

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1309,9 +1309,12 @@ def _run_extract(sldasm):
             pass
         _job["log"].append("cancelled.")
     except Exception as e:
+        import traceback
+
         from sw2robot.exporter.swcom import SolidWorksUnavailable
         _job["error"] = f"{type(e).__name__}: {e}"
         print(f"[sw2robot.web] extract FAILED: {e!r}")
+        traceback.print_exc()     # full traceback -> the exact failing line
         # Drop the cached session on anything that smells like a lost/failed
         # SolidWorks connection -- a couldn't-start/license error, a COM RPC
         # failure, or a dead instance -- so the NEXT extraction starts clean

--- a/sw2robot/exporter/mesh.py
+++ b/sw2robot/exporter/mesh.py
@@ -17,8 +17,8 @@ from .swcom import (
     SW_SAVEAS_COPY,
     SW_SAVEAS_SILENT,
     as_iface,
-    byref_long,
     doc_type_for,
+    open_doc6,
     safe_call,
     safe_prop,
 )
@@ -49,10 +49,10 @@ def _open_doc(app, path):
         return None
     _recent_opens.append(path)
     del _recent_opens[:-2]                  # keep the last two
-    err = byref_long(); warn = byref_long()
     try:
-        return app.OpenDoc6(path, doc_type_for(path),
-                            SW_OPEN_SILENT | 0x80, "", err, warn)
+        doc, _err, _warn = open_doc6(app, path, doc_type_for(path),
+                                     SW_OPEN_SILENT | 0x80)
+        return doc
     except Exception as e:
         if getattr(e, "hresult", None) == _RPC_DISCONNECTED:
             _crash_suspects.update(_recent_opens)

--- a/sw2robot/exporter/swcom.py
+++ b/sw2robot/exporter/swcom.py
@@ -269,6 +269,28 @@ def byref_long(initial=0):
     return win32com.client.VARIANT(pythoncom.VT_BYREF | pythoncom.VT_I4, initial)
 
 
+def open_doc6(app, path, dtype, options=SW_OPEN_SILENT):
+    """``IModelDoc2.OpenDoc6`` -> ``(doc, error_code, warning_code)``, tolerant of
+    the way win32com marshals its two ``[out]`` long params across versions.
+
+    The historical approach passes ``VARIANT(VT_BYREF|VT_I4)`` objects; pywin32
+    >= ~311 then raises ``TypeError: int() argument ... not 'VARIANT'`` while
+    coercing them inside ``InvokeTypes``.  Fall back to passing plain ints -- the
+    gen_py wrapper builds the byref itself and returns the updated values
+    alongside the document.  (A real COM failure -- e.g. an RPC disconnect when
+    SolidWorks dies -- is NOT a TypeError, so it propagates to the caller.)"""
+    try:
+        errors, warnings = byref_long(), byref_long()
+        doc = app.OpenDoc6(path, dtype, options, "", errors, warnings)
+        return doc, errors.value, warnings.value
+    except TypeError:
+        res = app.OpenDoc6(path, dtype, options, "", 0, 0)
+        if isinstance(res, (tuple, list)):
+            vals = [*res, 0, 0, 0]
+            return vals[0], vals[1], vals[2]
+        return res, 0, 0
+
+
 def doc_type_for(path):
     ext = os.path.splitext(path)[1].lower()
     if ext == ".sldasm":
@@ -435,60 +457,89 @@ class SolidWorks:
         path = os.path.abspath(path)
         if not os.path.exists(path):
             raise FileNotFoundError(path)
-        # A temp copy loses SolidWorks' "same folder as the assembly"
-        # reference-resolution rule; assemblies whose STORED part paths are
-        # stale then open with almost everything unresolved (home_drone
-        # came up as a single component).  Register the original's folder
-        # family as document search paths so rule (2) replaces rule (4).
         import time as _time
         t0 = _time.time()
-        self._register_search_folders(path)
-        tmpdir = tempfile.mkdtemp(prefix="sw2urdf_")
-        self._tempdirs.append(tmpdir)
-        tmp = os.path.join(tmpdir, os.path.basename(path))
-        shutil.copy2(path, tmp)
-        # Co-locate the assembly's sibling CAD files in the SAME temp dir so
-        # SolidWorks' "same folder as the assembly" rule resolves them by name.
-        # The search-folder registration above does NOT always override the
-        # absolute paths a downloaded (Pack-and-Go) assembly bakes in -- those
-        # then open with every component unresolved even though the parts sit
-        # right next to the .SLDASM.  A flat copy of the folder fixes that; deep
-        # sub-folder layouts still fall back to the search folders.
-        if doc_type_for(path) == SW_DOC_ASSEMBLY:
-            try:
-                siblings = os.listdir(os.path.dirname(path))
-            except OSError:
-                siblings = []
-            n_sib = 0
-            for fn in siblings:
-                if fn.startswith("~$") or not fn.lower().endswith(
-                        (".sldprt", ".sldasm", ".slddrw")):
-                    continue                    # lock files / non-CAD
-                s = os.path.join(os.path.dirname(path), fn)
-                d = os.path.join(tmpdir, fn)
-                if os.path.isfile(s) and not os.path.exists(d):
-                    try:
-                        shutil.copy2(s, d)
-                        n_sib += 1
-                    except OSError:
-                        pass
-            if n_sib:
-                print(f"      co-located {n_sib} sibling CAD file(s) for "
-                      f"reference resolution")
-        t1 = _time.time()
-
-        errors = byref_long()
-        warnings = byref_long()
-        doc = self.app.OpenDoc6(tmp, doc_type_for(tmp), SW_OPEN_SILENT, "",
-                                errors, warnings)
-        t2 = _time.time()
+        doc = None
+        # If the SAME assembly is already open in the user's reused session, use
+        # THAT document: it is already fully resolved (the user can see it), so
+        # we extract exactly what SolidWorks shows instead of a fragile copy +
+        # reference re-resolution that can come up with 0 components for a
+        # .SLDASM whose parts live elsewhere.  Read-only: extraction never saves,
+        # and attach mode never closes the user's docs.
+        if getattr(self, "_attached", False):
+            existing = self._find_open_doc(path)
+            if existing is not None:
+                print("      reusing the already-open document from your "
+                      "SolidWorks session (references already resolved)")
+                self._reused_open_doc = True
+                doc = existing
+        t1 = t0
         if doc is None:
-            raise RuntimeError(
-                f"OpenDoc6 failed for {tmp} "
-                f"(errors={errors.value}, warnings={warnings.value})")
-        self._open_docs.append(doc)
+            # A temp copy loses SolidWorks' "same folder as the assembly"
+            # reference-resolution rule; assemblies whose STORED part paths are
+            # stale then open with almost everything unresolved (home_drone came
+            # up as a single component).  Register the original's folder family
+            # as document search paths so rule (2) replaces rule (4).
+            self._register_search_folders(path)
+            tmpdir = tempfile.mkdtemp(prefix="sw2urdf_")
+            self._tempdirs.append(tmpdir)
+            # Open the copy under a UNIQUE title so it never clashes with the
+            # SAME assembly already open in the reused session -- OpenDoc6
+            # otherwise fails with swFileWithSameTitleAlreadyOpen (65536).
+            # Referenced parts are resolved by their own names (co-located
+            # below), so renaming the top assembly is safe.
+            stem, ext = os.path.splitext(os.path.basename(path))
+            tmp = os.path.join(tmpdir, f"{stem}_{os.path.basename(tmpdir)}{ext}")
+            shutil.copy2(path, tmp)
+            # Co-locate the assembly's sibling CAD files in the SAME temp dir so
+            # SolidWorks' "same folder as the assembly" rule resolves them by
+            # name.  The search-folder registration above does NOT always
+            # override the absolute paths a downloaded (Pack-and-Go) assembly
+            # bakes in -- those then open with every component unresolved even
+            # though the parts sit right next to the .SLDASM.  A flat copy fixes
+            # that; deep sub-folder layouts fall back to the search folders.
+            if doc_type_for(path) == SW_DOC_ASSEMBLY:
+                try:
+                    siblings = os.listdir(os.path.dirname(path))
+                except OSError:
+                    siblings = []
+                n_sib = 0
+                for fn in siblings:
+                    if fn.startswith("~$") or not fn.lower().endswith(
+                            (".sldprt", ".sldasm", ".slddrw")):
+                        continue                # lock files / non-CAD
+                    s = os.path.join(os.path.dirname(path), fn)
+                    d = os.path.join(tmpdir, fn)
+                    if os.path.isfile(s) and not os.path.exists(d):
+                        try:
+                            shutil.copy2(s, d)
+                            n_sib += 1
+                        except OSError:
+                            pass
+                if n_sib:
+                    print(f"      co-located {n_sib} sibling CAD file(s) for "
+                          f"reference resolution")
+            t1 = _time.time()
+            doc, ecode, wcode = open_doc6(self.app, tmp, doc_type_for(tmp))
+            if doc is None:
+                # 65536 = swFileWithSameTitleAlreadyOpen: a doc with this title
+                # is already open in the reused session (we copy under a unique
+                # title, so rare -- but a referenced part sharing a title with
+                # the user's open work can still trip it)
+                if ecode == 65536:
+                    raise RuntimeError(
+                        "SolidWorks refused to open the assembly because a "
+                        "document with the same name is already open in your "
+                        "running SolidWorks (error 65536). Close that document "
+                        "in SolidWorks (or close SolidWorks entirely so sw2robot "
+                        "opens it in a clean hidden instance), then retry.")
+                raise RuntimeError(
+                    f"OpenDoc6 failed for {tmp} "
+                    f"(errors={ecode}, warnings={wcode})")
+            self._open_docs.append(doc)
+        t2 = _time.time()
         t3 = t2
-        if doc_type_for(tmp) == SW_DOC_ASSEMBLY:
+        if doc_type_for(path) == SW_DOC_ASSEMBLY:
             asm = as_iface(doc, "IAssemblyDoc")
             try:
                 asm.ResolveAllLightWeightComponents(True)
@@ -543,7 +594,17 @@ class SolidWorks:
                         cand.append(p)
             except Exception:
                 pass
-            folders = ";".join(dict.fromkeys(cand))
+            # KEEP the user's existing referenced-document search paths and only
+            # ADD ours -- SolidWorks resolves this assembly's parts through those
+            # configured paths interactively, so replacing them (the old
+            # behaviour) made everything open unresolved when the .SLDASM sits
+            # somewhere its parts are not (e.g. a lone copy in Downloads).
+            prev = ""
+            if getattr(self, "_saved_search_prefs", None):
+                prev = self._saved_search_prefs[0] or ""
+            prev_list = [p for p in str(prev).split(";") if p]
+            merged = list(dict.fromkeys(cand + prev_list))
+            folders = ";".join(merged)
             try:
                 self.app.SetUserPreferenceToggle(
                     constants.swUseFolderSearchRule, True)
@@ -551,7 +612,8 @@ class SolidWorks:
                 pass
             self.app.SetSearchFolders(constants.swDocumentType, folders)
             print(f"      reference search folders set ({len(cand)} dirs "
-                  f"around {os.path.basename(src_dir)})")
+                  f"around {os.path.basename(src_dir)} + "
+                  f"{len(prev_list)} existing)")
         except Exception as e:
             print(f"      WARN: could not set search folders ({e!r}); "
                   f"stale part references may not resolve")
@@ -571,6 +633,30 @@ class SolidWorks:
             del self._saved_search_prefs
         except Exception:
             pass
+
+    def _find_open_doc(self, path):
+        """An already-open ModelDoc2 whose title matches ``path``'s file name, or
+        None.  Lets a reused session extract from the user's resolved document
+        instead of opening a (possibly unresolvable) copy."""
+        want = os.path.splitext(os.path.basename(path))[0].lower()
+        docs = safe_call(self.app, "GetDocuments")
+        if docs is None:
+            # fall back to the linked-list walk on versions without GetDocuments
+            docs = []
+            d = safe_call(self.app, "GetFirstDocument")
+            seen = 0
+            while d is not None and seen < 1000:
+                docs.append(d)
+                d = safe_call(d, "GetNext")
+                seen += 1
+        for d in (docs or []):
+            try:
+                title = safe_prop(d, "GetTitle") or ""
+            except Exception:
+                continue
+            if os.path.splitext(title)[0].lower() == want:
+                return d
+        return None
 
     def close_doc(self, doc):
         title = safe_prop(doc, "GetTitle")


### PR DESCRIPTION
Two independent improvements (one commit each).

## 1. Editor: box-select batch operations + reliable deselect

- **Box-select mode** toolbar toggle: plain left-drag selects a rectangle of links (Shift+drag still works at any time too), on top of the existing multi-select.
- **Batch operations** on the selection, from the bottom bulk bar: set **colour**, set **material** (density preset), and **reset colour** — alongside the existing bulk joint-type buttons.
- Box-selected links are now reported by `baseTint()`, so the selection highlight survives a colour change. This also **fixes deselect**: Escape / clicking empty space / the ✕ button now clear the box selection (it previously stuck, because `baseTint` re-applied the tint before the set was cleared).
- Renamed the "merge fixed" view toggle icon to 🔗 (the previous ⊟ was unclear).

## 2. Extract: robust SolidWorks document open

Fixes a chain of issues that stopped extraction on a current pywin32 / a running SolidWorks session:

- **`open_doc6()`**: pywin32 (≈ build 311+) raises `TypeError: int() argument ... not 'VARIANT'` while coercing `OpenDoc6`'s two `[out]` long params passed as `VARIANT(VT_BYREF|VT_I4)`. Fall back to plain-int args and read the returned values. Used by both the assembly open and the per-part mesh open.
- **Reference search folders**: merge our folders with the user's existing referenced-document search paths instead of *replacing* them (the old behaviour discarded the paths SolidWorks uses to resolve the parts).
- **Unique copy title**: open the throw-away copy under a unique file name so it never clashes with the same assembly already open in the reused session (`swFileWithSameTitleAlreadyOpen`, error 65536); a clear, actionable message if it still trips.
- **Reuse the already-open document**: when attached to the user's running SolidWorks and the target assembly is already open (and resolved), extract from that document instead of a fragile copy that can come up with 0 components for a `.SLDASM` whose parts live elsewhere. Read-only — extraction never saves, and attach mode never closes the user's docs.
- **Print the full traceback** on extract failure (it was previously swallowed, leaving only the message).

## Testing
- Editor: JS syntax checked; the batch colour/material/reset endpoints verified against the running server for multiple links.
- Extract: lint + import clean. The pywin32 `OpenDoc6` fix and the unique-title fix are confirmed against a live SolidWorks (the assembly opens); the "reuse the already-open document" path is pending a final live confirmation on a session that has the assembly open.
