### PR TITLE
Fix Delete for sub-assembly child links

### DIFF
--- a/sw2robot/exporter/model.py
+++ b/sw2robot/exporter/model.py
@@ -2157,6 +2157,18 @@ def _edge_rec(e):
             "mates": [g.model_dump() for g in e.mates] if e.mates else []}
 
 
+def _excluded(name, link_name, exclude):
+    """True if an ``exclude`` entry matches a component's SolidWorks ``name`` OR
+    its (sanitised) URDF ``link_name``.  The editor's Delete may send either form
+    -- the raw component name (``vial_phi30_all.SLDPRT-2/vial_phi30-1``) or the
+    link name (``vial_phi30_all_SLDPRT_2__vial_phi30_1``) -- and the two differ
+    by '.'/'/'/'-' vs '_', so matching only the component name silently missed
+    links whose Delete fell back to the link name."""
+    n = (name or "").lower()
+    ln = (link_name or "").lower()
+    return any(e in n or (ln and e in ln) for e in exclude)
+
+
 def from_graph(graph, exclude=None, expand=None, no_expand=None):
     """GraphState -> (comps, adjacency, ground), applying ``exclude`` and
     expanding sub-assemblies whose internals move (see
@@ -2167,7 +2179,7 @@ def from_graph(graph, exclude=None, expand=None, no_expand=None):
         print(f"      excluding {len(hidden)} hidden components")
     comps = []
     for cs in graph.components:
-        if any(e in cs.name.lower() for e in exclude):
+        if _excluded(cs.name, cs.link_name, exclude):
             continue
         if cs.name in hidden:
             continue
@@ -2185,8 +2197,22 @@ def from_graph(graph, exclude=None, expand=None, no_expand=None):
         adjacency[frozenset((e.a, e.b))] = _edge_rec(e)
     ground = {g for g in graph.ground if g in names}
     _snap_unsolved_mates(comps, adjacency)
-    return _expand_subassemblies(graph, comps, adjacency, ground,
-                                 expand=expand, no_expand=no_expand)
+    comps, adjacency, ground = _expand_subassemblies(
+        graph, comps, adjacency, ground, expand=expand, no_expand=no_expand)
+    if exclude:
+        # Apply `exclude` AGAIN after expansion: the filter at the top of this
+        # function only sees top-level graph.components, so a part excluded from
+        # INSIDE an expanded sub-assembly (e.g. the editor's Delete on a
+        # palm_1__* child) would otherwise be spliced back in here.  Prune the
+        # matching components and any adjacency edge / ground entry that
+        # referenced them.
+        keep = {c.name for c in comps
+                if not _excluded(c.name, c.link_name, exclude)}
+        comps = [c for c in comps if c.name in keep]
+        adjacency = {k: v for k, v in adjacency.items()
+                     if all(n in keep for n in k)}
+        ground = {g for g in ground if g in keep}
+    return comps, adjacency, ground
 
 
 # --------------------------------------------------------------------

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -226,6 +226,33 @@ def test_hidden_components_excluded():
     assert "plate-1" not in {c.name for c in comps2}
 
 
+def test_exclude_applies_after_subassembly_expansion():
+    # excluding a part that only exists AFTER sub-assembly expansion (what the
+    # editor's Delete sends for a sub-assembly child) must remove it -- the
+    # top-level exclude filter never sees it, so the post-expansion pass does.
+    comps, adj, ground = from_graph(make_graph(), exclude=["servo-1/horn-1"])
+    names = {c.name for c in comps}
+    assert "servo-1/horn-1" not in names
+    assert names == {"plate-1", "servo-1/case-1"}
+    # the removed child no longer appears on any adjacency edge
+    assert not any("horn-1" in n for key in adj for n in key)
+    # a top-level exclude still works (regression guard)
+    comps2, _, _ = from_graph(make_graph(), exclude=["plate-1"])
+    assert "plate-1" not in {c.name for c in comps2}
+
+
+def test_excluded_matches_component_or_link_name():
+    # the editor's Delete may send the raw component name OR the sanitised link
+    # name; both must match (they differ by '.'/'/'/'-' vs '_').  Real vial case.
+    from sw2robot.exporter.model import _excluded
+    comp = "vial_phi30_all.SLDPRT-2/vial_phi30-1"
+    link = "vial_phi30_all_SLDPRT_2__vial_phi30_1"
+    assert _excluded(comp, link, [link.lower()])      # link-name form
+    assert _excluded(comp, link, [comp.lower()])      # component-name form
+    assert not _excluded(comp, link, ["unrelated"])
+    assert not _excluded(comp, link, ["vial_phi30_all_sldprt_1__vial_phi30_1"])
+
+
 def test_snap_not_fooled_by_multi_mate_single_instance():
     # ONE cover mated to two boards: hole A on its origin axis (0mm), hole B
     # 20mm away -- legitimate design, must NOT be "corrected"


### PR DESCRIPTION
## Summary
The editor's Delete key removes a link by adding its component to the URDF `exclude:` list and rebuilding. Parts **inside an expanded sub-assembly** (e.g. `vial_phi30_all_SLDPRT_2__vial_phi30_1`, the feetech `palm_1__*` children) never went away. Two causes, both fixed in `from_graph`:

1. **exclude ran before expansion.** It only filtered top-level `graph.components`; `_expand_subassemblies` then spliced the children back in. Now exclude is re-applied to the final component list (pruning the matching components and any adjacency edge / ground entry that referenced them).
2. **exclude matched only the component name.** Delete may send the *sanitised URDF link name* instead of the raw SolidWorks component name, and the two differ by `.`/`/`/`-` vs `_` (`vial_phi30_all.SLDPRT-2/vial_phi30-1` vs `vial_phi30_all_SLDPRT_2__vial_phi30_1`), so the match silently missed. A new `_excluded()` helper matches an exclude entry against **either** the component name **or** the link name.

## Testing
- `tests/test_expand.py`: `test_exclude_applies_after_subassembly_expansion` (a sub-assembly child is removed after expansion; top-level exclude still works) and `test_excluded_matches_component_or_link_name` (the real vial names, both forms).
- Verified end-to-end against the real `/api/set_exclude` path on the extracted feetech + vial packages: the targeted child drops from the rebuilt URDF (45->44 / 63->62).