### PR TITLE
Auto joint-limit margin (deg/mm) + prismatic sweep

### DIFF
--- a/sw2robot/editor/_autolimits_cli.py
+++ b/sw2robot/editor/_autolimits_cli.py
@@ -7,7 +7,8 @@ keep-alive connection threads -- the classic CPython convoy, which inflated an
 8 s sweep to ~90 s just by having a page open.  A fresh process has its own GIL
 and no server threads, so it stays at the true ~8 s (+~3 s to load the model).
 
-    python -m sw2robot.editor._autolimits_cli <urdf> <step_deg> <max_deg>
+    python -m sw2robot.editor._autolimits_cli <urdf> <step_deg> <max_deg> \
+        [margin_deg] [margin_mm]
     -> stdout: {"results": [{"child","lower","upper","continuous"}, ...]}
 """
 
@@ -59,6 +60,9 @@ def _emit(**ev):
 
 def main():
     urdf, step_deg, max_deg = sys.argv[1], float(sys.argv[2]), float(sys.argv[3])
+    # optional backoff margins: degrees (revolute), mm (prismatic)
+    margin_deg = float(sys.argv[4]) if len(sys.argv) > 4 else 2.0
+    margin_mm = float(sys.argv[5]) if len(sys.argv) > 5 else 2.0
     from skrobot.models.urdf import RobotModelFromURDF
 
     from sw2robot.editor import autoinit
@@ -76,7 +80,7 @@ def main():
     meshes = autoinit.link_meshes(robot)
 
     total = sum(1 for j in robot.joint_list
-                if type(j).__name__ == "RotationalJoint")
+                if type(j).__name__ in ("RotationalJoint", "LinearJoint"))
     _emit(event="start", total=total)
     done = [0]
 
@@ -85,7 +89,8 @@ def main():
         _emit(event="joint", i=done[0], total=total, joint=name)
 
     results = autoinit.sweep_limits(
-        robot, meshes, step_deg=step_deg, max_deg=max_deg, margin_deg=2.0,
+        robot, meshes, step_deg=step_deg, max_deg=max_deg,
+        margin_deg=margin_deg, margin_mm=margin_mm,
         refine=True, progress=progress)
     out = [{"child": v["child"], "lower": v["lower"], "upper": v["upper"],
             "continuous": v["continuous"]}

--- a/sw2robot/editor/autoinit.py
+++ b/sw2robot/editor/autoinit.py
@@ -324,44 +324,51 @@ class SelfCollision:
         return float(d), tuple(sorted((la, lb)))
 
 
+def _prismatic_joints(robot):
+    return [j for j in robot.joint_list
+            if type(j).__name__ == "LinearJoint"]
+
+
 def sweep_limits(robot, meshes, step_deg=6.0, max_deg=180.0, margin_deg=2.0,
+                 step_mm=5.0, max_mm=300.0, margin_mm=2.0,
                  margin_m=REST_MARGIN, only=None, progress=None, refine=True,
-                 refine_tol_deg=0.4, sc=None, hull=False):
-    """Per-joint self-collision limit sweep, from the HOME pose (all angles 0).
+                 refine_tol_deg=0.4, refine_tol_mm=0.2, sc=None, hull=False):
+    """Per-joint self-collision limit sweep, from the HOME pose (all at 0).
 
-    Returns ``{joint_name: {lower, upper, continuous, hit_lower, hit_upper,
-    child}}`` with angles in radians.  ``hit_*`` is the colliding link pair
-    that stopped that direction (or ``None`` if the sweep reached ``max_deg``
-    freely).  A joint free in both directions is flagged ``continuous`` (and
-    given the full +-max range as a nominal limit).
+    Sweeps REVOLUTE joints in radians (``step_deg`` / ``max_deg``) and PRISMATIC
+    joints in metres (``step_mm`` / ``max_mm``).  Returns
+    ``{joint_name: {lower, upper, continuous, hit_lower, hit_upper, child}}`` --
+    revolute limits in radians, prismatic limits in metres.  ``hit_*`` is the
+    colliding link pair that stopped that direction (or ``None`` if it reached
+    the max freely).  A revolute joint free both ways is flagged ``continuous``.
 
-    The sweep is a COARSE linear scan (``step_deg``) to bracket the first new
-    self-collision, then -- when ``refine`` -- a BISECTION between the last
-    clear step and the first colliding step to pin the boundary to
-    ``refine_tol_deg`` (the user's idea: a binary search beats fine stepping,
-    so the coarse step can be large and the result is still precise).  The
-    reported limit is the last clear angle minus a small ``margin_deg``.
+    The sweep is a COARSE linear scan to bracket the first new self-collision,
+    then -- when ``refine`` -- a BISECTION to pin the boundary.  The reported
+    limit is the last clear position **backed off** by ``margin_deg`` (revolute)
+    or ``margin_mm`` (prismatic) -- the user-facing safety margin from the
+    colliding edge.
 
-    ``only`` (a set/list of joint names) restricts the sweep to those joints --
-    used by the UI's per-joint "auto-fit" button.  Contacts and adjacency form
-    the baseline at the home pose, and every other joint stays at 0 while one
-    joint sweeps (so each limit is measured against the rest of the robot at
-    rest).  Pass an already-built ``sc`` (SelfCollision) to skip rebuilding it.
-    The robot's pre-call joint angles are restored before returning.
+    ``only`` (joint names) restricts the sweep.  Contacts + adjacency form the
+    HOME baseline; every other joint stays at 0 while one sweeps.  Pass a built
+    ``sc`` to skip rebuilding it.  Pre-call joint angles are restored on return.
     """
     rjoints = _rotational_joints(robot)
+    pjoints = _prismatic_joints(robot)
     if only is not None:
         only = set(only)
         rjoints = [j for j in rjoints if j.name in only]
+        pjoints = [j for j in pjoints if j.name in only]
+    joints = rjoints + pjoints
 
     # snapshot to restore at the end; widen limits so the sweep is not clamped
     snapshot = {j.name: float(j.joint_angle()) for j in robot.joint_list}
     saved_lims = {}
-    for j in _rotational_joints(robot):
+    for j in rjoints + pjoints:
         saved_lims[j.name] = (j.min_angle, j.max_angle)
-        j.min_angle, j.max_angle = -4 * np.pi, 4 * np.pi
+        wide = 10.0 if j in pjoints else 4 * np.pi   # metres vs radians
+        j.min_angle, j.max_angle = -wide, wide
     # baseline (rest contacts + adjacency) is defined at the HOME pose
-    for j in _rotational_joints(robot):
+    for j in joints:
         j.joint_angle(0.0)
     if sc is None:
         # hull=False by default here: the limit sweep needs the EXACT meshes
@@ -369,7 +376,7 @@ def sweep_limits(robot, meshes, step_deg=6.0, max_deg=180.0, margin_deg=2.0,
         # wide).  Callers that already built a hull `sc` (the live UI) pass it.
         sc = SelfCollision(robot, meshes, margin=margin_m, hull=hull)
     # Hull PRE-FILTER world.  A convex hull CONTAINS its mesh, so if two hulls
-    # do not collide the meshes inside them cannot either: a hull-clear angle is
+    # do not collide the meshes inside them cannot either: a hull-clear pose is
     # provably mesh-clear.  The coarse scan runs on these cheap hulls and only
     # escalates to the exact mesh where a hull flags a possible collision, so a
     # free joint (the common, expensive case -- it scans the whole range finding
@@ -378,11 +385,6 @@ def sweep_limits(robot, meshes, step_deg=6.0, max_deg=180.0, margin_deg=2.0,
     # it rather than build a redundant second hull world.)
     sc_hull = sc if hull else SelfCollision(robot, meshes, margin=margin_m,
                                             hull=True)
-
-    step = np.radians(step_deg)
-    nmax = max(1, int(np.radians(max_deg) / step))
-    margin = np.radians(margin_deg)
-    tol = np.radians(refine_tol_deg)
 
     import fcl
 
@@ -406,14 +408,15 @@ def sweep_limits(robot, meshes, step_deg=6.0, max_deg=180.0, margin_deg=2.0,
     raw_objs, raw_g2n, raw_set_T = _world(sc)
     hull_objs, hull_g2n, hull_set_T = _world(sc_hull)
 
-    def _moving_set(J):
-        # Which links ACTUALLY move when only J rotates?  Determined by probing
+    def _moving_set(J, probe):
+        # Which links ACTUALLY move when only J moves?  Determined by probing
         # (the skrobot parent/child tree-walk under-reports the subtree for
         # this model -- it returned just the immediate child while 18 links
         # really move).  The subtree is rigid, so one probe reveals all of it;
-        # the full transform comparison catches on-axis rotation too.
+        # the full transform comparison catches on-axis rotation too.  ``probe``
+        # is in the joint's native unit (radians / metres).
         home = {n: sc._link[n].worldcoords().T() for n in sc.names}
-        J.joint_angle(np.radians(7.0))
+        J.joint_angle(probe)
         moved = {n for n in sc.names
                  if not np.allclose(sc._link[n].worldcoords().T(),
                                     home[n], atol=1e-7)}
@@ -422,15 +425,30 @@ def sweep_limits(robot, meshes, step_deg=6.0, max_deg=180.0, margin_deg=2.0,
 
     out = {}
     try:
-        for J in rjoints:
-            moving = _moving_set(J)
+        for J in joints:
+            pris = J in pjoints
+            # per-joint sweep parameters in the joint's native unit
+            if pris:
+                u_step = step_mm / 1000.0
+                u_max = max_mm / 1000.0
+                u_margin = margin_mm / 1000.0
+                u_tol = refine_tol_mm / 1000.0
+                u_probe = max(u_step, 0.005)
+            else:
+                u_step = np.radians(step_deg)
+                u_max = np.radians(max_deg)
+                u_margin = np.radians(margin_deg)
+                u_tol = np.radians(refine_tol_deg)
+                u_probe = np.radians(7.0)
+            nmax = max(1, int(u_max / u_step))
+            moving = _moving_set(J, u_probe)
             static = [n for n in sc.names if n not in moving]
             if not moving or not static:
                 # nothing can collide; treat as free
                 out[J.name] = {
-                    "lower": round(-np.radians(max_deg), 5),
-                    "upper": round(np.radians(max_deg), 5),
-                    "continuous": max_deg >= 180.0,
+                    "lower": round(-u_max, 5),
+                    "upper": round(u_max, 5),
+                    "continuous": (not pris) and max_deg >= 180.0,
                     "hit_lower": None, "hit_upper": None,
                     "child": J.child_link.name if J.child_link else None}
                 if progress:
@@ -502,7 +520,7 @@ def sweep_limits(robot, meshes, step_deg=6.0, max_deg=180.0, margin_deg=2.0,
                 # rest of this direction and scan the mesh directly.
                 use_hull = True
                 for k in range(1, nmax + 1):
-                    mag = k * step
+                    mag = k * u_step
                     if use_hull and _hull_clear(mag, direction):
                         clear_mag = mag          # hull clear => mesh clear
                         continue
@@ -515,7 +533,7 @@ def sweep_limits(robot, meshes, step_deg=6.0, max_deg=180.0, margin_deg=2.0,
                 # bisect [clear_mag, hit_mag] to the precise boundary
                 if refine and hit_mag is not None:
                     a, b = clear_mag, hit_mag
-                    while b - a > tol:
+                    while b - a > u_tol:
                         m = 0.5 * (a + b)
                         if _collides(m, direction):
                             b = m
@@ -524,12 +542,13 @@ def sweep_limits(robot, meshes, step_deg=6.0, max_deg=180.0, margin_deg=2.0,
                     clear_mag = a
                 J.joint_angle(0.0)   # back to home before the other direction
                 if hit_mag is None:
-                    lim[direction] = direction * np.radians(max_deg)
+                    lim[direction] = direction * u_max
                 else:
-                    lim[direction] = direction * max(0.0, clear_mag - margin)
+                    lim[direction] = direction * max(0.0, clear_mag - u_margin)
                 hit[direction] = hit_pair
             lo, up = sorted([lim[-1], lim[+1]])
-            continuous = hit[+1] is None and hit[-1] is None and max_deg >= 180.0
+            continuous = (not pris) and hit[+1] is None and hit[-1] is None \
+                and max_deg >= 180.0
             out[J.name] = {
                 "lower": round(float(lo), 5),
                 "upper": round(float(up), 5),
@@ -541,7 +560,7 @@ def sweep_limits(robot, meshes, step_deg=6.0, max_deg=180.0, margin_deg=2.0,
             if progress:
                 progress(J.name, out[J.name])
     finally:
-        for j in rjoints:
+        for j in rjoints + pjoints:
             j.min_angle, j.max_angle = saved_lims[j.name]
         for j in robot.joint_list:
             try:

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -554,6 +554,26 @@
               data-i18n-title="t.autolimits"
               title="各回転関節を ±2π(±360°)の範囲で自己干渉が起きる角度まで掃引(粗スキャン+二分探索)して lower/upper を自動設定。±2π まで自由に回る関節は continuous に。Ctrl+Zで戻せます">
         🛠 自動関節リミット (自己干渉, ±2π)</button>
+      <div style="display:flex;gap:8px;align-items:center;margin-top:4px;
+                  font-size:11px;color:#8a93a3">
+        <span data-i18n="ui.marginLabel">余裕:</span>
+        <label style="display:flex;gap:3px;align-items:center"
+               data-i18n-title="t.marginDeg"
+               title="back off this many degrees from the colliding edge (revolute joints)">
+          <input id="marginDeg" type="number" value="2" min="0" step="0.5"
+                 style="width:46px;background:#15171a;color:#cfe3ff;
+                        border:1px solid #2d4a35;border-radius:3px;padding:1px 3px">
+          <span>° <span data-i18n="ui.marginRev">回転</span></span>
+        </label>
+        <label style="display:flex;gap:3px;align-items:center"
+               data-i18n-title="t.marginMm"
+               title="back off this many mm from the colliding edge (prismatic joints)">
+          <input id="marginMm" type="number" value="2" min="0" step="0.5"
+                 style="width:46px;background:#15171a;color:#cfe3ff;
+                        border:1px solid #2d4a35;border-radius:3px;padding:1px 3px">
+          <span>mm <span data-i18n="ui.marginPris">直動</span></span>
+        </label>
+      </div>
     </div>
     <div id="rootbox" style="border:1px solid #333;border-radius:4px;
          padding:6px 8px;margin:6px 0;background:#1e2126;font-size:12px">
@@ -1231,6 +1251,13 @@ skrobot / native-mesh consumers (not RViz-loadable)">⬇ glb</button></a>
     't.autolimits': { en: 'sweep each rotary joint over ±2π(±360°) to the self-collision angle (coarse scan + binary search) and auto-set lower/upper. Joints free over the full ±2π become continuous. Ctrl+Z to undo.',
                       ja: '各回転関節を ±2π(±360°)の範囲で自己干渉が起きる角度まで掃引(粗スキャン+二分探索)して lower/upper を自動設定。±2π まで自由に回る関節は continuous に。Ctrl+Zで戻せます' },
     'ui.autolimits': { en: '🛠 auto joint limits (self-collision, ±2π)', ja: '🛠 自動関節リミット (自己干渉, ±2π)' },
+    'ui.marginLabel': { en: 'margin:', ja: '余裕:' },
+    'ui.marginRev': { en: 'rev', ja: '回転' },
+    'ui.marginPris': { en: 'pris', ja: '直動' },
+    't.marginDeg': { en: 'back off this many degrees from the colliding edge (revolute joints)',
+                     ja: '衝突する端からこの角度(度)だけ手前で止める（回転関節）' },
+    't.marginMm': { en: 'back off this many mm from the colliding edge (prismatic joints)',
+                    ja: '衝突する端からこのmmだけ手前で止める（直動関節）' },
     'ui.rootframe': { en: 'root frame (rotate about current axes / set numbers)',
                       ja: 'root frame (rotate about current axes / set numbers)' },
     'ui.enterApply': { en: '(Enter applies)', ja: '(Enter で即適用)' },
@@ -3891,7 +3918,11 @@ autolimitsBtn.addEventListener('click', async () => {
   // its GIL the way the old in-process sweep did.)
   showLoadbar(t('auto.sweepBar'), { indet: true });
   try {
-    const resp0 = await fetch('/api/auto_limits');
+    const md = document.getElementById('marginDeg')?.value || '2';
+    const mm = document.getElementById('marginMm')?.value || '2';
+    const resp0 = await fetch(
+      `/api/auto_limits?margin_deg=${encodeURIComponent(md)}`
+      + `&margin_mm=${encodeURIComponent(mm)}`);
     const data = await resp0.json();
     if (!resp0.ok || data.error) { throw new Error(data.error ?? resp0.status); }
     let st = {};

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1458,7 +1458,8 @@ _limjob = {"running": False, "log": [], "error": None, "results": None,
 _limjob_lock = threading.Lock()
 
 
-def _run_auto_limits(pkg_dir, urdf_rel, step_deg, max_deg):
+def _run_auto_limits(pkg_dir, urdf_rel, step_deg, max_deg,
+                     margin_deg=2.0, margin_mm=2.0):
     """Run the self-collision limit sweep in a SUBPROCESS and return
     ``(results_list, error)``.  A subprocess on purpose: the sweep is CPU-bound
     and releases the GIL (numpy / fcl), so running it inside the threaded HTTP
@@ -1488,7 +1489,7 @@ def _run_auto_limits(pkg_dir, urdf_rel, step_deg, max_deg):
     else:
         cmd = [sys.executable, "-m", "sw2robot.editor._autolimits_cli"]
         cwd = PROJECT_ROOT
-    cmd += [urdf, str(step_deg), str(max_deg)]
+    cmd += [urdf, str(step_deg), str(max_deg), str(margin_deg), str(margin_mm)]
     _t0 = time.time()
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE, text=True, cwd=cwd)
@@ -1836,8 +1837,11 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 try:
                     step = float((query.get("step") or ["10"])[0])
                     mx = float((query.get("max") or ["360"])[0])  # ±2π
+                    # backoff margins from the colliding edge: deg / mm
+                    margin_deg = float((query.get("margin_deg") or ["2"])[0])
+                    margin_mm = float((query.get("margin_mm") or ["2"])[0])
                 except ValueError:
-                    return self._send_json({"error": "bad step/max"}, 400)
+                    return self._send_json({"error": "bad step/max/margin"}, 400)
                 # URDF-input mode: sweep the live overlay (type edits included)
                 try:
                     pkg = cls.pkg_dir
@@ -1858,7 +1862,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 # the /api/extract* handlers with an UnboundLocalError.
                 def _sweep_job():
                     try:
-                        results, err = _run_auto_limits(pkg, rel, step, mx)
+                        results, err = _run_auto_limits(
+                            pkg, rel, step, mx, margin_deg, margin_mm)
                     except Exception as e:           # never leave it "running"
                         results, err = None, f"{type(e).__name__}: {e}"
                     with _limjob_lock:

--- a/tests/test_autoinit.py
+++ b/tests/test_autoinit.py
@@ -133,6 +133,28 @@ def test_sweep_limits_finds_limits_and_restores_pose(built_pkg):
             assert abs(float(j.joint_angle())) < 1e-6
 
 
+def test_sweep_margin_tightens_limit(built_pkg):
+    """A bigger backoff margin must never WIDEN a hit-bounded limit (it backs
+    further off the colliding edge).  Guards the configurable margin_deg."""
+    if not _skrobot_ready():
+        pytest.skip("skrobot / python-fcl not available")
+    from sw2robot.editor import autoinit
+
+    robot, meshes = _load_robot_and_meshes(built_pkg)
+    small = autoinit.sweep_limits(robot, meshes, step_deg=6, max_deg=120,
+                                  margin_deg=2.0)
+    hit = next((jn for jn, v in small.items()
+                if v.get("hit_upper") or v.get("hit_lower")), None)
+    if hit is None:
+        pytest.skip("no joint hit a collision in this fixture")
+    big = autoinit.sweep_limits(robot, meshes, step_deg=6, max_deg=120,
+                                margin_deg=20.0, only={hit})
+    if small[hit]["hit_upper"] is not None:
+        assert big[hit]["upper"] <= small[hit]["upper"] + 1e-9
+    if small[hit]["hit_lower"] is not None:
+        assert big[hit]["lower"] >= small[hit]["lower"] - 1e-9
+
+
 def test_self_collision_min_distance(built_pkg):
     if not _skrobot_ready():
         pytest.skip("skrobot / python-fcl not available")


### PR DESCRIPTION
## Summary
The auto joint-limit sweep now (1) backs off from the colliding edge by a **user-settable margin** instead of a hardcoded 2°, and (2) also sweeps **prismatic** joints (was revolute-only).

## What changed
- **`sweep_limits`**: sweeps revolute joints in radians (`step_deg`/`max_deg`/`margin_deg`) and prismatic joints in metres (`step_mm`/`max_mm`/`margin_mm`). Each limit is backed off the colliding edge in its own unit. `continuous` stays revolute-only; prismatic limits are reported in metres.
- **margins threaded** through `_autolimits_cli` (extra argv) and `/api/auto_limits` (`margin_deg`/`margin_mm` query params) → `_run_auto_limits`.
- **Editor UI**: a *degree* margin input (revolute) and an *mm* margin input (prismatic) next to the 🛠 auto-limits button; sent on the sweep request.
- **Test**: a larger margin never widens a hit-bounded limit.

## Testing
- Full suite green (skips are fixture/UI-dep, unchanged).
- Verified live on the **vial gripper** (18 revolute + 2 prismatic):
  - revolute margin backs the limit off and clamps at 0 as expected;
  - a prismatic limit moved from **−23.8 mm → −5.8 mm** with a margin 18 mm bigger (exactly the extra backoff), limits in metre-scale, swept without error.