### PR TITLE
fix(update): make self-update reliable from OneDrive-synced folders

### DIFF
--- a/sw2robot/editor/update.py
+++ b/sw2robot/editor/update.py
@@ -33,6 +33,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 import urllib.request
@@ -218,10 +219,67 @@ def _popen_detached(argv):
     subprocess.Popen(argv, **kw)
 
 
+def _current_bound_port():
+    """The port the running web server actually bound (so the relaunch can
+    reclaim the SAME one); None outside the web server."""
+    try:
+        from . import webserver
+        return getattr(webserver, "BOUND_PORT", None)
+    except Exception:
+        return None
+
+
 def _relaunch_argv(exe):
-    """The new binary + the same user args (package dir, --root, --port ...)
-    the current run got, so the relaunched editor reopens the same context."""
-    return [exe, *sys.argv[1:]]
+    """The new binary + the user's original args (package dir, --root ...), with
+    three adjustments so the relaunch lands back in the SAME browser tab instead
+    of leaving a dead one behind on a drifting port:
+
+      * force ``--no-browser`` -- the page that triggered the update reloads
+        itself once the new server is up (see index.html), so opening a second
+        tab is just clutter that points at the old, now-exited instance;
+      * pin ``--port`` to the port THIS server actually bound, so that reload
+        reconnects at the same URL (without it the relaunch defaults to 8090 and
+        may bind a different free port than the tab is open on);
+      * pass ``--reclaim-port`` so the new instance briefly WAITS for that exact
+        port to free up (the old one is mid-exit) rather than immediately
+        walking forward to the next free port.
+    The three flags are stripped from the inherited args first so they don't
+    accumulate across successive self-updates."""
+    args, skip = [], False
+    for a in sys.argv[1:]:
+        if skip:                                   # value of a prior "--port"
+            skip = False
+            continue
+        if a == "--port":
+            skip = True
+            continue
+        if a.startswith("--port=") or a in ("--no-browser", "--reclaim-port"):
+            continue
+        args.append(a)
+    argv = [exe, *args, "--no-browser", "--reclaim-port"]
+    port = _current_bound_port()
+    if port:
+        argv += ["--port", str(port)]
+    return argv
+
+
+def _replace_into(src, dst):
+    """Move ``src`` onto ``dst``.  ``os.replace`` is atomic but only WITHIN one
+    filesystem; the download now lives in %TEMP%, which may sit on a different
+    volume than the exe (e.g. TEMP on C:, the exe on D:), where ``os.replace``
+    raises EXDEV / WinError 17.  Fall back to copying onto a sibling of ``dst``
+    (same volume) and atomically replacing from there, so ``dst`` is never seen
+    half-written by a concurrent reader."""
+    try:
+        os.replace(src, dst)
+    except OSError:
+        tmp = dst + ".new"
+        shutil.copyfile(src, tmp)
+        os.replace(tmp, dst)            # same-dir -> atomic
+        try:
+            os.remove(src)
+        except OSError:
+            pass
 
 
 def _swap_exe_and_relaunch(new_file, target):
@@ -235,7 +293,7 @@ def _swap_exe_and_relaunch(new_file, target):
         pass
     os.replace(target, old)             # rename the running image (allowed)
     try:
-        os.replace(new_file, target)    # move the new binary into place
+        _replace_into(new_file, target)  # move the new binary into place
     except OSError:
         os.replace(old, target)         # roll the rename back on failure
         raise
@@ -297,11 +355,15 @@ def _run_update(info):
     url = asset.get("url")
     name = asset.get("name") or "sw2robot-web-update"
     kind, target = _current_target()
-    dldir = os.path.dirname(target)
-    # download next to the target so the final os.replace is a same-filesystem
-    # rename; a leading '.' keeps the package scanner from picking it up
-    part = os.path.join(dldir, "." + name + ".part")
-    final = os.path.join(dldir, "." + name + ".download")
+    # Download into a private, NON-synced temp dir -- NOT next to the exe.  The
+    # exe often lives in a OneDrive/Dropbox-synced folder (e.g. the Desktop);
+    # streaming a multi-100MB .part right beside a synced binary makes the sync
+    # client fight us for the file the whole download.  We download to %TEMP%
+    # and only move the finished file across at the very end (_replace_into
+    # handles the cross-volume case).
+    dldir = tempfile.mkdtemp(prefix="sw2robot-update-")
+    part = os.path.join(dldir, name + ".part")
+    final = os.path.join(dldir, name)
     try:
         _set(state="downloading", pct=0, error=None, version=info.get("latest"),
              downloaded=0, total=asset.get("size") or 0)
@@ -320,15 +382,10 @@ def _run_update(info):
             _swap_exe_and_relaunch(final, target)
         _set(state="restarting")
         # let the UI's status poll read 'restarting' once, then exit so the
-        # relaunched instance can bind the (now-freed) port
+        # relaunched instance can reclaim the (now-freed) port
         threading.Timer(1.0, lambda: os._exit(0)).start()
     except Exception as e:
-        for p in (part, final):
-            try:
-                if os.path.exists(p):
-                    os.remove(p)
-            except OSError:
-                pass
+        shutil.rmtree(dldir, ignore_errors=True)
         _set(state="error", error=f"{type(e).__name__}: {e}")
 
 

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -40,6 +40,11 @@ PACKAGE_ROOT = os.path.dirname(HERE)
 PROJECT_ROOT = os.path.dirname(PACKAGE_ROOT)
 WEB_DIR = os.path.join(HERE, "web")
 
+# The port the running server bound (set in serve()).  The self-update relaunch
+# reads this (sw2robot.editor.update._current_bound_port) to reclaim the SAME
+# port, so the page that reloads after an update reconnects at the same URL.
+BOUND_PORT = None
+
 
 def _app_data_dir():
     """Writable base for runtime side-files (the default package root, the
@@ -2881,14 +2886,28 @@ class _Handler(http.server.BaseHTTPRequestHandler):
         pass
 
 
-def _bind_free_port(handler, port, tries=20):
+def _bind_free_port(handler, port, tries=20, wait_first=0.0):
     """Bind a ThreadingTCPServer on the first free port >= ``port``.
 
     A second editor instance (or a leftover one) would otherwise collide on the
     default port and the launch crashes with ``WinError 10048`` (address in
     use); walking forward to the next free port lets every instance just come
-    up. Returns ``(httpd, bound_port)``."""
+    up. Returns ``(httpd, bound_port)``.
+
+    ``wait_first`` (seconds) makes a self-update relaunch RECLAIM the exact same
+    port: the instance we are replacing is still mid-exit, so retry ``port`` for
+    a moment before walking forward -- that way the browser tab that reloads
+    after the update reconnects at the same URL instead of finding the new
+    server on a drifted port."""
     last = None
+    if wait_first > 0:
+        deadline = time.time() + wait_first
+        while time.time() < deadline:
+            try:
+                return socketserver.ThreadingTCPServer(("", port), handler), port
+            except OSError as e:
+                last = e
+                time.sleep(0.3)
     for p in range(port, port + tries):
         try:
             return socketserver.ThreadingTCPServer(("", p), handler), p
@@ -2897,7 +2916,9 @@ def _bind_free_port(handler, port, tries=20):
     raise OSError(f"no free port in {port}..{port + tries - 1}: {last}")
 
 
-def serve(package_dir=None, root_dir=None, port=8090, open_browser=True):
+def serve(package_dir=None, root_dir=None, port=8090, open_browser=True,
+          reclaim_port=False):
+    global BOUND_PORT
     import atexit
     import signal
     # reap any private SolidWorks instance a PREVIOUS run spawned and leaked
@@ -2929,10 +2950,14 @@ def serve(package_dir=None, root_dir=None, port=8090, open_browser=True):
     else:
         print(f"[sw2robot.web] no package yet -- pick one in the browser "
               f"(root: {_Handler.root_dir})")
-    httpd, bound = _bind_free_port(_Handler, port)
+    # a self-update relaunch reclaims the exact port the old instance had (it is
+    # mid-exit), so wait briefly for it instead of immediately drifting forward
+    httpd, bound = _bind_free_port(_Handler, port,
+                                   wait_first=8.0 if reclaim_port else 0.0)
     if bound != port:
         print(f"[sw2robot.web] port {port} busy -> using {bound}")
     port = bound
+    BOUND_PORT = bound
     httpd.daemon_threads = True
     url = f"http://localhost:{port}"
     print(f"[sw2robot.web] open {url}")
@@ -2945,6 +2970,141 @@ def serve(package_dir=None, root_dir=None, port=8090, open_browser=True):
     httpd.serve_forever()
 
 
+# --- run-from-%LOCALAPPDATA% relocation (avoid self-updating inside OneDrive) -
+# A self-updating single-file exe must never live in a cloud-synced folder: the
+# sync client (OneDrive/Dropbox) watches the file, so the in-place swap fights
+# the uploader (locks, conflict copies, a stale cloud copy rehydrating the OLD
+# version).  Surface/Win11 ships with the Desktop redirected INTO OneDrive, so
+# users routinely drop the exe there.  Fix: on launch, if we are a frozen exe
+# sitting under a synced root, copy ourselves once to a stable, NON-synced
+# install dir (%LOCALAPPDATA%\sw2robot\bin) and relaunch from there.  Every later
+# self-update then rewrites that LocalAppData copy, which no sync client touches.
+
+def _sync_roots():
+    """Cloud-sync root dirs (OneDrive/Dropbox/Google Drive) a self-updating exe
+    must not live in.  Best-effort; empty off Windows."""
+    if sys.platform != "win32":
+        return []
+    roots, home = [], os.path.expanduser("~")
+    for var in ("OneDrive", "OneDriveConsumer", "OneDriveCommercial"):
+        v = os.environ.get(var)
+        if v:
+            roots.append(v)
+    try:
+        for n in os.listdir(home):
+            low = n.lower()
+            if low.startswith("onedrive") or low in ("dropbox", "google drive",
+                                                      "my drive"):
+                roots.append(os.path.join(home, n))
+    except OSError:
+        pass
+    out, seen = [], set()
+    for r in roots:
+        nr = os.path.normcase(os.path.normpath(r))
+        if nr not in seen:
+            seen.add(nr)
+            out.append(nr)
+    return out
+
+
+def _under_any(path, roots):
+    p = os.path.normcase(os.path.normpath(os.path.realpath(path)))
+    for r in roots:
+        try:
+            if os.path.commonpath([p, r]) == r:
+                return True
+        except ValueError:
+            pass                              # different drive -> not under it
+    return False
+
+
+def _install_dir():
+    base = os.environ.get("LOCALAPPDATA") or os.path.join(
+        os.path.expanduser("~"), "AppData", "Local")
+    return os.path.join(base, "sw2robot", "bin")
+
+
+def _make_start_menu_shortcut(target):
+    """Best-effort Start-menu .lnk to the installed exe, so there's a fast launch
+    path that doesn't go through the synced stub.  win32com is bundled on the
+    Windows build (it's the SolidWorks COM glue); absent -> just skip."""
+    try:
+        import win32com.client
+        programs = os.path.join(os.environ["APPDATA"], "Microsoft", "Windows",
+                                "Start Menu", "Programs")
+        os.makedirs(programs, exist_ok=True)
+        sc = win32com.client.Dispatch("WScript.Shell").CreateShortcut(
+            os.path.join(programs, "sw2robot-web.lnk"))
+        sc.TargetPath = target
+        sc.WorkingDirectory = os.path.dirname(target)
+        sc.Description = "sw2robot web editor"
+        sc.save()
+    except Exception as e:
+        print(f"[sw2robot.web] start-menu shortcut skipped: {e!r}")
+
+
+def _relocate_to_install_dir():
+    """If we're a frozen exe running from a cloud-synced folder, install a copy
+    to %LOCALAPPDATA%\\sw2robot\\bin and relaunch it.  Returns True if it
+    relaunched (caller must exit), False to keep running in place.  No-op in a
+    source checkout, off Windows, when already the installed copy, or when run
+    from a normal local folder (stays portable)."""
+    if not getattr(sys, "frozen", False) or sys.platform != "win32":
+        return False
+    if "--no-relocate" in sys.argv:           # we ARE the relaunched install
+        return False
+    try:
+        me = os.path.normcase(os.path.realpath(sys.executable))
+        canonical = os.path.join(_install_dir(), "sw2robot-web.exe")
+        if me == os.path.normcase(os.path.realpath(canonical)):
+            return False                      # already running from the install
+        if not _under_any(sys.executable, _sync_roots()):
+            return False                      # local/portable run -> leave as-is
+        from . import update  # reuse the detached launcher + ver parse
+        bindir = os.path.dirname(canonical)
+        os.makedirs(bindir, exist_ok=True)
+        verfile = os.path.join(bindir, "installed-version.txt")
+        old = canonical + ".old"
+        try:
+            if os.path.exists(old):
+                os.remove(old)                # reap a prior upgrade's leftover
+        except OSError:
+            pass
+        try:
+            with open(verfile, encoding="utf-8") as f:
+                installed = f.read().strip()
+        except OSError:
+            installed = ""
+        from .. import __version__
+        fresh = (not os.path.exists(canonical)
+                 or update._parse_version(__version__)
+                 > update._parse_version(installed))
+        if fresh:
+            import shutil
+            tmp = canonical + ".new"
+            shutil.copyfile(sys.executable, tmp)
+            try:
+                os.replace(tmp, canonical)
+            except OSError:                   # an installed instance is running
+                os.replace(canonical, old)    # rename it aside (allowed)
+                os.replace(tmp, canonical)
+            try:
+                with open(verfile, "w", encoding="utf-8") as f:
+                    f.write(__version__)
+            except OSError:
+                pass
+            _make_start_menu_shortcut(canonical)
+            print(f"[sw2robot.web] installed v{__version__} -> {canonical}")
+        # relaunch the install copy with the same args, flagged so it won't loop
+        update._popen_detached([canonical, *sys.argv[1:], "--no-relocate"])
+        print(f"[sw2robot.web] relaunching from {canonical} "
+              f"(was running from a synced folder)")
+        return True
+    except Exception as e:
+        print(f"[sw2robot.web] relocate skipped: {e!r}")
+        return False
+
+
 def main():
     # self-dispatch: the auto-limit sweep re-invokes this exe as a subprocess
     # (a frozen .exe has no `python -m` to call) with a sentinel first arg.
@@ -2952,6 +3112,11 @@ def main():
         from ._autolimits_cli import main as _autolimits_main
         del sys.argv[1]                       # _autolimits_cli reads argv[1:]
         return _autolimits_main()
+
+    # before anything else, move out of a OneDrive/Dropbox-synced folder so the
+    # self-update never rewrites a binary the sync client is watching
+    if _relocate_to_install_dir():
+        return 0
 
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     ap.add_argument("package_dir", nargs="?", default=None)
@@ -2964,9 +3129,16 @@ def main():
     ap.add_argument("--no-browser", action="store_true",
                     help="do not open the editor in the default browser on "
                          "startup")
+    ap.add_argument("--reclaim-port", action="store_true",
+                    help=argparse.SUPPRESS)   # internal: set by the self-update
+                    # relaunch so the new instance waits for the exact port the
+                    # exiting old instance is about to free (see _bind_free_port)
+    ap.add_argument("--no-relocate", action="store_true",
+                    help=argparse.SUPPRESS)   # internal: set on the relaunch from
+                    # the %LOCALAPPDATA% install copy so it doesn't re-relocate
     args = ap.parse_args()
     serve(args.package_dir, root_dir=args.root, port=args.port,
-          open_browser=not args.no_browser)
+          open_browser=not args.no_browser, reclaim_port=args.reclaim_port)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The packaged `sw2robot-web.exe` is commonly kept on the Windows Desktop, which Win11 redirects into **OneDrive**. A self-rewriting single-file binary inside a cloud-synced folder is structurally fragile:

- the 116 MB update streams its `.part` right next to the synced exe, so OneDrive contends for the file the whole download;
- the relaunch opens a *new* browser tab and can drift to another port (8091), so it looks like nothing changed;
- a stale cloud copy can rehydrate the old version.

Net effect: "I update, restart, and it still shows the old version" — even though the on-disk swap itself works.

## Fixes

1. **Download to `%TEMP%`** (not next to the synced exe). `_replace_into` does the final move, falling back to copy-onto-sibling + atomic replace when `%TEMP%` and the exe are on different volumes.
2. **Same-tab / same-port handoff.** `webserver.BOUND_PORT` exposes the bound port; the relaunch pins `--port` to it, forces `--no-browser` (the page reloads itself), and passes `--reclaim-port` so the new instance waits for the exiting one to free the port instead of walking forward (`_bind_free_port(wait_first=…)`).
3. **Run from `%LOCALAPPDATA%`.** On launch, a frozen Windows exe under a synced root (OneDrive/Dropbox) copies itself once to `%LOCALAPPDATA%\sw2robot\bin\sw2robot-web.exe` (version-gated via `installed-version.txt`) and relaunches with `--no-relocate`. All later self-updates rewrite the LocalAppData copy, which no sync client touches; the synced binary becomes an immutable launcher.

Relocation is best-effort and a no-op in a source checkout, off Windows, when already running from the install dir, or when launched from a normal local folder (stays portable).

## Testing

- `_relaunch_argv` (dedup + flags), `_replace_into` (cross-device fallback), port reclaim (reclaims same port vs. drifts to next), full swap integration, and relocation decision + version-gating — all verified.
- Existing suites: `test_webserver_port.py`, `test_cad_mode_webserver.py`, `test_urdf_mode_webserver.py` — 40 passed.
- The swap/relaunch path was also validated against a real PyInstaller onefile build (local and on a OneDrive Desktop).

## Notes

- Takes effect from the next release build (the currently-running binary uses the old logic).
- macOS `.app` relaunch is out of scope here (the OneDrive case is Windows).