### PR TITLE
feat(editor): instant joint-type edits + shift-click multi-select

### DIFF
--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -1004,6 +1004,9 @@ skrobot / native-mesh consumers (not RViz-loadable)">⬇ glb</button></a>
     'types.rebuilt': { en: a => `rebuilt ✓ (${a.n} change(s)) — reloading (meshes come from cache, pose+camera kept)`,
                        ja: a => `再ビルド完了 ✓（${a.n} 件）— reloading（メッシュはキャッシュ、姿勢・カメラ維持）` },
     'types.applyFail': { en: a => `apply failed: ${a.e}`, ja: a => `適用に失敗: ${a.e}` },
+    'types.applied': { en: a => `${a.n} type change(s) applied instantly — saving in background …`,
+                       ja: a => `${a.n} 件の種類変更を即時反映しました — バックグラウンドで保存中 …` },
+    'types.saved': { en: a => `saved ✓ (${a.n} change(s))`, ja: a => `保存しました ✓（${a.n} 件）` },
     'jtype.toggle': { en: a => `${a.joint}: ${a.from} → ${a.to} (t)`,
                       ja: a => `${a.joint}: ${a.from} → ${a.to} に変更 (t)` },
     'flip.applying': { en: a => `reversing ${a.joint} …`,
@@ -3833,15 +3836,73 @@ document.getElementById('bulkset').addEventListener('click', () => {
   applyTypeChanges(changes);             // the whole batch in ONE rebuild
 });
 
-// set joint type(s) -> patch joints.yaml + rebuild + reload (applied instantly;
-// the sidebar dropdown / box-select / panel all funnel through here)
-async function applyTypeChanges(changes) {
-  if (!changes.length || !currentInfo) {
-    reselectAfterLoad = null;
-    return false;
+// set joint type(s).  A fixed<->movable flip NEVER changes topology (same links,
+// joint names and tree -- only the joint's type + <axis>/<limit> presence; the
+// exporter even writes a ghost <axis> on fixed joints), so we apply it INSTANTLY
+// in the live model and persist (patch joints.yaml + rebuild URDF) in the
+// BACKGROUND -- no full reload / mesh re-parse on the happy path, hence no lag.
+// Same trust-the-client pattern as root-frame edits.  The sidebar dropdown /
+// box-select / panel all funnel through here.
+
+// best-known axis [x,y,z] for a joint being (re)enabled: this session's memory
+// (stored whenever it was movable) -> the URDF's <axis> tag (present even on
+// fixed joints) -> the live loader axis.  null only if truly unknown.
+function jointAxisArray(j) {
+  const m = axisMemory.get(j.name);
+  if (m && m.length === 3 && m.every(n => Number.isFinite(n))) { return m; }
+  const el = j.urdfNode && [...j.urdfNode.children]
+    .find(e => e.tagName === 'axis');
+  if (el) {
+    const a = (el.getAttribute('xyz') ?? '').trim().split(/\s+/).map(Number);
+    if (a.length === 3 && a.every(n => Number.isFinite(n))) { return a; }
   }
-  log(t('types.applying', { n: changes.length }));
-  statusEl.textContent = t('status.rebuilding');
+  if (j.axis) { return j.axis.toArray(); }
+  return null;
+}
+
+// mutate the live urdf-loader joint so the 3D model + drag behave as the new
+// type, WITHOUT reloading the URDF (topology is identical across a type flip).
+function patchJointTypeLive(j, type) {
+  if (type === 'fixed') {
+    if (j.jointType !== 'fixed') {
+      axisMemory.set(j.name, j.axis.toArray());  // remember for un-fixing later
+      j.setJointValue(0);                         // return to rest before locking
+    }
+    j.jointType = 'fixed';
+    return;
+  }
+  // -> movable: ensure a usable axis (a freshly un-fixed joint may carry none)
+  const arr = jointAxisArray(j) ?? [0, 0, 1];
+  if (!j.axis) { j.axis = new THREE.Vector3(); }
+  j.axis.set(arr[0], arr[1], arr[2]).normalize();
+  j.jointType = type;
+  if (type === 'revolute' || type === 'prismatic') {
+    const lo = Number(j.limit?.lower), hi = Number(j.limit?.upper);
+    // un-fixed joints have no <limit>; default to +-pi like the exporter does.
+    // the background rebuild persists the authoritative range for next reload.
+    if (!(hi > lo)) { j.limit = { lower: -Math.PI, upper: Math.PI }; }
+  }
+  j.setJointValue(0);
+}
+
+// re-render everything that reads a joint's type WITHOUT touching the 3D scene
+// or re-parsing meshes: sidebar tree, move-mode sliders, axis markers, and the
+// open joint panel.  DOM-only -> this is what makes a type flip feel instant.
+function refreshAfterTypeChange() {
+  buildJointRows(viewer.robot);
+  if (playMode) { buildPlayRows(viewer.robot); }
+  addAxisMarkers(viewer.robot);
+  if (selectedLink && viewer.robot.links[selectedLink]) {
+    selectLink(selectedLink);          // rebuild the panel (type / limit / axis)
+  }
+  viewer.redraw();
+}
+
+// serialize the background persists: the editor server is threaded, so two
+// overlapping /api/set_types calls would race the shared joints.yaml + build()
+let typePersistChain = Promise.resolve();
+
+async function persistTypeChanges(changes) {
   try {
     const resp = await fetch('/api/set_types', {
       method: 'POST',
@@ -3849,23 +3910,45 @@ async function applyTypeChanges(changes) {
       body: JSON.stringify({ changes }) });
     const r = await resp.json();
     if (!resp.ok || r.error) { throw new Error(r.error ?? resp.status); }
+    refreshHistory();
     if (r.missed?.length) {
       log(t('types.notFound', { list: r.missed.join(', ') }), 'wrn');
-    }
-    if (!r.applied?.length) {
+    } else if (!r.applied?.length) {
       log(t('types.noneMatched'), 'err');
-      reselectAfterLoad = null;
-      return false;
+    } else {
+      log(t('types.saved', { n: r.applied.length }), 'ok');
+      return;
     }
-    log(t('types.rebuilt', { n: r.applied.length }), 'ok');
-    loadRobot(currentInfo, { keepPose: true });
-    refreshHistory();
-    return true;
+    // anything the optimistic view changed but the file did NOT accept -> resync
+    // the live model from the server's URDF so the editor never drifts.
+    if (currentInfo) { loadRobot(currentInfo, { keepPose: true }); }
   } catch (e) {
     log(t('types.applyFail', { e: e.message ?? e }), 'err');
+    if (currentInfo) { loadRobot(currentInfo, { keepPose: true }); }
+  }
+}
+
+function applyTypeChanges(changes) {
+  if (!changes.length || !currentInfo || !viewer.robot) {
     reselectAfterLoad = null;
     return false;
   }
+  // 1. optimistic in-place patch (instant)
+  const patched = [];
+  for (const ch of changes) {
+    const j = viewer.robot.joints[ch.name];
+    if (!j) { continue; }
+    patchJointTypeLive(j, ch.type);
+    patched.push(ch);
+  }
+  reselectAfterLoad = null;            // no reload -> nothing to reselect
+  if (!patched.length) { return false; }
+  refreshAfterTypeChange();
+  log(t('types.applied', { n: patched.length }));
+  // 2. persist + rebuild URDF in the background (serialized)
+  typePersistChain = typePersistChain
+    .then(() => persistTypeChanges(changes));
+  return true;                         // the panel/rows were rebuilt in place
 }
 
 // write one joint's travel range to joints.yaml (lower/upper, in NATIVE units:
@@ -5103,7 +5186,13 @@ window.addEventListener('pointerup', ev => {
   boxselEl.style.display = 'none';
   viewer.controls.enabled = true;
   applyPoseDrag();                 // restore the chosen drag mode (orbit/pose)
-  if (Math.abs(ev.clientX - x0) < 4 && Math.abs(ev.clientY - y0) < 4) { return; }
+  if (Math.abs(ev.clientX - x0) < 4 && Math.abs(ev.clientY - y0) < 4) {
+    // a Shift+CLICK (no drag): toggle the clicked link in the selection so
+    // repeated clicks accumulate, same as a region box-select
+    const ax = pickAxis(ev);
+    toggleBoxLink(ax ? ax.child : pickLink(ev));
+    return;
+  }
   selectLinksInBox({ l: Math.min(x0, ev.clientX), r: Math.max(x0, ev.clientX),
                      t: Math.min(y0, ev.clientY), b: Math.max(y0, ev.clientY) });
 });
@@ -5128,15 +5217,38 @@ function selectLinksInBox(rect) {
   }
   for (const n of boxSelected) { _tintLink(n, 'sel'); }
   op('boxSelect', { n: boxSelected.size });
+  refreshBulkbar();
+  log(boxSelected.size ? t('bulk.boxSelected', { n: boxSelected.size })
+                       : t('bulk.boxNone'), boxSelected.size ? undefined : 'wrn');
+}
+
+// reflect the current box-selection count in the bulkbar (shared by the
+// Shift+drag box and the Shift+click accumulation below)
+function refreshBulkbar() {
   if (boxSelected.size) {
     document.getElementById('bulkcount').textContent =
       t('bulk.count', { n: boxSelected.size });
     bulkbarEl.style.display = 'flex';
-    log(t('bulk.boxSelected', { n: boxSelected.size }));
   } else {
     bulkbarEl.style.display = 'none';
-    log(t('bulk.boxNone'), 'wrn');
   }
+}
+
+// Shift+CLICK a link to ADD/REMOVE it from the selection -- build a multi-select
+// one link at a time into the SAME set + bulkbar as a Shift+drag box, so you can
+// then bulk-set their joint type together.
+function toggleBoxLink(name) {
+  if (!name) { return; }
+  if (!boxSelected.size && selectedLink) { selectLink(null); }  // box replaces single
+  if (boxSelected.has(name)) {
+    boxSelected.delete(name);
+    _tintLink(name, baseTint(name));
+  } else {
+    boxSelected.add(name);
+    _tintLink(name, 'sel');
+  }
+  op('boxToggle', { name, n: boxSelected.size });
+  refreshBulkbar();
 }
 
 function clearBoxSelection() {
@@ -5272,29 +5384,26 @@ mimicBar.querySelector('#mimicapply').addEventListener('click', applyMimic);
 mimicBar.querySelector('#mimiccancel').addEventListener('click', cancelMimic);
 
 // apply one joint type to every box-selected link's controlling joint
-async function bulkSetType(type) {
+function bulkSetType(type) {
   const links = [...boxSelected];
   if (!links.length || !currentInfo) { return; }
-  bulkbarEl.querySelectorAll('button').forEach(b => b.disabled = true);
-  log(t('bulk.applying', { n: links.length, type }));
-  statusEl.textContent = t('status.rebuilding');
-  try {
-    const resp = await fetch('/api/set_types', {
-      method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ changes: links.map(c => ({ child: c, type })) }) });
-    const r = await resp.json();
-    if (!resp.ok || r.error) { throw new Error(r.error ?? resp.status); }
-    log(t('bulk.applied', { n: r.applied?.length ?? 0 }) +
-        (r.missed?.length ? t('bulk.appliedMissed', { m: r.missed.length }) : '') +
-        t('bulk.reloadUndo'), 'ok');
-    clearBoxSelection();
-    loadRobot(currentInfo, { keepPose: true });
-    refreshHistory();
-  } catch (e) {
-    log(t('bulk.fail', { e: e.message ?? e }), 'err');
-  } finally {
-    bulkbarEl.querySelectorAll('button').forEach(b => b.disabled = false);
+  // route the 3D box-selection through the SAME optimistic path as the sidebar
+  // checkbox bulk: map each selected child link to its joint, apply instantly,
+  // persist in the background.  Root / unmatched links carry no joint -> skipped;
+  // joints already at `type` are no-ops and dropped.
+  const byChild = new Map([...rows.values()].map(r => [r.child, r]));
+  const changes = [];
+  for (const c of links) {
+    const rec = byChild.get(c);
+    if (rec && rec.joint.jointType !== type) {
+      changes.push({ name: rec.joint.name, parent: rec.parent,
+                     child: rec.child, type });
+    }
   }
+  clearBoxSelection();
+  if (!changes.length) { log(t('bulk.noneSelected'), 'wrn'); return; }
+  log(t('bulk.applying', { n: changes.length, type }));
+  applyTypeChanges(changes);          // instant + background persist (serialized)
 }
 bulkbarEl.querySelectorAll('button[data-bt]').forEach(b =>
   b.addEventListener('click', () => bulkSetType(b.dataset.bt)));
@@ -5885,6 +5994,9 @@ async function refreshHistory() {
 async function doHistory(which) {
   op(which);
   if (!currentInfo) { return; }
+  // a type flip persists its yaml+rebuild in the BACKGROUND; let it finish
+  // before undo/redo rebuilds, or the server runs two builds at once
+  await typePersistChain.catch(() => {});
   try {
     const resp = await fetch('/api/' + which, { method: 'POST' });
     const r = await resp.json();

--- a/tests/e2e/verify_bulk_types.mjs
+++ b/tests/e2e/verify_bulk_types.mjs
@@ -1,0 +1,93 @@
+// Verify MULTI-SELECT joint-type changes after the optimistic-update rework.
+//  A) sidebar checkboxes + #bulkset  -> goes through applyTypeChanges (instant)
+//  B) 3D box-select + bulkType()     -> bulkSetType (reload path, persist-guarded)
+import puppeteer from 'puppeteer-core';
+const URL = (process.argv[2] ?? 'http://localhost:8090') + '?lang=ja';
+const YAML = process.argv[3];
+const CHROME = process.env.CHROME_PATH
+  ?? 'C:/Program Files/Google/Chrome/Application/chrome.exe';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+let fail = 0;
+const check = (n, ok, d = '') => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${n}${d ? '  -- ' + d : ''}`); if (!ok) fail++; };
+
+const browser = await puppeteer.launch({
+  executablePath: CHROME, headless: 'new', args: ['--disable-gpu'] });
+const page = await browser.newPage();
+const errs = []; page.on('pageerror', e => errs.push(e.message.split('\n')[0]));
+await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+await page.waitForFunction(
+  () => [...document.querySelectorAll('#log div')]
+    .some(d => d.textContent.includes('カメラを調整しました')), { timeout: 60000 }).catch(() => {});
+await sleep(1500);
+
+const movct = () => page.evaluate(() => Object.values(
+  document.getElementById('viewer').robot.joints)
+  .filter(j => j.jointType !== 'fixed' && !j.mimicJoint).length);
+
+// ---- A) checkbox multi-select -> bulkset 'fixed' (optimistic path) ----------
+const a = await page.evaluate(() => {
+  const v = document.getElementById('viewer');
+  const robotBefore = v.robot;
+  const movBefore = Object.values(v.robot.joints)
+    .filter(j => j.jointType !== 'fixed' && !j.mimicJoint).length;
+  let picked = 0; const targets = [];
+  for (const row of document.querySelectorAll('.joint')) {
+    const sel = row.querySelector('.jtypesel');
+    if (sel && sel.value !== 'fixed') {
+      const pick = row.querySelector('.pick');
+      if (pick) {
+        pick.checked = true;
+        targets.push(row.querySelector('.jname').textContent.trim());
+        picked++;
+      }
+    }
+    if (picked >= 3) break;
+  }
+  document.getElementById('bulktype').value = 'fixed';
+  document.getElementById('bulkset').click();           // synchronous handler
+  const movAfter = Object.values(v.robot.joints)
+    .filter(j => j.jointType !== 'fixed' && !j.mimicJoint).length;
+  return { picked, movBefore, movAfter, same: v.robot === robotBefore, targets };
+});
+check('checkbox bulk->fixed: all picked joints flip synchronously',
+  a.picked === 3 && a.movAfter === a.movBefore - a.picked, JSON.stringify(a));
+check('checkbox bulk->fixed: NO full robot reload (same object)',
+  a.same === true, `same=${a.same}`);
+
+// persisted to yaml?
+if (YAML) {
+  const fs = await import('node:fs');
+  let ok = false;
+  for (let i = 0; i < 40; i++) {
+    await sleep(1000);
+    const txt = fs.readFileSync(YAML, 'utf-8');
+    ok = a.targets.every(c => new RegExp('child:\\s*' + c +
+      '\\s*\\n\\s*type:\\s*fixed').test(txt));
+    if (ok) break;
+  }
+  check('checkbox bulk->fixed: all 3 persisted to joints.yaml', ok,
+    a.targets.join(', '));
+}
+
+// ---- B) 3D box-select everything -> bulkType('fixed') (now optimistic too) --
+const bsel = await page.evaluate(() => {
+  const v = document.getElementById('viewer');
+  const robotBefore = v.robot;
+  const mv = () => Object.values(v.robot.joints)
+    .filter(j => j.jointType !== 'fixed' && !j.mimicJoint).length;
+  const movBefore = mv();
+  window.sw2robot.boxSelect();
+  window.sw2robot.bulkType('fixed');
+  return { movBefore, movAfter: mv(), same: v.robot === robotBefore };
+});
+check('box-select bulk->fixed: flips synchronously to 0 movable',
+  bsel.movAfter === 0, JSON.stringify(bsel));
+check('box-select bulk->fixed: NO full robot reload (same object)',
+  bsel.same === true, `same=${bsel.same}`);
+await sleep(8000);   // let the box-select background persist + rebuild settle
+
+check('no page errors during bulk type changes', errs.length === 0, errs.join(' | '));
+await browser.close();
+console.log(`\n${fail === 0 ? 'ALL PASSED' : fail + ' FAILED'}`);
+process.exit(fail === 0 ? 0 : 1);

--- a/tests/e2e/verify_shiftclick.mjs
+++ b/tests/e2e/verify_shiftclick.mjs
@@ -1,0 +1,102 @@
+// Verify Shift+click accumulates link selection into the same set + bulkbar as
+// a Shift+drag region box-select.
+import puppeteer from 'puppeteer-core';
+const URL = (process.argv[2] ?? 'http://localhost:8090') + '?lang=ja';
+const CHROME = process.env.CHROME_PATH
+  ?? 'C:/Program Files/Google/Chrome/Application/chrome.exe';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+let fail = 0;
+const check = (n, ok, d = '') => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${n}${d ? '  -- ' + d : ''}`); if (!ok) fail++; };
+
+const browser = await puppeteer.launch({
+  executablePath: CHROME, headless: 'new', args: ['--disable-gpu'] });
+const page = await browser.newPage();
+const errs = []; page.on('pageerror', e => errs.push(e.message.split('\n')[0]));
+await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+await page.waitForFunction(
+  () => [...document.querySelectorAll('#log div')]
+    .some(d => d.textContent.includes('カメラを調整しました')), { timeout: 60000 }).catch(() => {});
+await sleep(1500);
+
+const boxN = () => page.evaluate(() => window.sw2robot.boxSelected().length);
+const bulkbarShown = () => page.evaluate(() =>
+  getComputedStyle(document.getElementById('bulkbar')).display !== 'none');
+
+// project each link's own-mesh centroid to screen coords (camera matrices),
+// so we can fire real Shift+clicks at links.
+const points = await page.evaluate(() => {
+  const v = document.getElementById('viewer');
+  const r = v.getBoundingClientRect();
+  v.robot.updateMatrixWorld(true);
+  // grab THREE from the module scope via a known object: viewer.camera is a
+  // THREE.Camera; reuse its constructor's Vector3? Instead use project() helper.
+  const cam = v.camera;
+  const res = [];
+  for (const [name, link] of Object.entries(v.robot.links)) {
+    let cx = 0, cy = 0, cz = 0, k = 0;
+    link.traverse(o => {
+      if (o.isMesh && o.geometry) {
+        o.geometry.computeBoundingBox?.();
+        const bb = o.geometry.boundingBox; if (!bb) return;
+        const c = { x: (bb.min.x + bb.max.x) / 2, y: (bb.min.y + bb.max.y) / 2,
+                    z: (bb.min.z + bb.max.z) / 2 };
+        o.updateMatrixWorld(true);
+        const e = o.matrixWorld.elements;
+        const wx = e[0]*c.x + e[4]*c.y + e[8]*c.z + e[12];
+        const wy = e[1]*c.x + e[5]*c.y + e[9]*c.z + e[13];
+        const wz = e[2]*c.x + e[6]*c.y + e[10]*c.z + e[14];
+        cx += wx; cy += wy; cz += wz; k++;
+      }
+    });
+    if (!k) continue;
+    cx /= k; cy /= k; cz /= k;
+    // project with camera matrices
+    cam.updateMatrixWorld(true);
+    const vp = cam.projectionMatrix.clone().multiply(cam.matrixWorldInverse);
+    const m = vp.elements;
+    const px = m[0]*cx + m[4]*cy + m[8]*cz + m[12];
+    const py = m[1]*cx + m[5]*cy + m[9]*cz + m[13];
+    const pw = m[3]*cx + m[7]*cy + m[11]*cz + m[15];
+    if (pw <= 0) continue;
+    const ndcx = px / pw, ndcy = py / pw;
+    if (ndcx < -1 || ndcx > 1 || ndcy < -1 || ndcy > 1) continue;
+    res.push({ name,
+      x: r.left + (ndcx * 0.5 + 0.5) * r.width,
+      y: r.top + (-ndcy * 0.5 + 0.5) * r.height });
+  }
+  return res;
+});
+check('projected at least 3 on-screen links', points.length >= 3,
+  `got ${points.length}`);
+
+// pick 3 spread-out points
+points.sort((a, b) => a.x - b.x);
+const probes = [points[0], points[Math.floor(points.length / 2)], points[points.length - 1]];
+
+await page.keyboard.down('Shift');
+const sizes = [];
+for (const p of probes) {
+  await page.mouse.move(p.x, p.y);
+  await page.mouse.down(); await page.mouse.up();
+  await sleep(120);
+  sizes.push(await boxN());
+}
+check('shift+click accumulates selection (grows past 1)',
+  sizes[sizes.length - 1] >= 2, `sizes=${JSON.stringify(sizes)}`);
+check('bulkbar appears once links are shift-selected', await bulkbarShown(), '');
+
+// re-click the LAST probe point -> toggles that link back off (count drops)
+const beforeToggle = await boxN();
+await page.mouse.move(probes[probes.length - 1].x, probes[probes.length - 1].y);
+await page.mouse.down(); await page.mouse.up();
+await sleep(150);
+const afterToggle = await boxN();
+check('shift+click again toggles a link OFF',
+  afterToggle === beforeToggle - 1, `${beforeToggle} -> ${afterToggle}`);
+await page.keyboard.up('Shift');
+
+check('no page errors during shift-click selection', errs.length === 0, errs.join(' | '));
+await browser.close();
+console.log(`\n${fail === 0 ? 'ALL PASSED' : fail + ' FAILED'}`);
+process.exit(fail === 0 ? 0 : 1);

--- a/tests/e2e/verify_type_optimistic.mjs
+++ b/tests/e2e/verify_type_optimistic.mjs
@@ -1,0 +1,113 @@
+// Focused verification of the OPTIMISTIC joint-type change (no full reload).
+// Drives the real sidebar <select> and asserts the live model + UI reflect the
+// flip synchronously, that the 3D robot object is NOT reloaded, and that the
+// change still persists to joints.yaml in the background.
+import puppeteer from 'puppeteer-core';
+
+const URL = (process.argv[2] ?? 'http://localhost:8090') + '?lang=ja';
+const YAML = process.argv[3];   // path to joints.yaml on disk to verify persist
+const CHROME = process.env.CHROME_PATH
+  ?? 'C:/Program Files/Google/Chrome/Application/chrome.exe';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+let fail = 0;
+const check = (n, ok, d = '') => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${n}${d ? '  -- ' + d : ''}`);
+  if (!ok) fail++;
+};
+
+const browser = await puppeteer.launch({
+  executablePath: CHROME, headless: 'new', args: ['--disable-gpu'] });
+const page = await browser.newPage();
+const errs = [];
+page.on('pageerror', e => errs.push(e.message.split('\n')[0]));
+
+await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+await page.waitForFunction(
+  () => [...document.querySelectorAll('#log div')]
+    .some(d => d.textContent.includes('カメラを調整しました')),
+  { timeout: 60000 }).catch(() => {});
+await sleep(1500);
+
+// helper run in the page: flip a joint via its sidebar <select> and report the
+// SYNCHRONOUS post-dispatch state (proves "instant, no reload").
+const flip = (kind, toType) => page.evaluate((kind, toType) => {
+  const v = document.getElementById('viewer');
+  const joints = Object.values(v.robot.joints);
+  const childOf = j => [...(j.urdfNode?.children ?? [])]
+    .find(e => e.tagName === 'child')?.getAttribute('link') ?? '';
+  const want = kind === 'movable'
+    ? joints.find(j => j.jointType !== 'fixed' && !j.mimicJoint)
+    : joints.find(j => j.jointType === 'fixed');
+  if (!want) { return { err: 'no ' + kind + ' joint' }; }
+  const name = want.name, child = childOf(want);
+  // find the row <select> whose row names this child link
+  let sel = null;
+  for (const row of document.querySelectorAll('.joint')) {
+    const jn = row.querySelector('.jname');
+    if (jn && jn.textContent.trim() === child) {
+      sel = row.querySelector('.jtypesel'); break;
+    }
+  }
+  if (!sel) { return { err: 'no row select for ' + child }; }
+  const robotBefore = v.robot;
+  const movBefore = joints.filter(j => j.jointType !== 'fixed').length;
+  sel.value = toType;
+  sel.dispatchEvent(new Event('change', { bubbles: true }));
+  // read state SYNCHRONOUSLY right after the handler returned
+  const j2 = v.robot.joints[name];
+  const movAfter = Object.values(v.robot.joints)
+    .filter(j => j.jointType !== 'fixed').length;
+  return {
+    name, child, toType,
+    newType: j2.jointType,
+    sameRobot: v.robot === robotBefore,   // false => a full reload happened
+    movBefore, movAfter,
+    axis: j2.axis ? j2.axis.toArray() : null,
+  };
+}, kind, toType);
+
+// 1. movable -> fixed, instantly + no reload
+const a = await flip('movable', 'fixed');
+check('movable->fixed: type flips synchronously',
+  a.newType === 'fixed', JSON.stringify(a));
+check('movable->fixed: NO full robot reload (same object)',
+  a.sameRobot === true, `sameRobot=${a.sameRobot}`);
+check('movable->fixed: movable count drops instantly',
+  a.movAfter === a.movBefore - 1, `${a.movBefore}->${a.movAfter}`);
+const lockedName = a.name, lockedChild = a.child;
+
+// 2. fixed -> movable (revolute), instantly with a usable axis
+const b = await flip('fixed', 'revolute');
+check('fixed->revolute: type flips synchronously',
+  b.newType === 'revolute', JSON.stringify(b));
+check('fixed->revolute: NO full robot reload (same object)',
+  b.sameRobot === true, `sameRobot=${b.sameRobot}`);
+const axLen = b.axis ? Math.hypot(...b.axis) : 0;
+check('fixed->revolute: joint has a unit-length axis',
+  b.axis && axLen > 0.9 && axLen < 1.1, `axis=${JSON.stringify(b.axis)} |a|=${axLen.toFixed(3)}`);
+
+// 3. background persist reaches joints.yaml (poll the file)
+let persisted = false;
+if (YAML) {
+  const fs = await import('node:fs');
+  for (let i = 0; i < 40; i++) {
+    await sleep(1000);
+    const txt = fs.readFileSync(YAML, 'utf-8');
+    // the joint we locked (child=lockedChild) should now read type: fixed,
+    // and the joint we unfixed (child=b.child) should read type: revolute
+    const lockOk = new RegExp('child:\\s*' + lockedChild +
+      '\\s*\\n\\s*type:\\s*fixed').test(txt);
+    const moveOk = new RegExp('child:\\s*' + b.child +
+      '\\s*\\n\\s*type:\\s*revolute').test(txt);
+    if (lockOk && moveOk) { persisted = true; break; }
+  }
+  check('background persist: joints.yaml shows both new types', persisted,
+    `lockedChild=${lockedChild} unfixedChild=${b.child}`);
+}
+
+// 4. the page never threw
+check('no page errors during type flips', errs.length === 0, errs.join(' | '));
+
+await browser.close();
+console.log(`\n${fail === 0 ? 'ALL PASSED' : fail + ' FAILED'}`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## 概要

エディタで関節タイプ（fixed ↔ revolute/continuous/prismatic）を変更したとき、反映までのラグをなくしました。あわせて Shift+クリックでの複数リンク選択を追加します。

## 1. タイプ変更の即時反映

これまでタイプ変更は毎回「サーバで URDF 全再生成（`build()`）→ 3D モデルを丸ごと再ロード（全メッシュ再パース）」を**同期的に直列で**待っており、これがラグの原因でした。

fixed ↔ 可動の切替は**トポロジーを一切変えない**（リンク・関節名・木構造は同一で、`type` 属性と `<axis>`/`<limit>` の有無だけが変わる）ため、

- ライブの urdf-loader 関節を**その場で書き換え**、サイドバー／軸マーカー／パネルだけ再描画（メッシュ再パースなし）→ 体感ゼロ遅延
- yaml 保存＋URDF 再ビルドは**バックグラウンド**で実行

un-fix（fixed→可動）時の軸は `axisMemory`（可動時に記憶）か、エクスポータが fixed 関節にも書き出すゴースト `<axis>` から復元します。

対象経路：サイドバーのドロップダウン／パネル／`t` キー／チェックボックス一括／3D ボックス選択一括（すべて即時化）。

### 競合対策
エディタサーバはスレッド型（`ThreadingTCPServer`）なので、バックグラウンド保存を `typePersistChain` で直列化し、undo/redo は保留中の保存完了を待ってから再ビルドします。

## 2. Shift+クリックで追加選択

Shift+クリック（ドラッグなし）で、クリックしたリンクが領域選択（Shift+ドラッグ）と同じ選択集合・bulkbar にトグルで貯まります。1 個ずつクリックして複数選択を作り、そのまま一括でタイプ変更できます。

## テスト

standalone な e2e チェックを追加（実機 Chrome + 実サーバ、すべて PASS）:

- `tests/e2e/verify_type_optimistic.mjs` — 単体変更の同期反映・非リロード・軸復元・保存
- `tests/e2e/verify_bulk_types.mjs` — チェックボックス／ボックス選択の一括が即時
- `tests/e2e/verify_shiftclick.mjs` — Shift+クリックの蓄積・トグル・bulkbar