### PR TITLE
fix dependency about trimesh

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ license-files = ["LICENSE"]
 authors = [{ name = "Iori Yanokura", email = "ab.ioryz@gmail.com" }]
 dependencies = [
     "numpy>=2",
-    "trimesh>=3.9",
-    "networkx>=3",
+    "trimesh[easy]>=3.9",
+    "scipy>=1.11",
     "lxml",
     "pydantic>=2",
     "pyyaml>=6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ authors = [{ name = "Iori Yanokura", email = "ab.ioryz@gmail.com" }]
 dependencies = [
     "numpy>=2",
     "trimesh>=3.9",
+    "networkx>=3",
     "lxml",
     "pydantic>=2",
     "pyyaml>=6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ authors = [{ name = "Iori Yanokura", email = "ab.ioryz@gmail.com" }]
 dependencies = [
     "numpy>=2",
     "trimesh[easy]>=3.9",
-    "scipy>=1.11",
     "lxml",
     "pydantic>=2",
     "pyyaml>=6",


### PR DESCRIPTION
I installed 0.2.6 on windows(amd64) in venv env with `pip install -e .`
When I run `sw2robot-web` and load my quadrotor, I encountered errors due to lack of at least following dependency.
- networkx
- scipy
<img width="2559" height="1599" alt="スクリーンショット 2026-06-25 204754" src="https://github.com/user-attachments/assets/59a908c2-c7db-4e32-9ea9-52fe155f572d" />
Is this correct with this install method? (without ".[ui]" option)

I fixed trimesh install version to `trimesh[easy]` to resolve these dependency. 
Afterwards, robot is correctly visualized. 
<img width="2560" height="1552" alt="gimbal_quadrotor_vanilla — sw2robot - Google Chrome 2026_06_25 21_25_06" src="https://github.com/user-attachments/assets/ee9c6e8d-3b29-4d55-96e1-7061299cbb71" />



