### PR TITLE
feat: make the package-relative mesh directory configurable

### DIFF
--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -664,6 +664,17 @@ Leave empty to match the package name (e.g. bambulab_description.urdf)."
                       border:1px solid #2d4a35;border-radius:3px;padding:2px 5px;
                       font-size:11px" placeholder="robot_description">
       </div>
+      <div style="display:flex;gap:4px;align-items:center;margin-bottom:4px">
+        <span style="color:#8a93a3;min-width:54px" data-i18n="ui.expmeshdir">mesh dir</span>
+        <input id="expmeshdir" type="text" spellcheck="false"
+               data-i18n-title="t.expmeshdir"
+               title="package-relative directory the meshes go in, and that the
+URDF's package:// refs point at (default 'meshes'). Set it to match a robot whose
+mesh layout differs, e.g. 'urdf/mesh'. A '/' makes subdirectories."
+               style="flex:1;min-width:0;background:#15171a;color:#cfe3ff;
+                      border:1px solid #2d4a35;border-radius:3px;padding:2px 5px;
+                      font-size:11px" placeholder="meshes">
+      </div>
       <div style="display:flex;gap:6px;align-items:center;margin-bottom:4px;flex-wrap:wrap">
         <label style="display:flex;gap:4px;align-items:center;color:#8a93a3;cursor:pointer"
                data-i18n-title="t.coacd"
@@ -1289,6 +1300,9 @@ skrobot / native-mesh consumers (not RViz-loadable)">⬇ glb</button></a>
     'ui.expurdfname': { en: 'URDF', ja: 'URDF名' },
     't.expurdfname': { en: 'file name (stem) of the URDF inside the package. Leave empty to match the package name (e.g. bambulab_description.urdf).',
                        ja: 'パッケージ内 URDF のファイル名（拡張子なし）。空欄ならパッケージ名と同じ（例: bambulab_description.urdf）。' },
+    'ui.expmeshdir': { en: 'mesh dir', ja: 'メッシュ' },
+    't.expmeshdir': { en: "package-relative directory the meshes go in, and that the URDF's package:// refs point at (default 'meshes'). Set it to match a robot whose mesh layout differs, e.g. 'urdf/mesh'. A '/' makes subdirectories.",
+                      ja: 'メッシュを置くパッケージ相対ディレクトリ。URDF の package:// 参照もここを指します（既定: meshes）。メッシュ配置がロボットによって異なる場合に設定（例: urdf/mesh）。/ でサブディレクトリ。' },
     't.expdae': { en: 'portable ROS 1 (catkin) package (<name>_description): package:// URLs, visual = colour COLLADA .dae, collision = .stl (loads in RViz/Gazebo)',
                   ja: 'ポータブルな ROS 1 (catkin) パッケージ (<name>_description): package:// URL、visual = カラー COLLADA .dae、collision = .stl（RViz/Gazebo で読込可）' },
     'ui.expdae': { en: '⬇ ROS1 package', ja: '⬇ ROS1 パッケージ' },
@@ -4116,6 +4130,7 @@ autolimitsBtn.addEventListener('click', async () => {
 // them.  Empty URDF name -> the URDF inside is named after the package.
 const exppkg = document.getElementById('exppkg');
 const expurdf = document.getElementById('expurdf');
+const expmeshdir = document.getElementById('expmeshdir');
 const expLinks = ['expdae', 'expros2', 'expglb']
   .map(id => document.getElementById(id)).filter(Boolean);
 function exportDefaultName() {
@@ -4147,6 +4162,13 @@ expurdf?.addEventListener('input', () => {
   const clean = expurdf.value
     .replace(/[^A-Za-z0-9_.-]/g, '_').replace(/^[^A-Za-z0-9]+/, '');
   if (expurdf.value !== clean) { expurdf.value = clean; }
+});
+// the mesh dir is a package-relative path: letters/digits/_/-/. segments joined
+// by '/'; drop other chars and any leading slash (must stay inside the package)
+expmeshdir?.addEventListener('input', () => {
+  const clean = expmeshdir.value
+    .replace(/[^A-Za-z0-9_./-]/g, '_').replace(/^\/+/, '');
+  if (expmeshdir.value !== clean) { expmeshdir.value = clean; }
 });
 // building a ROS package converts every mesh (3dxml -> dae/stl) and can take a
 // few seconds, during which a plain <a download> gives NO feedback.  Drive it
@@ -4366,15 +4388,18 @@ mergeViewBtn?.addEventListener('click', () => {
 });
 expLinks.forEach(a => a.addEventListener('click', async ev => {
   ev.preventDefault();
-  const base = a.getAttribute('href').split('&name=')[0].split('&urdf=')[0];
+  const base = a.getAttribute('href')
+    .split('&name=')[0].split('&urdf=')[0].split('&meshdir=')[0];
   const name = (exppkg?.value || '').trim();
   const urdf = (expurdf?.value || '').trim();
+  const meshdir = (expmeshdir?.value || '').trim().replace(/^\/+|\/+$/g, '');
   // coacd + merge-fixed apply to the ROS (.dae) packages, not the uniform glb
   const coacd = a.id !== 'expglb' && !!coacdBox?.checked;
   const mergeFixed = a.id !== 'expglb' && !!mergeFixedBox?.checked;
   const url = base
     + (name ? `&name=${encodeURIComponent(name)}` : '')
     + (urdf ? `&urdf=${encodeURIComponent(urdf)}` : '')
+    + (meshdir ? `&meshdir=${encodeURIComponent(meshdir)}` : '')
     + (coacd ? `&collision=coacd&cquality=${cqualitySel?.value || 'balanced'}` : '')
     + (mergeFixed ? '&mergefixed=1' : '');
   const what = a.id === 'expglb' ? 'glb'

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -517,7 +517,7 @@ def _read_root_pose(txt):
 def _export_zip(pkg_dir, robot_name, mesh_fmt="dae", ros_version=1,
                 pkg_name=None, urdf_name=None, colors=None,
                 collision="copy", collision_quality="balanced",
-                merge_fixed=False):
+                merge_fixed=False, mesh_dir=None):
     """ZIP a portable ROS package (package:// URLs), named ``pkg_name`` if given
     else ``<robot_name>_description``; the URDF inside is named ``urdf_name`` if
     given, else the package name.
@@ -553,6 +553,7 @@ def _export_zip(pkg_dir, robot_name, mesh_fmt="dae", ros_version=1,
                                                collision=collision,
                                                collision_quality=collision_quality,
                                                merge_fixed=merge_fixed,
+                                               mesh_dir=mesh_dir,
                                                **kwargs):
             z.writestr(arc, data)
     return pkg, buf.getvalue()
@@ -1956,6 +1957,7 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 merge_fixed = (query.get("mergefixed") or ["0"])[0] == "1"
                 pkg_name = (query.get("name") or [""])[0].strip() or None
                 urdf_name = (query.get("urdf") or [""])[0].strip() or None
+                mesh_dir = (query.get("meshdir") or [""])[0].strip() or None
                 # the ROS exporter hardcodes the urdf/<robot_name>.urdf + meshes/
                 # layout; in URDF-input mode the opened file may sit elsewhere, so
                 # fail clearly instead of with a confusing missing-file 500
@@ -1981,7 +1983,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                                                 colors=colors,
                                                 collision=collision,
                                                 collision_quality=cquality,
-                                                merge_fixed=merge_fixed)
+                                                merge_fixed=merge_fixed,
+                                                mesh_dir=mesh_dir)
                 except ValueError as e:
                     return self._send_json({"error": str(e)}, 400)
                 fname = (f"{cls.robot_name}_glb.zip" if fmt == "glb"

--- a/sw2robot/exporter/build.py
+++ b/sw2robot/exporter/build.py
@@ -24,12 +24,15 @@ def main():
                          "<name>_description); lowercase letters/digits/_ only")
     ap.add_argument("--ros-urdf-name", default=None,
                     help="stem for the URDF inside --ros-pkg (default: pkg name)")
+    ap.add_argument("--ros-mesh-dir", default=None,
+                    help="package-relative mesh directory for --ros-pkg "
+                         "(default: 'meshes'); e.g. 'urdf/mesh'")
     args = ap.parse_args()
     exclude = [x.strip() for x in args.exclude.split(",")] if args.exclude else None
     build(args.pkg_dir, config_path=args.config, base_hint=args.base,
           exclude=exclude, ros_pkg=args.ros_pkg or args.ros2,
           ros_version=2 if args.ros2 else 1, ros_pkg_name=args.ros_pkg_name,
-          ros_urdf_name=args.ros_urdf_name)
+          ros_urdf_name=args.ros_urdf_name, ros_mesh_dir=args.ros_mesh_dir)
 
 
 if __name__ == "__main__":

--- a/sw2robot/exporter/export.py
+++ b/sw2robot/exporter/export.py
@@ -160,7 +160,7 @@ def extract(assembly_path, out_dir=None, robot_name=None, visible=False,
 def build(pkg_dir, config_path=None, base_hint=None, exclude=None,
           ros_pkg=False, density=None, ros_version=1, ros_pkg_name=None,
           ros_urdf_name=None, collision="copy", collision_quality="balanced",
-          merge_fixed=False):
+          merge_fixed=False, ros_mesh_dir=None):
     _tolerant_console()
     graph = GraphState.load(os.path.join(pkg_dir, GRAPH_FILE))
     robot_name = graph.robot_name
@@ -203,7 +203,7 @@ def build(pkg_dir, config_path=None, base_hint=None, exclude=None,
             ros_version=ros_version, pkg_name=ros_pkg_name,
             urdf_name=ros_urdf_name, colors=colors,
             collision=collision, collision_quality=collision_quality,
-            merge_fixed=merge_fixed)
+            merge_fixed=merge_fixed, mesh_dir=ros_mesh_dir)
 
     print(f"\nDONE. Package: {pkg_dir}")
     print(f"  URDF:   {urdf_path}")
@@ -220,13 +220,14 @@ def build(pkg_dir, config_path=None, base_hint=None, exclude=None,
 def export(assembly_path, out_dir=None, robot_name=None, visible=False,
            config_path=None, base_hint=None, exclude=None, ros_pkg=False,
            ros_version=1, ros_pkg_name=None, ros_urdf_name=None,
-           collision="copy", collision_quality="balanced", merge_fixed=False):
+           collision="copy", collision_quality="balanced", merge_fixed=False,
+           ros_mesh_dir=None):
     pkg_dir = extract(assembly_path, out_dir, robot_name, visible)
     return build(pkg_dir, config_path=config_path, base_hint=base_hint,
                  exclude=exclude, ros_pkg=ros_pkg, ros_version=ros_version,
                  ros_pkg_name=ros_pkg_name, ros_urdf_name=ros_urdf_name,
                  collision=collision, collision_quality=collision_quality,
-                 merge_fixed=merge_fixed)
+                 merge_fixed=merge_fixed, ros_mesh_dir=ros_mesh_dir)
 
 
 def _exclude_list(s):
@@ -257,6 +258,10 @@ def main():
     ap.add_argument("--ros-urdf-name", default=None,
                     help="stem for the URDF file inside the --ros-pkg package "
                          "(default: the package name)")
+    ap.add_argument("--ros-mesh-dir", default=None,
+                    help="package-relative directory the --ros-pkg meshes go in "
+                         "and that the URDF's package:// refs point at (default: "
+                         "'meshes'); e.g. 'urdf/mesh' for a different layout")
     ap.add_argument("--collision", choices=("copy", "coacd"), default="copy",
                     help="--ros-pkg <collision> geometry: 'copy' (default) "
                          "reuses the visual mesh as one STL; 'coacd' runs "
@@ -279,7 +284,7 @@ def main():
            ros_version=2 if args.ros2 else 1,
            ros_pkg_name=args.ros_pkg_name, ros_urdf_name=args.ros_urdf_name,
            collision=args.collision, collision_quality=args.collision_quality,
-           merge_fixed=args.merge_fixed)
+           merge_fixed=args.merge_fixed, ros_mesh_dir=args.ros_mesh_dir)
 
 
 if __name__ == "__main__":

--- a/sw2robot/exporter/ros_export.py
+++ b/sw2robot/exporter/ros_export.py
@@ -575,15 +575,45 @@ def ros_urdf_stem(pkg, urdf_name=None):
     return stem
 
 
+def ros_mesh_dir(mesh_dir=None):
+    """The package-relative directory the exported meshes go in (and that the
+    URDF's ``package://<pkg>/...`` refs point at): an explicit ``mesh_dir`` or the
+    default ``meshes``.
+
+    The relative path from the package root to the meshes differs between robots
+    (``meshes``, ``urdf/mesh``, ...), so it is settable.  A leading/trailing slash
+    is trimmed and back-slashes are accepted as separators; the path must stay
+    inside the package -- no absolute path and no ``..`` segment -- and each
+    segment may use only letters, digits, ``_``, ``-`` and ``.``."""
+    if not mesh_dir or not mesh_dir.strip():
+        return "meshes"
+    raw = mesh_dir.strip().replace("\\", "/").strip("/")
+    parts = raw.split("/") if raw else []
+    if not parts or any(
+            p in ("", ".", "..") or not re.fullmatch(r"[A-Za-z0-9_.-]+", p)
+            for p in parts):
+        raise ValueError(
+            f"invalid mesh directory {mesh_dir!r}: use a package-relative path "
+            "of letters, digits, '_', '-', '.' separated by '/' (e.g. 'meshes' "
+            "or 'urdf/mesh')")
+    return "/".join(parts)
+
+
 def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
                           ctx_fmt=_CTX_FMT, ros_version=1, pkg_name=None,
                           urdf_name=None, colors=None, collision="copy",
-                          collision_quality="balanced", merge_fixed=False):
+                          collision_quality="balanced", merge_fixed=False,
+                          mesh_dir=None):
     """``pkg_dir`` (a built package) -> ``[(arcname, bytes), ...]`` for a portable
     ROS package, all behind ``package://`` URLs.  The package is named
     ``pkg_name`` if given (validated, see :func:`ros_pkg_name`), else
     ``<robot_name>_description``.  The URDF inside is named ``urdf_name`` if
     given, else the package name (so ``<pkg>/urdf/<pkg>.urdf`` by default).
+
+    ``mesh_dir`` is the package-relative directory the meshes go in and that the
+    URDF's ``package://<pkg>/...`` refs point at (validated, see
+    :func:`ros_mesh_dir`); it defaults to ``meshes`` but may be set to match a
+    robot whose mesh layout differs (e.g. ``urdf/mesh``).
 
     ``ctx_fmt`` maps each URDF context to a mesh format; the default emits
     ``<visual>`` as colour ``.dae`` and ``<collision>`` as plain ``.stl`` (the
@@ -628,6 +658,7 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
     coacd_cache_dir = os.path.join(pkg_dir, "meshes", ".coacd_cache")
     pkg = ros_pkg_name(robot_name, pkg_name)
     urdf_stem = ros_urdf_stem(pkg, urdf_name)
+    mesh_rel = ros_mesh_dir(mesh_dir)
     # the opened package's own name(s) -- only package:// refs to one of these
     # are vendored/repointed; refs to other ROS packages are left untouched
     own_pkgs = _own_pkg_names(pkg_dir)
@@ -676,7 +707,7 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
                     dae_dir = os.path.dirname(src)
                     for rel in _dae_sidecar_images(src):
                         img = os.path.normpath(os.path.join(dae_dir, rel))
-                        arc = f"{pkg}/meshes/{rel}"
+                        arc = f"{pkg}/{mesh_rel}/{rel}"
                         if os.path.exists(img) and arc not in used_names:
                             with open(img, "rb") as f:
                                 files.append((arc, f.read()))
@@ -687,7 +718,7 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
             errors.append(f"{base}: {fmt} convert failed ({e!r})")
             return None
         used_names.add(name)
-        files.append((f"{pkg}/meshes/{name}", data))
+        files.append((f"{pkg}/{mesh_rel}/{name}", data))
         done[key] = name
         return name
 
@@ -711,7 +742,7 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
                 j += 1
                 name = f"{base}_collision_{i}_{j}.stl"
             used_names.add(name)
-            files.append((f"{pkg}/meshes/{name}", data))
+            files.append((f"{pkg}/{mesh_rel}/{name}", data))
             names.append(name)
         done[key] = names
         return names
@@ -741,7 +772,7 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
             for k, name in enumerate(names):
                 nb = copy.deepcopy(block)
                 next(nb.iter("mesh")).set(
-                    "filename", f"package://{pkg}/meshes/{name}")
+                    "filename", f"package://{pkg}/{mesh_rel}/{name}")
                 link.insert(idx + k, nb)
 
     for link in root.findall("link"):
@@ -764,7 +795,8 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
                         continue
                     name = _emit(base, src, fmt, link_color or colors.get(base))
                     if name is not None:
-                        mesh.set("filename", f"package://{pkg}/meshes/{name}")
+                        mesh.set("filename",
+                                 f"package://{pkg}/{mesh_rel}/{name}")
 
     if errors:
         raise RuntimeError("ROS description export failed: " + "; ".join(errors))
@@ -803,21 +835,22 @@ def write_ros_description_package(pkg_dir, robot_name, dest_dir,
                                   pkg_name=None, urdf_name=None, colors=None,
                                   collision="copy",
                                   collision_quality="balanced",
-                                  merge_fixed=False):
+                                  merge_fixed=False, mesh_dir=None):
     """Write the ROS package under ``dest_dir`` and return its directory path.
     The package is named ``pkg_name`` if given, else ``<robot_name>_description``;
     the URDF inside is named ``urdf_name`` if given, else the package name.
     ``ros_version`` (1 = catkin, 2 = ament_cmake), ``colors`` (per-link colour
     overrides), ``collision`` / ``collision_quality`` (CoACD collision-mesh
-    decomposition) and ``merge_fixed`` (lump fixed-joint children into parents)
-    are passed through to :func:`build_ros_description`."""
+    decomposition), ``merge_fixed`` (lump fixed-joint children into parents) and
+    ``mesh_dir`` (package-relative mesh directory, default ``meshes``) are passed
+    through to :func:`build_ros_description`."""
     pkg = ros_pkg_name(robot_name, pkg_name)
     files = build_ros_description(pkg_dir, robot_name, email=email,
                                   ros_version=ros_version, pkg_name=pkg,
                                   urdf_name=urdf_name, colors=colors,
                                   collision=collision,
                                   collision_quality=collision_quality,
-                                  merge_fixed=merge_fixed)
+                                  merge_fixed=merge_fixed, mesh_dir=mesh_dir)
     root = os.path.abspath(dest_dir)
     for arc, data in files:
         dst = os.path.join(root, *arc.split("/"))

--- a/tests/test_ros_export.py
+++ b/tests/test_ros_export.py
@@ -188,6 +188,46 @@ def test_build_ros_description_layout(tmp_path):
             assert len(m.faces) > 0
 
 
+def test_build_ros_description_custom_mesh_dir(tmp_path):
+    """``mesh_dir`` moves the emitted meshes (and repoints the URDF's
+    package:// refs) to a custom package-relative directory."""
+    import xml.etree.ElementTree as ET
+
+    from sw2robot.exporter.ros_export import build_ros_description
+
+    pkg_dir = _make_pkg(tmp_path, robot="fing")
+    files = dict(build_ros_description(pkg_dir, "fing", mesh_dir="urdf/mesh"))
+    arcs = set(files)
+
+    # meshes ship under the custom dir, NOT the default meshes/
+    assert "fing_description/urdf/mesh/part.dae" in arcs
+    assert "fing_description/urdf/mesh/part.stl" in arcs
+    assert not any(a.startswith("fing_description/meshes/") for a in arcs)
+
+    urdf = files["fing_description/urdf/fing_description.urdf"].decode()
+    link = ET.fromstring(urdf).find("link")
+    assert (link.find("visual").find(".//mesh").get("filename")
+            == "package://fing_description/urdf/mesh/part.dae")
+    assert (link.find("collision").find(".//mesh").get("filename")
+            == "package://fing_description/urdf/mesh/part.stl")
+
+
+def test_ros_mesh_dir_default_and_validation():
+    from sw2robot.exporter.ros_export import ros_mesh_dir
+
+    # default + blank fall back to 'meshes'
+    assert ros_mesh_dir() == "meshes"
+    assert ros_mesh_dir("") == "meshes"
+    assert ros_mesh_dir("   ") == "meshes"
+    # trims surrounding slashes, normalises back-slashes, keeps subdirs
+    assert ros_mesh_dir("/urdf/mesh/") == "urdf/mesh"
+    assert ros_mesh_dir("urdf\\mesh") == "urdf/mesh"
+    # an escaping / absolute / malformed path is rejected
+    for bad in ("../evil", "urdf/../mesh", "a//b", "me sh", "/", ".."):
+        with pytest.raises(ValueError):
+            ros_mesh_dir(bad)
+
+
 def test_build_ros2_description_layout(tmp_path):
     """ros_version=2 emits an ament_cmake manifest + launch + rviz, on top of
     the same package:// URDF and converted meshes."""


### PR DESCRIPTION
## What

The relative path from the package root to the meshes differs between robots
(`meshes`, `urdf/mesh`, ...), so make it settable instead of hardcoding `meshes/`.

For example these two robots place their meshes differently:
- `gimbalrotor.urdf.xacro` -> `urdf/mesh/...`
- `mini_quadrotor/robot.urdf.xacro` -> `meshes/...`

## How

- Add `ros_mesh_dir()` which validates a package-relative path (default `meshes`):
  trims surrounding slashes, normalises back-slashes, and rejects absolute / `..`
  escaping / malformed paths.
- Thread a `mesh_dir` argument through `build_ros_description` /
  `write_ros_description_package`; it now drives both the emitted mesh arc paths
  and the URDF `package://<pkg>/<mesh_dir>/<name>` references (dae / stl / glb /
  CoACD parts / `.dae` sidecar textures alike).
- Expose it everywhere the package/URDF name already is:
  - editor export panel: a **mesh dir** field (`&meshdir=`)
  - `/api/export/zip`: a `meshdir` query param
  - CLI: `--ros-mesh-dir` on both `export` and `build`

The default (`meshes`) is unchanged, so existing behaviour is identical.

## Test

- New tests: custom `mesh_dir` layout + URDF ref rewrite, and `ros_mesh_dir`
  default / validation cases.
- `test_ros_export.py`, `test_urdf_mode_webserver.py`, `test_sanitize_names.py`:
  65 passed, 2 skipped.
