### PR TITLE
feat: auto-couple closed-loop (four-bar) linkages as mimic joints

### DIFF
--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -729,6 +729,15 @@ package:// URLs, .dae/.stl meshes, plus launch/display.launch.py + rviz config
           <button data-i18n-title="t.expglb" title="uniform .glb meshes (colour kept) for three.js /
 skrobot / native-mesh consumers (not RViz-loadable)">⬇ glb</button></a>
       </div>
+      <div style="display:flex;gap:4px;flex-wrap:wrap;align-items:center;margin-top:4px">
+        <button id="redetectmimic" data-i18n="ui.redetectmimic"
+                data-i18n-title="t.redetectmimic"
+                title="Re-run the automatic closed-loop (four-bar) detection on the
+cached CAD graph and merge the resulting mimic couplings into this package's
+joints.yaml -- keeping your types/renames/base. Use it to pick up the couplings
+on a package that was extracted before the feature existed (a re-extract reuses
+the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect mimic</button>
+      </div>
     </div>
     <div id="hint" data-i18n="ui.hint">left-drag: 視点回転 · right-drag: pan · wheel: zoom ·
       クリックでリンク選択 · 関節はパネルのスライダーで操作
@@ -1244,6 +1253,13 @@ skrobot / native-mesh consumers (not RViz-loadable)">⬇ glb</button></a>
                       ja: '最近のファイル・フルパス貼り付け・右の 🗄' },
     't.selexclude': { en: 'exclude from the URDF (adds to yaml exclude:, Ctrl+Z to undo)',
                       ja: 'URDFから除外する (yaml exclude: に追加、Ctrl+Zで戻る)' },
+    'ui.redetectmimic': { en: '🔗 re-detect mimic', ja: '🔗 mimic再検出' },
+    't.redetectmimic': { en: 'auto-detect closed-loop (four-bar) couplings from the CAD graph and merge them into joints.yaml (keeps your edits)',
+                         ja: 'CADグラフから閉ループ(四節)のmimicを自動検出し、joints.yamlにマージ（編集は保持）' },
+    'redetect.start': { en: 're-detecting closed-loop couplings …', ja: '閉ループmimicを再検出中 …' },
+    'redetect.ok': { en: a => `mimic re-detected ✓ — ${a.n} follower(s) coupled`, ja: a => `mimic再検出 ✓ — ${a.n} 件を連結` },
+    'redetect.none': { en: 'no closed-loop (four-bar) coupling found', ja: '閉ループ(四節)mimicは見つかりませんでした' },
+    'redetect.fail': { en: a => `re-detect failed: ${a.e}`, ja: a => `mimic再検出に失敗: ${a.e}` },
     'ui.selroot': { en: '⌂ make root', ja: '⌂ ルート化' },
     'ui.bulkArrow': { en: '→ bulk set:', ja: '→ 一括設定:' },
     'ui.btFixed': { en: 'fixed', ja: '固定' },
@@ -4545,6 +4561,24 @@ async function reRoot(link) {
     log(t('reroot.fail', { e: e.message ?? e }), 'err');
   }
 }
+
+async function redetectMimic() {
+  if (!currentInfo) { log(t('reroot.needPkg'), 'wrn'); return; }
+  log(t('redetect.start'));
+  try {
+    const resp = await fetch('/api/redetect_couplings', { method: 'POST' });
+    const r = await resp.json();
+    if (!resp.ok || r.error) { throw new Error(r.error ?? resp.status); }
+    if (!r.applied || !r.applied.length) { log(t('redetect.none'), 'wrn'); return; }
+    log(t('redetect.ok', { n: r.applied.length }), 'ok');
+    loadRobot(currentInfo, { keepPose: true, followCamera: true });
+    refreshHistory();
+  } catch (e) {
+    log(t('redetect.fail', { e: e.message ?? e }), 'err');
+  }
+}
+document.getElementById('redetectmimic')
+  ?.addEventListener('click', redetectMimic);
 
 // ---- 3D hover: name the link under the cursor, R = make it root,
 // double-click = jump to its row in the tree -------------------------------

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -555,7 +555,16 @@ def _export_zip(pkg_dir, robot_name, mesh_fmt="dae", ros_version=1,
                                                merge_fixed=merge_fixed,
                                                mesh_dir=mesh_dir,
                                                **kwargs):
-            z.writestr(arc, data)
+            # a node under scripts/ must extract executable (0755) so ament's
+            # install(PROGRAMS) + `colcon build --symlink-install` leaves a
+            # runnable libexec entry that `ros2 launch` can find
+            if "/scripts/" in arc and arc.endswith(".py"):
+                zi = zipfile.ZipInfo(arc)
+                zi.external_attr = 0o755 << 16
+                zi.compress_type = zipfile.ZIP_DEFLATED
+                z.writestr(zi, data)
+            else:
+                z.writestr(arc, data)
     return pkg, buf.getvalue()
 
 
@@ -657,7 +666,7 @@ def _remove_yaml_block(txt, mapkey):
                   txt)
 
 
-def _set_mimic_yaml(txt, child, master, multiplier, offset, clear):
+def _set_mimic_yaml(txt, child, master, multiplier, offset, clear, poly=None):
     """Add / replace / remove the ``mimic:`` block of the joints.yaml entry whose
     ``child:`` is the component ``child``.  ``master`` is the driver joint's URDF
     name (stored verbatim -- urdf_writer's name remap is the identity on an
@@ -712,6 +721,9 @@ def _set_mimic_yaml(txt, child, master, multiplier, offset, clear):
                      f"{key_ind}  joint: {master}",
                      f"{key_ind}  multiplier: {float(multiplier):g}",
                      f"{key_ind}  offset: {float(offset):g}"]
+            if poly:
+                pj = ", ".join(repr(float(x)) for x in poly)
+                block.append(f"{key_ind}  poly: [{pj}]")
             ti = next((i for i, x in enumerate(cleaned)
                        if re.match(r"^\s*type:", x)), len(cleaned) - 1)
             cleaned = cleaned[:ti + 1] + block + cleaned[ti + 1:]
@@ -2279,6 +2291,82 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 return self._send_json(
                     {"applied": [c.get("child") for c in applied],
                      "missed": [c.get("child") for c in missed]})
+            if parsed.path == "/api/redetect_couplings":
+                # Re-run the AUTO closed-loop (four-bar) detection on the cached
+                # CAD graph and MERGE the resulting <mimic> couplings into the
+                # existing joints.yaml -- keeping the user's types/renames/base/
+                # limits.  A re-extract reuses the config (directed path) and so
+                # never re-detects; this is the non-destructive way to pick the
+                # couplings up on a package built before the feature existed.
+                cls = type(self)
+                if not cls.pkg_dir:
+                    return self._send_json({"error": "no package open"}, 400)
+                if not _cad_mode(cls.pkg_dir):
+                    return self._send_json(
+                        {"error": "re-detect needs the CAD graph.json "
+                                  "(re-extract this package once)"}, 400)
+                name = os.path.splitext(os.path.basename(cls.urdf_rel))[0]
+                yml = os.path.join(cls.pkg_dir, name + ".joints.yaml")
+                gj = os.path.join(cls.pkg_dir, "graph.json")
+                if not (os.path.exists(yml) and os.path.exists(gj)):
+                    return self._send_json(
+                        {"error": "joints.yaml / graph.json missing -- "
+                                  "re-extract this package once"}, 400)
+                import yaml as _yaml
+
+                from sw2robot.exporter import model as _M
+                from sw2robot.exporter.state import GraphState
+                with open(yml, encoding="utf-8") as f:
+                    txt = f.read()
+                cfg = _yaml.safe_load(txt) or {}
+                # detect on the AUTO tree, but rooted at the user's chosen base
+                # so the joint names line up with their config
+                graph = GraphState.load(gj)
+                comps, adjacency, _gnd = _M.from_graph(
+                    graph, exclude=list(cfg.get("exclude") or []),
+                    expand=cfg.get("expand"), no_expand=cfg.get("no_expand"))
+                base = _M.choose_base(comps, _gnd, cfg.get("base"), adjacency)
+                joints = _M.build_tree(comps, adjacency, base)
+                by_name = {j.name: j for j in joints}
+                applied, missed, drivers = [], [], {}
+                for j in joints:
+                    m = j.mimic
+                    if not (m and m.get("poly")):
+                        continue
+                    txt, ky = _set_mimic_yaml(
+                        txt, j.child, m["joint"], m.get("multiplier", 1.0),
+                        m.get("offset", 0.0), False, poly=m.get("poly"))
+                    # the follower's real swing (the loop constrains it)
+                    if j.lower is not None and j.upper is not None:
+                        txt, _ = _set_joint_limit(txt, j.child, j.lower,
+                                                  j.upper, False)
+                    drivers[m["joint"]] = True
+                    (applied if ky else missed).append(j.child)
+                # the driver's travel is bounded by the four-bar toggle, not the
+                # default +-pi -- push that limit too
+                for dn in drivers:
+                    dj = by_name.get(dn)
+                    if dj is not None and dj.lower is not None \
+                            and dj.upper is not None:
+                        txt, _ = _set_joint_limit(txt, dj.child, dj.lower,
+                                                  dj.upper, False)
+                if not applied:
+                    return self._send_json({"detected": 0, "applied": [],
+                                            "missed": missed})
+                _snapshot(cls.pkg_dir, yml, f"re-detect mimic x{len(applied)}")
+                with open(yml, "w", encoding="utf-8") as f:
+                    f.write(txt)
+                from sw2robot.exporter.export import build
+                try:
+                    build(cls.pkg_dir, config_path=yml)
+                except Exception as e:
+                    return self._send_json(
+                        {"error": f"rebuild failed: {e}"}, 500)
+                print(f"[sw2robot.web] redetect_couplings: {len(applied)} "
+                      f"applied, {len(missed)} not matched")
+                return self._send_json(
+                    {"detected": len(applied) + len(missed),
+                     "applied": applied, "missed": missed})
             if parsed.path == "/api/set_base":
                 cls = type(self)
                 n = int(self.headers.get("Content-Length", 0))

--- a/sw2robot/exporter/export.py
+++ b/sw2robot/exporter/export.py
@@ -156,6 +156,28 @@ def extract(assembly_path, out_dir=None, robot_name=None, visible=False,
     return pkg_dir
 
 
+def _loop_couplings(model, joint_overrides):
+    """Closed-loop (four-bar) joints carry a cubic ``poly`` on their mimic so a
+    consumer can drive the follower nonlinearly for an exact loop, which the
+    linear URDF ``<mimic>`` cannot reach.  Collect them, grouped by driver, with
+    the SAME final joint names the URDF writer emits (safe_name + renames), so a
+    relay node's config lines up with the shipped URDF."""
+    from .model import safe_name
+    jo = joint_overrides or {}
+
+    def jn(n):
+        return safe_name(jo.get(n, n))
+
+    by_driver = {}
+    for j in model.joints:
+        m = getattr(j, "mimic", None)
+        if not (m and m.get("poly")):
+            continue
+        by_driver.setdefault(jn(m["joint"]), []).append(
+            {"joint": jn(j.name), "poly": [float(c) for c in m["poly"]]})
+    return [{"driver": d, "followers": f} for d, f in sorted(by_driver.items())]
+
+
 # ---------------------------------------------------------------- build
 def build(pkg_dir, config_path=None, base_hint=None, exclude=None,
           ros_pkg=False, density=None, ros_version=1, ros_pkg_name=None,
@@ -189,6 +211,22 @@ def build(pkg_dir, config_path=None, base_hint=None, exclude=None,
     if not config_path:
         jointcfg.write_template(model, tmpl)
 
+    # Persist any closed-loop (four-bar) couplings beside the package so a LATER
+    # ROS 2 export -- the CLI here OR the editor's ZIP download, which both only
+    # see the on-disk package, not this model -- can ship the relay node + cubic
+    # config.  Refresh every build; drop a stale file once a re-wire removes the
+    # loop.  (The editor re-runs build() on every edit, so this stays current.)
+    joint_overrides = (config.get("joint_names") or {}
+                       if isinstance(config, dict) else {})
+    couplings = _loop_couplings(model, joint_overrides)
+    side = os.path.join(pkg_dir, "loop_couplings.yaml")
+    if couplings:
+        from .ros_export import _loop_couplings_yaml
+        with open(side, "w", encoding="utf-8") as f:
+            f.write(_loop_couplings_yaml(couplings))
+    elif os.path.exists(side):
+        os.remove(side)
+
     desc_dir = None
     if ros_pkg:
         # a standalone package next to pkg_dir (default <robot_name>_description,
@@ -203,7 +241,8 @@ def build(pkg_dir, config_path=None, base_hint=None, exclude=None,
             ros_version=ros_version, pkg_name=ros_pkg_name,
             urdf_name=ros_urdf_name, colors=colors,
             collision=collision, collision_quality=collision_quality,
-            merge_fixed=merge_fixed, mesh_dir=ros_mesh_dir)
+            merge_fixed=merge_fixed, mesh_dir=ros_mesh_dir,
+            loop_couplings=couplings)
 
     print(f"\nDONE. Package: {pkg_dir}")
     print(f"  URDF:   {urdf_path}")

--- a/sw2robot/exporter/jointcfg.py
+++ b/sw2robot/exporter/jointcfg.py
@@ -78,6 +78,20 @@ def write_template(model, path):
                 and j.lower is not None and j.upper is not None:
             lines.append(f"    lower: {float(j.lower):.5f}")
             lines.append(f"    upper: {float(j.upper):.5f}")
+        # round-trip the mimic coupling: a config rebuild (the editor's path)
+        # takes the directed branch, which does NOT re-run the auto four-bar /
+        # gear detection -- so without this the auto-detected <mimic> (and its
+        # cubic ``poly`` for the ROS 2 loop relay) silently vanishes on the next
+        # build.  Loader: resolve_directed reads this dict back verbatim.
+        m = getattr(j, "mimic", None)
+        if m and m.get("joint"):
+            lines.append("    mimic:")
+            lines.append(f"      joint: {m['joint']}")
+            lines.append(f"      multiplier: {float(m.get('multiplier', 1.0)):g}")
+            lines.append(f"      offset: {float(m.get('offset', 0.0)):g}")
+            if m.get("poly"):
+                poly = ", ".join(repr(float(x)) for x in m["poly"])
+                lines.append(f"      poly: [{poly}]")
     # robot-compiler module interface (root is emitted as base_link by default)
     lines.append("")
     lines.append("# --- robot-compiler module interface (optional) ---")

--- a/sw2robot/exporter/model.py
+++ b/sw2robot/exporter/model.py
@@ -1695,6 +1695,306 @@ def _auto_mimic(comps, adjacency, parent_of, edge_info):
                              f"(dual rack on {link_of.get(common, common)})")
 
 
+def _circle_isect(c0, r0, c1, r1, branch):
+    """One intersection of circles (c0,r0)/(c1,r1) in the plane, or None.
+
+    ``branch`` (+1/-1) picks which of the two; the caller fixes it once to the
+    assembled pose so the four-bar tracks the same configuration as it sweeps."""
+    d = np.linalg.norm(c1 - c0)
+    if d < 1e-12 or d > r0 + r1 or d < abs(r0 - r1):
+        return None
+    a = (r0 * r0 - r1 * r1 + d * d) / (2 * d)
+    h2 = r0 * r0 - a * a
+    if h2 < 0:
+        return None
+    m = c0 + a * (c1 - c0) / d
+    perp = np.array([-(c1 - c0)[1], (c1 - c0)[0]]) / d
+    return m + branch * np.sqrt(h2) * perp
+
+
+def _auto_loop_mimic(comps, adjacency, parent_of, edge_info, base):
+    """Couple the passive joints of a closed-loop *planar four-bar* to its driver.
+
+    A SolidWorks closed linkage (a needle-holder pantograph, a parallel-jaw
+    gripper, ...) is fully constrained: four revolute hinges about parallel axes
+    around one loop, so only ONE joint is really free.  The spanning tree keeps
+    three of the four hinges as independent revolute joints and drops the fourth
+    as a loop closure; with no coupling those three move independently and the
+    linkage flies apart.  Detect the four-bar, keep the most crank-like grounded
+    hinge as the driver, and ``<mimic>`` the other two tree hinges to it with the
+    multiplier read off the linkage geometry.
+
+    The ratio is exact only for a parallelogram, but a general four-bar's
+    velocity ratio is near-constant over a wide travel, so a least-squares
+    linear fit over a +-25 deg sweep tracks it closely -- far better than the
+    frozen/free joints we would emit otherwise."""
+    link_of = {c.name: c.link_name for c in comps}
+
+    # rigid groups: union components joined by a FIXED tree edge, so a hinge
+    # whose far link is bolted to the base reads as a hinge to GROUND.
+    uf = {c.name: c.name for c in comps}
+
+    def find(x):
+        while uf[x] != x:
+            uf[x] = uf[uf[x]]
+            x = uf[x]
+        return x
+
+    movable_tree = {}
+    for child, par in parent_of.items():
+        info = edge_info.get((child, par), {})
+        if info.get("type") in _MOVABLE_TYPES and info.get("axis") is not None:
+            movable_tree[(child, par)] = info
+        else:
+            uf[find(child)] = find(par)
+
+    tree_pairs = {frozenset((c, p)) for c, p in parent_of.items()}
+
+    def root_path(n):
+        out = [n]
+        while n in parent_of:
+            n = parent_of[n]
+            out.append(n)
+        return out
+
+    for key, rec in adjacency.items():
+        if key in tree_pairs:
+            continue
+        jt, ax, _note = classify_edge_auto(rec)
+        if jt not in _MOVABLE_TYPES or ax is None:
+            continue                          # only a movable loop closure
+        a, b = tuple(key)
+        if a not in parent_of or b not in parent_of:
+            continue
+        # fundamental cycle: tree paths to the root, cut at their LCA
+        pa, pb = root_path(a), root_path(b)
+        sb = set(pb)
+        lca = next((x for x in pa if x in sb), None)
+        if lca is None:
+            continue
+        # the loop's GROUND bar is the rigid group where its two branches rejoin
+        # the tree toward the root (the LCA) -- NOT necessarily the URDF root, so
+        # the four-bar is still found when the part is rooted elsewhere (e.g. at
+        # a module-mount connector reached through an extra joint)
+        ground = find(lca)
+        ring = pa[:pa.index(lca) + 1] + list(reversed(pb[:pb.index(lca)]))
+        # the four real hinges around the loop, in ring order
+        hinges = []
+        for u, v in zip(ring, ring[1:] + ring[:1]):
+            if (u, v) in movable_tree:
+                info, tedge = movable_tree[(u, v)], (u, v)
+            elif (v, u) in movable_tree:
+                info, tedge = movable_tree[(v, u)], (v, u)
+            elif frozenset((u, v)) == key:
+                info, tedge = {"axis": ax}, None      # the dropped closure
+            else:
+                continue                              # fixed edge -> collapses
+            pt, d = info["axis"]
+            hinges.append({"pt": np.asarray(pt, float),
+                           "d": np.asarray(d, float),
+                           "tedge": tedge, "gu": find(u), "gv": find(v)})
+        groups = []
+        for n in ring:
+            g = find(n)
+            if not groups or groups[-1] != g:
+                groups.append(g)
+        if groups and groups[0] == groups[-1]:
+            groups.pop()
+        # one 1-DOF loop = 4 distinct rigid groups, 4 hinges (3 tree + closure)
+        if len(groups) != 4 or len(hinges) != 4:
+            continue
+        if sum(1 for h in hinges if h["tedge"] is None) != 1:
+            continue
+        if ground not in groups:
+            continue                          # a free-floating loop -- skip
+        # all hinge axes must be parallel (a planar single-DOF linkage)
+        n_hat = hinges[0]["d"] / (np.linalg.norm(hinges[0]["d"]) or 1.0)
+        if any(abs(abs(h["d"] @ n_hat /
+                       (np.linalg.norm(h["d"]) or 1.0)) - 1.0) > 1e-3
+               for h in hinges):
+            continue
+        # planar basis perpendicular to the common axis; project pivots to 2D
+        e1, e2 = _perp_basis(n_hat)
+        for h in hinges:
+            h["p2"] = np.array([h["pt"] @ e1, h["pt"] @ e2])
+        ground_h = [h for h in hinges if ground in (h["gu"], h["gv"])]
+        if len(ground_h) != 2:
+            continue                          # ground must be one contiguous bar
+        drivers = [h for h in ground_h if h["tedge"] is not None]
+        if not drivers:
+            continue                          # both ground pivots dropped (rare)
+
+        def depth(h):
+            return len(root_path(h["tedge"][0]))
+
+        def moving_group(h):
+            return h["gu"] if h["gv"] == ground else h["gv"]
+
+        def moving_bar(h):
+            gm = moving_group(h)
+            h2 = next((x for x in hinges
+                       if x is not h and gm in (x["gu"], x["gv"])), None)
+            return (np.linalg.norm(h["p2"] - h2["p2"])
+                    if h2 is not None else float("inf"))
+        # driver = the most crank-like grounded hinge: the shorter its moving
+        # bar, the more it swings per unit linkage travel, so it is the natural
+        # input (and the best-conditioned to drive).  Ties by depth then name.
+        driver = min(drivers, key=lambda h: (round(moving_bar(h), 9), depth(h),
+                                             f"{link_of[h['tedge'][1]]}__"
+                                             f"{link_of[h['tedge'][0]]}"))
+        other_ground = next(h for h in ground_h if h is not driver)
+        g_in = moving_group(driver)
+        g_out = moving_group(other_ground)
+        g_cpl = next((g for g in groups
+                      if g not in (ground, g_in, g_out)), None)
+        if g_cpl is None or g_in == g_out:
+            continue
+        # the two non-ground hinges: one input<->coupler, one coupler<->output
+        h_ic = next((h for h in hinges
+                     if {h["gu"], h["gv"]} == {g_in, g_cpl}), None)
+        h_oc = next((h for h in hinges
+                     if {h["gu"], h["gv"]} == {g_out, g_cpl}), None)
+        if h_ic is None or h_oc is None:
+            continue
+
+        Pd, Pe = driver["p2"], other_ground["p2"]
+        Pi, Po = h_ic["p2"], h_oc["p2"]
+        L_in = np.linalg.norm(Pi - Pd)
+        L_cpl = np.linalg.norm(Po - Pi)
+        L_out = np.linalg.norm(Po - Pe)
+        if min(L_in, L_cpl, L_out) < 1e-6:
+            continue
+        phi0 = np.arctan2(*(Pi - Pd)[::-1])
+        branch = None
+        for br in (+1, -1):
+            test = _circle_isect(Pi, L_cpl, Pe, L_out, br)
+            if test is not None and np.linalg.norm(test - Po) < 1e-6:
+                branch = br
+                break
+        if branch is None:
+            continue
+
+        in0 = np.arctan2((Pi - Pd)[1], (Pi - Pd)[0])
+        cpl0 = np.arctan2((Po - Pi)[1], (Po - Pi)[0])
+        out0 = np.arctan2((Po - Pe)[1], (Po - Pe)[0])
+
+        def solve(dphi):
+            """Group rotations {ground:0, in, coupler, out} at driver += dphi."""
+            Pi_ = Pd + L_in * np.array([np.cos(phi0 + dphi),
+                                        np.sin(phi0 + dphi)])
+            Po_ = _circle_isect(Pi_, L_cpl, Pe, L_out, branch)
+            if Po_ is None:
+                return None
+            d_in = np.arctan2((Pi_ - Pd)[1], (Pi_ - Pd)[0]) - in0
+            d_cpl = np.arctan2((Po_ - Pi_)[1], (Po_ - Pi_)[0]) - cpl0
+            d_out = np.arctan2((Po_ - Pe)[1], (Po_ - Pe)[0]) - out0
+            return {ground: 0.0, g_in: d_in, g_cpl: d_cpl, g_out: d_out}
+
+        def jval(h, dth):
+            c, p = h["tedge"]
+            s = 1.0 if (h["d"] @ n_hat) >= 0 else -1.0
+            return s * (dth[find(c)] - dth[find(p)])
+
+        # The loop itself bounds how far the driver can turn: a non-Grashof
+        # four-bar binds at a TOGGLE (coupler & output go collinear) where
+        # solve() has no solution.  Walk out from the home pose in each
+        # direction until it binds -> the reachable driver arc.  This is the
+        # real servo travel; the default +-pi is physically unreachable.
+        sdrv = 1.0 if (driver["d"] @ n_hat) >= 0 else -1.0
+        followers = [h for h in (h_ic, h_oc, other_ground)
+                     if h is not driver and h["tedge"] is not None]
+        step = np.radians(0.5)
+        d0, d1 = solve(0.0), solve(step)
+        if d0 is None or d1 is None or not followers:
+            continue
+
+        def frate(da, db):
+            return max((abs(jval(f, da) - jval(f, db)) / step
+                        for f in followers), default=0.0)
+        # near a toggle the follower velocity ratio diverges; bound the usable
+        # arc to where it stays well-conditioned (<= 4x the home gearing) so the
+        # driver gets a real, drivable limit and the coupling fit stays accurate
+        rate_cap = max(4.0 * frate(d1, d0), 3.0)
+
+        def reach(direction):
+            prev, d, last = d0, 0.0, 0.0
+            while d < np.radians(178):
+                d += step
+                cur = solve(direction * d)
+                if cur is None or frate(cur, prev) > rate_cap:
+                    break
+                last, prev = direction * d, cur
+            return last
+        hi_phi, lo_phi = reach(+1), reach(-1)
+        # One toggle can be far (the input rocker can swing most of a turn the
+        # "long way", which collisions we don't model would block anyway, and
+        # over which the linear/cubic coupling is meaningless).  Take the NEAREST
+        # toggle on either side and use it symmetrically: a safe arc that clears
+        # both locks and keeps the coupling fit accurate.
+        # also cap at 60 deg: a change-point linkage (parallelogram) keeps one
+        # clean assembly branch only over a limited swing before the circle
+        # solve flips to the other branch and the fit would be corrupted; 60 deg
+        # is a safe, well-conditioned default (a CAD limit-mate can widen it)
+        tight = min(hi_phi, -lo_phi, np.radians(60.0))
+        tight -= min(np.radians(3.0), 0.08 * tight)    # margin off the toggle
+        if tight < np.radians(1):
+            continue                       # locked / degenerate -- not drivable
+
+        mname = (f"{link_of[driver['tedge'][1]]}__"
+                 f"{link_of[driver['tedge'][0]]}")
+        di = edge_info[driver["tedge"]]
+        # driver value q = sdrv * dphi.  Intersect the linkage arc with any
+        # existing range (a SolidWorks limit-mate servo stop) so a real, tighter
+        # CAD limit still wins.
+        geo_lo, geo_hi = -tight, tight
+        d_lo = geo_lo if di.get("lower") is None else max(geo_lo, di["lower"])
+        d_hi = geo_hi if di.get("upper") is None else min(geo_hi, di["upper"])
+        if d_hi - d_lo < np.radians(1):      # CAD limit disjoint -- keep linkage
+            d_lo, d_hi = geo_lo, geo_hi
+        di["lower"], di["upper"] = round(d_lo, 6), round(d_hi, 6)
+
+        # sample the coupling over the REACHABLE range -> the poly fits the real
+        # travel and each follower's limit is its actual swing (not mult*pi)
+        qs = np.linspace(d_lo, d_hi, 25)
+        dths = [(q, solve(q / sdrv)) for q in qs]
+        dths = [(q, d) for q, d in dths if d is not None]
+        if len(dths) < 4:
+            continue
+        qa = np.array([q for q, _ in dths])
+        n_set = 0
+        for follower in (h_ic, h_oc, other_ground):
+            if follower is driver or follower["tedge"] is None:
+                continue
+            fi = edge_info[follower["tedge"]]
+            if fi.get("mimic"):
+                continue
+            qf = np.array([jval(follower, d) for _, d in dths])
+            den = float(qa @ qa)
+            if den < 1e-12:
+                continue
+            mult = float(qa @ qf) / den
+            # a cubic captures the four-bar's nonlinearity that the linear URDF
+            # <mimic> cannot (a consumer can drive the follower by this poly for
+            # an exact loop); highest-degree coeff first, numpy.polyval order
+            deg = min(3, len(dths) - 1)
+            poly = [round(float(c), 8) for c in np.polyfit(qa, qf, deg)]
+            fi["mimic"] = {"joint": mname, "multiplier": round(mult, 6),
+                           "offset": 0.0, "poly": poly}
+            # the follower's real limit is the span it actually sweeps over the
+            # driver's reachable arc
+            fi["lower"], fi["upper"] = (round(float(qf.min()), 6),
+                                        round(float(qf.max()), 6))
+            note = fi.get("note") or "geo:"
+            fi["note"] = note + (f"; mimic {mname} x{round(mult, 3)} "
+                                 f"(four-bar loop closure)")
+            n_set += 1
+        if n_set:
+            print(f"      four-bar loop: driver {link_of[driver['tedge'][1]]}"
+                  f"->{link_of[driver['tedge'][0]]} "
+                  f"range [{round(np.degrees(d_lo))},{round(np.degrees(d_hi))}] deg"
+                  f", {n_set} mimic follower(s)")
+
+
 def _config_parent_map(comps, adjacency, base, directed):
     """Build parent_of + edge_info from an explicit directed joint list.
 
@@ -1888,6 +2188,7 @@ def build_tree(comps, adjacency, base, directed=None, root_rpy=None,
     else:
         parent_of, edge_info = _auto_parent_map(comps, adjacency, base)
         _auto_mimic(comps, adjacency, parent_of, edge_info)
+        _auto_loop_mimic(comps, adjacency, parent_of, edge_info, base)
     return _finalize_tree(comps, adjacency, base, parent_of, edge_info,
                           root_rpy=root_rpy, root_z_offset=root_z_offset,
                           root_xyz=root_xyz)

--- a/sw2robot/exporter/ros_export.py
+++ b/sw2robot/exporter/ros_export.py
@@ -33,11 +33,37 @@ import xml.etree.ElementTree as ET
 from .urdf_writer import (
     CMAKELISTS,
     CMAKELISTS_ROS2,
+    CMAKELISTS_ROS2_COUPLED,
     DISPLAY_LAUNCH_ROS2,
+    DISPLAY_LAUNCH_ROS2_COUPLED,
+    LOOP_COUPLING_RELAY_PY,
     PACKAGE_XML,
     PACKAGE_XML_ROS2,
+    PACKAGE_XML_ROS2_COUPLED,
     RVIZ_CONFIG_ROS2,
 )
+
+
+def _loop_couplings_yaml(couplings):
+    """Serialise the closed-loop coupling list to the relay node's config YAML.
+
+    Hand-formatted (not via the yaml dumper) so the polynomial coefficients
+    stay readable and the file carries an explaining header."""
+    lines = [
+        "# Closed-loop (four-bar) joint couplings for loop_coupling_relay.",
+        "# Each follower angle = polyval(poly, driver_angle) (highest-degree",
+        "# coefficient first); this is the exact coupling the linear URDF",
+        "# <mimic> can only approximate.",
+        "couplings:",
+    ]
+    for c in couplings:
+        lines.append(f"  - driver: {c['driver']}")
+        lines.append("    followers:")
+        for f in c["followers"]:
+            poly = ", ".join(repr(float(x)) for x in f["poly"])
+            lines.append(f"      - joint: {f['joint']}")
+            lines.append(f"        poly: [{poly}]")
+    return "\n".join(lines) + "\n"
 
 # extensions we convert; anything else (already .dae/.stl, abs URLs) is left alone
 # source mesh formats we can load + reconvert: CAD output (.3dxml mm, .glb m)
@@ -415,9 +441,16 @@ def _collada_meshes(mesh):
     else:
         return [mesh]
 
-    face_colors = np.asarray(face_colors, dtype=np.uint8)
+    face_colors = np.array(face_colors, dtype=np.uint8)   # copy: clamped below
     if len(face_colors) != len(mesh.faces):
         return [mesh]
+    # A pure-black COLLADA material (diffuse 0,0,0) renders as a RED fallback in
+    # RViz2/Ogre instead of black; lift near-black faces to a dark grey so black
+    # CAD parts stay (almost) black rather than flashing red.  Alpha and any
+    # genuinely coloured face are left untouched.
+    if face_colors.shape[1] >= 3:
+        black = (face_colors[:, :3] < 12).all(axis=1)
+        face_colors[black, :3] = 12
     unique, inverse = np.unique(face_colors, axis=0, return_inverse=True)
     if len(unique) <= 1:
         mesh.visual.face_colors = np.tile(unique[0], (len(mesh.faces), 1))
@@ -603,7 +636,7 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
                           ctx_fmt=_CTX_FMT, ros_version=1, pkg_name=None,
                           urdf_name=None, colors=None, collision="copy",
                           collision_quality="balanced", merge_fixed=False,
-                          mesh_dir=None):
+                          mesh_dir=None, loop_couplings=None):
     """``pkg_dir`` (a built package) -> ``[(arcname, bytes), ...]`` for a portable
     ROS package, all behind ``package://`` URLs.  The package is named
     ``pkg_name`` if given (validated, see :func:`ros_pkg_name`), else
@@ -638,6 +671,13 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
     ``launch/display.launch.py`` + ``rviz/<urdf>.rviz`` so the package runs with
     ``ros2 launch <name> display.launch.py``.
 
+    ``loop_couplings`` (ROS 2 only) is an optional ``[{driver, followers:[{joint,
+    poly}]}]`` list describing closed-loop (four-bar) couplings: when present the
+    package additionally ships ``config/loop_couplings.yaml``, a
+    ``loop_coupling_relay`` node, and a launch wired GUI -> relay ->
+    robot_state_publisher so the loop follows its exact (cubic) coupling -- the
+    linear URDF ``<mimic>`` alone tracks a general four-bar only approximately.
+
     Reads the on-disk ``urdf/<robot_name>.urdf`` (which already carries the
     editor's applied edits).  A missing/unconvertible mesh aborts the export
     before any entries are emitted, so a half-rewritten package never ships."""
@@ -656,6 +696,18 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
                 "CoACD collision decomposition needs the optional 'coacd' "
                 "package -- install it with: pip install coacd")
     coacd_cache_dir = os.path.join(pkg_dir, "meshes", ".coacd_cache")
+    if loop_couplings is None:
+        # the editor's ZIP export calls us directly (no model); pick up the
+        # closed-loop couplings build() persisted beside the package so the ZIP
+        # ships the relay node + cubic config too
+        side = os.path.join(pkg_dir, "loop_couplings.yaml")
+        if os.path.isfile(side):
+            try:
+                import yaml
+                with open(side, encoding="utf-8") as f:
+                    loop_couplings = (yaml.safe_load(f) or {}).get("couplings")
+            except Exception:
+                loop_couplings = None
     pkg = ros_pkg_name(robot_name, pkg_name)
     urdf_stem = ros_urdf_stem(pkg, urdf_name)
     mesh_rel = ros_mesh_dir(mesh_dir)
@@ -811,17 +863,27 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
         first_link = root.find("link")
         fixed_frame = (first_link.get("name") if first_link is not None
                        else "base_link") or "base_link"
+        # a detected kinematic loop ships a relay node + cubic config + a launch
+        # wired GUI -> relay -> robot_state_publisher (linear <mimic> alone can't
+        # track a four-bar); a plain robot keeps the simpler GUI -> RSP launch
+        coupled = bool(loop_couplings)
+        pkg_xml = PACKAGE_XML_ROS2_COUPLED if coupled else PACKAGE_XML_ROS2
+        cmake = CMAKELISTS_ROS2_COUPLED if coupled else CMAKELISTS_ROS2
+        launch = DISPLAY_LAUNCH_ROS2_COUPLED if coupled else DISPLAY_LAUNCH_ROS2
         files.append((f"{pkg}/package.xml",
-                      PACKAGE_XML_ROS2.format(name=pkg, email=email)
-                      .encode("utf-8")))
+                      pkg_xml.format(name=pkg, email=email).encode("utf-8")))
         files.append((f"{pkg}/CMakeLists.txt",
-                      CMAKELISTS_ROS2.format(name=pkg).encode("utf-8")))
+                      cmake.format(name=pkg).encode("utf-8")))
         files.append((f"{pkg}/launch/display.launch.py",
-                      DISPLAY_LAUNCH_ROS2.format(name=pkg, robot=urdf_stem)
-                      .encode("utf-8")))
+                      launch.format(name=pkg, robot=urdf_stem).encode("utf-8")))
         files.append((f"{pkg}/rviz/{urdf_stem}.rviz",
                       RVIZ_CONFIG_ROS2.format(fixed_frame=fixed_frame)
                       .encode("utf-8")))
+        if coupled:
+            files.append((f"{pkg}/config/loop_couplings.yaml",
+                          _loop_couplings_yaml(loop_couplings).encode("utf-8")))
+            files.append((f"{pkg}/scripts/loop_coupling_relay.py",
+                          LOOP_COUPLING_RELAY_PY.encode("utf-8")))
     else:
         files.append((f"{pkg}/package.xml",
                       PACKAGE_XML.format(name=pkg, email=email).encode("utf-8")))
@@ -835,14 +897,16 @@ def write_ros_description_package(pkg_dir, robot_name, dest_dir,
                                   pkg_name=None, urdf_name=None, colors=None,
                                   collision="copy",
                                   collision_quality="balanced",
-                                  merge_fixed=False, mesh_dir=None):
+                                  merge_fixed=False, mesh_dir=None,
+                                  loop_couplings=None):
     """Write the ROS package under ``dest_dir`` and return its directory path.
     The package is named ``pkg_name`` if given, else ``<robot_name>_description``;
     the URDF inside is named ``urdf_name`` if given, else the package name.
     ``ros_version`` (1 = catkin, 2 = ament_cmake), ``colors`` (per-link colour
     overrides), ``collision`` / ``collision_quality`` (CoACD collision-mesh
-    decomposition), ``merge_fixed`` (lump fixed-joint children into parents) and
-    ``mesh_dir`` (package-relative mesh directory, default ``meshes``) are passed
+    decomposition), ``merge_fixed`` (lump fixed-joint children into parents),
+    ``mesh_dir`` (package-relative mesh directory, default ``meshes``) and
+    ``loop_couplings`` (ROS 2 closed-loop relay node + config) are passed
     through to :func:`build_ros_description`."""
     pkg = ros_pkg_name(robot_name, pkg_name)
     files = build_ros_description(pkg_dir, robot_name, email=email,
@@ -850,11 +914,18 @@ def write_ros_description_package(pkg_dir, robot_name, dest_dir,
                                   urdf_name=urdf_name, colors=colors,
                                   collision=collision,
                                   collision_quality=collision_quality,
-                                  merge_fixed=merge_fixed, mesh_dir=mesh_dir)
+                                  merge_fixed=merge_fixed, mesh_dir=mesh_dir,
+                                  loop_couplings=loop_couplings)
     root = os.path.abspath(dest_dir)
     for arc, data in files:
         dst = os.path.join(root, *arc.split("/"))
         os.makedirs(os.path.dirname(dst), exist_ok=True)
         with open(dst, "wb") as f:
             f.write(data)
+        # a node under scripts/ must be executable: ament's install(PROGRAMS)
+        # copies 0755, but `colcon build --symlink-install` SYMLINKS back to
+        # this source file, so a 0644 source leaves a non-executable libexec
+        # entry that `ros2 launch` cannot find
+        if "/scripts/" in arc and arc.endswith(".py"):
+            os.chmod(dst, 0o755)
     return os.path.join(root, pkg)

--- a/sw2robot/exporter/urdf_writer.py
+++ b/sw2robot/exporter/urdf_writer.py
@@ -402,8 +402,15 @@ Visualization Manager:
     - Class: rviz_default_plugins/RobotModel
       Enabled: true
       Name: RobotModel
+      Visual Enabled: true
+      Collision Enabled: false
+      Description Source: Topic
       Description Topic:
         Value: /robot_description
+        Depth: 5
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Durability Policy: Transient Local
     - Class: rviz_default_plugins/TF
       Enabled: true
       Name: TF
@@ -418,6 +425,164 @@ Visualization Manager:
       Class: rviz_default_plugins/Orbit
       Name: Current View
 """
+
+# --- ROS 2 closed-loop (four-bar) variants ----------------------------------
+# A package with a detected kinematic loop ships three extra pieces: the cubic
+# coupling config, a relay node that applies it, and a launch file wired
+# GUI -> relay -> robot_state_publisher so the loop tracks faithfully in RViz.
+# (robot_state_publisher honours a URDF <mimic> only LINEARLY, which a general
+# four-bar's follower angle is not.)
+PACKAGE_XML_ROS2_COUPLED = """<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>{name}</name>
+  <version>0.0.1</version>
+  <description>URDF generated from SolidWorks assembly {name}</description>
+  <maintainer email="{email}">auto</maintainer>
+  <license>TODO</license>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
+  <exec_depend>rviz2</exec_depend>
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>python3-yaml</exec_depend>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>
+"""
+
+CMAKELISTS_ROS2_COUPLED = """cmake_minimum_required(VERSION 3.8)
+project({name})
+find_package(ament_cmake REQUIRED)
+install(DIRECTORY urdf meshes launch rviz config
+  DESTINATION share/${{PROJECT_NAME}})
+install(PROGRAMS scripts/loop_coupling_relay.py
+  DESTINATION lib/${{PROJECT_NAME}})
+ament_package()
+"""
+
+# {name} = package name, {robot} = urdf file stem.  Sliders drive the
+# independent joints; <mimic> followers are dependent, so the GUI shows no
+# slider for them.  The GUI publishes on joint_states_source; the relay
+# overrides the loop followers with their exact cubic coupling and republishes
+# on joint_states, which robot_state_publisher consumes.
+DISPLAY_LAUNCH_ROS2_COUPLED = '''import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    pkg = get_package_share_directory("{name}")
+    urdf = os.path.join(pkg, "urdf", "{robot}.urdf")
+    with open(urdf) as f:
+        robot_description = f.read()
+    rviz = os.path.join(pkg, "rviz", "{robot}.rviz")
+    couplings = os.path.join(pkg, "config", "loop_couplings.yaml")
+    return LaunchDescription([
+        Node(
+            package="robot_state_publisher",
+            executable="robot_state_publisher",
+            output="screen",
+            parameters=[{{"robot_description": robot_description}}],
+        ),
+        Node(
+            package="joint_state_publisher_gui",
+            executable="joint_state_publisher_gui",
+            output="screen",
+            remappings=[("joint_states", "joint_states_source")],
+        ),
+        Node(
+            package="{name}",
+            executable="loop_coupling_relay.py",
+            output="screen",
+            parameters=[{{"config_file": couplings}}],
+        ),
+        Node(
+            package="rviz2",
+            executable="rviz2",
+            output="screen",
+            arguments=["-d", rviz],
+        ),
+    ])
+'''
+
+# A standalone rclpy node (no {{}} .format here -- shipped verbatim).
+LOOP_COUPLING_RELAY_PY = '''#!/usr/bin/env python3
+"""Apply the exact (nonlinear) coupling of a closed-loop linkage's followers.
+
+robot_state_publisher / joint_state_publisher honour a URDF <mimic> only
+LINEARLY (multiplier*q + offset).  A four-bar's follower angle is a nonlinear
+function of its driver, so this node republishes /joint_states with each loop
+follower recomputed from the cubic polynomial in config/loop_couplings.yaml.
+Wire it between the joint-state source and robot_state_publisher.
+"""
+import rclpy
+import yaml
+from rclpy.node import Node
+from sensor_msgs.msg import JointState
+
+
+def _polyval(coeffs, x):
+    # Horner, highest-degree coefficient first (numpy.polyval order)
+    acc = 0.0
+    for c in coeffs:
+        acc = acc * x + c
+    return acc
+
+
+class LoopCouplingRelay(Node):
+    def __init__(self):
+        super().__init__("loop_coupling_relay")
+        self.declare_parameter("config_file", "")
+        path = self.get_parameter("config_file").value
+        couplings = []
+        if path:
+            with open(path) as f:
+                couplings = (yaml.safe_load(f) or {}).get("couplings", []) or []
+        self._couplings = couplings
+        if not couplings:
+            self.get_logger().warn("no couplings loaded; relaying unchanged")
+        self._pub = self.create_publisher(JointState, "joint_states", 10)
+        self.create_subscription(JointState, "joint_states_source",
+                                 self._cb, 10)
+
+    def _cb(self, msg):
+        pos = dict(zip(msg.name, msg.position))
+        for c in self._couplings:
+            drv = c.get("driver")
+            if drv not in pos:
+                continue
+            q = pos[drv]
+            for f in c.get("followers", []):
+                pos[f["joint"]] = _polyval(f.get("poly", []), q)
+        out = JointState()
+        out.header = msg.header
+        out.name = list(pos.keys())
+        out.position = [float(pos[n]) for n in out.name]
+        self._pub.publish(out)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = LoopCouplingRelay()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
+
+
+if __name__ == "__main__":
+    main()
+'''
 
 
 def write_ros_package(model, pkg_dir, email="auto@example.com"):

--- a/tests/test_loop_mimic.py
+++ b/tests/test_loop_mimic.py
@@ -1,0 +1,124 @@
+"""A closed-loop (four-bar) linkage is exported as driver + mimic followers.
+
+A SolidWorks closed linkage is fully constrained -- four revolute hinges about
+parallel axes around one loop, so only ONE joint is really free.  The spanning
+tree keeps three hinges as revolute and drops the fourth as a loop closure;
+without coupling the three move independently and the linkage flies apart.
+``_auto_loop_mimic`` detects the four-bar and makes the two passive tree hinges
+``<mimic>`` the driver.  For a parallelogram the coupling is exactly +-1, which
+these tests pin so the detection (and multiplier maths) cannot silently regress.
+"""
+import numpy as np
+
+from sw2robot.exporter.model import build_model
+from sw2robot.exporter.state import ComponentState, GraphState, MateEdge, MateGeo
+
+CYL, PLANE = 4, 3
+
+
+def _comp(name, xyz=(0, 0, 0), fixed=False):
+    w = np.eye(4)
+    w[:3, 3] = xyz
+    return ComponentState(
+        name=name, link_name=name.replace(" ", "_"), part_path=None,
+        is_subassembly=False, world=[float(x) for x in w.flatten()],
+        fixed=fixed)
+
+
+def _geo(mtype, ents):
+    return MateGeo(type=mtype,
+                   etypes=[e[0] for e in ents],
+                   points=[list(map(float, e[1])) for e in ents],
+                   dirs=[list(map(float, e[2])) for e in ents],
+                   radii=[None] * len(ents))
+
+
+def _hinge_z(a, b, p):
+    """A pure revolute about world +Z at point ``p``: a concentric Z cylinder
+    (rotation + axial slide) pinned axially by a coincident Z-normal plane."""
+    p = list(map(float, p))
+    return MateEdge(a=a, b=b, types=["CONCENTRIC", "COINCIDENT"],
+                    axis_point=p, axis_dir=[0.0, 0.0, 1.0],
+                    mates=[_geo("CONCENTRIC", [(CYL, p, [0, 0, 1]),
+                                               (CYL, p, [0, 0, 1])]),
+                           _geo("COINCIDENT", [(PLANE, p, [0, 0, 1]),
+                                               (PLANE, p, [0, 0, 1])])])
+
+
+def _graph(comps, edges, ground):
+    return GraphState(robot_name="t", source_assembly="t.SLDASM",
+                      components=comps, edges=edges, ground=ground)
+
+
+def _parallelogram():
+    # ground bar A(0,0)->D(2,0); equal input A->B(0,1) and output D->C(2,1);
+    # coupler B->C has the same length as the ground bar -> a parallelogram.
+    base = _comp("base", fixed=True)
+    inl = _comp("inlink", (0, 1, 0))
+    cpl = _comp("coupler", (1, 1, 0))
+    outl = _comp("outlink", (2, 1, 0))
+    edges = [
+        _hinge_z("base", "inlink", [0, 0, 0]),       # A
+        _hinge_z("inlink", "coupler", [0, 1, 0]),    # B
+        _hinge_z("coupler", "outlink", [2, 1, 0]),   # C
+        _hinge_z("outlink", "base", [2, 0, 0]),      # D
+    ]
+    return _graph([base, inl, cpl, outl], edges, ground=["base"])
+
+
+def test_four_bar_loop_becomes_driver_plus_two_mimics():
+    model = build_model(_parallelogram())
+    rev = [j for j in model.joints if j.jtype == "revolute"]
+    # 4 physical hinges, one dropped as the loop closure -> 3 revolute tree edges
+    assert len(rev) == 3
+    mimics = [j for j in rev if j.mimic]
+    free = [j for j in rev if not j.mimic]
+    assert len(mimics) == 2 and len(free) == 1      # one driver, two followers
+    driver = free[0]
+    # both followers mimic the SAME (driver) joint, offset 0
+    assert all(j.mimic["joint"] == driver.name for j in mimics)
+    assert all(j.mimic["offset"] == 0.0 for j in mimics)
+    # a parallelogram couples exactly +-1
+    for j in mimics:
+        assert abs(abs(j.mimic["multiplier"]) - 1.0) < 1e-3
+
+
+def test_loop_mimic_round_trips_through_joints_yaml(tmp_path):
+    # The editor rebuilds via build(--config joints.yaml), which takes the
+    # DIRECTED branch and does NOT re-run auto loop detection -- so the mimic
+    # must be persisted in the template and read back, or it (and the viewer's
+    # purple axis) vanishes on the next build.
+    import yaml
+
+    from sw2robot.exporter import jointcfg
+    from sw2robot.exporter.model import build_model
+
+    graph = _parallelogram()
+    model = build_model(graph)
+    follower = next(j for j in model.joints if j.mimic)
+
+    tmpl = tmp_path / "j.yaml"
+    jointcfg.write_template(model, str(tmpl))
+    cfg = yaml.safe_load(tmpl.read_text(encoding="utf-8"))
+    entry = next(j for j in cfg["joints"]
+                 if j.get("mimic", {}).get("joint") == follower.mimic["joint"])
+    assert entry["mimic"]["joint"] == follower.mimic["joint"]
+    assert "poly" in entry["mimic"] and len(entry["mimic"]["poly"]) >= 2
+
+    # feeding that config back keeps the <mimic> (directed path, no auto detect)
+    model2 = build_model(graph, config=cfg)
+    f2 = next((j for j in model2.joints
+               if j.name == follower.name), None)
+    assert f2 is not None and f2.mimic is not None
+    assert f2.mimic["joint"] == follower.mimic["joint"]
+
+
+def test_four_bar_driver_carries_no_mimic_and_loop_is_open():
+    model = build_model(_parallelogram())
+    # exactly one revolute hinge is dropped (the URDF tree stays acyclic): 4
+    # links, and link count - 1 == joint count for a tree
+    assert len(model.joints) == len(model.components) - 1
+    # the driver is a real, independent joint (no <mimic> on it)
+    rev = [j for j in model.joints if j.jtype == "revolute"]
+    driver = next(j for j in rev if not j.mimic)
+    assert driver.mimic is None

--- a/tests/test_ros_export.py
+++ b/tests/test_ros_export.py
@@ -281,6 +281,112 @@ def test_invalid_ros_version_rejected(tmp_path):
         build_ros_description(pkg_dir, "r", ros_version=3)
 
 
+def test_ros2_loop_couplings_ship_relay_and_config(tmp_path):
+    # a detected closed loop ships a relay node + cubic config + a launch wired
+    # GUI -> relay -> robot_state_publisher so the four-bar tracks in RViz
+    from sw2robot.exporter.ros_export import build_ros_description
+
+    pkg_dir = _make_pkg(tmp_path, robot="fb")
+    couplings = [{
+        "driver": "a__b",
+        "followers": [
+            {"joint": "c__d", "poly": [0.0878, 0.0034, 1.3246, -0.0003]},
+            {"joint": "e__f", "poly": [0.0135, 0.1572, 0.5728, -0.0003]},
+        ],
+    }]
+    files = dict(build_ros_description(pkg_dir, "fb", ros_version=2,
+                                       loop_couplings=couplings))
+    arcs = set(files)
+
+    # the extra artifacts only the coupled path emits
+    assert "fb_description/config/loop_couplings.yaml" in arcs
+    assert "fb_description/scripts/loop_coupling_relay.py" in arcs
+
+    cfg = files["fb_description/config/loop_couplings.yaml"].decode()
+    import yaml
+    parsed = yaml.safe_load(cfg)
+    assert parsed["couplings"][0]["driver"] == "a__b"
+    polys = {f["joint"]: f["poly"]
+             for f in parsed["couplings"][0]["followers"]}
+    assert polys["c__d"][2] == 1.3246           # the ~linear (degree-1) term
+    assert len(polys["e__f"]) == 4              # cubic
+
+    # relay node is valid python and reads the config param
+    relay = files["fb_description/scripts/loop_coupling_relay.py"].decode()
+    compile(relay, "loop_coupling_relay.py", "exec")
+    assert "config_file" in relay and "joint_states_source" in relay
+
+    # launch wires GUI -> relay -> RSP (GUI publishes on the source topic)
+    launch = files["fb_description/launch/display.launch.py"].decode()
+    compile(launch, "display.launch.py", "exec")
+    assert '("joint_states", "joint_states_source")' in launch
+    assert "loop_coupling_relay.py" in launch
+
+    # build + deps follow: install config/scripts, depend on rclpy/sensor_msgs
+    cmake = files["fb_description/CMakeLists.txt"].decode()
+    assert "config" in cmake and "scripts/loop_coupling_relay.py" in cmake
+    pxml = files["fb_description/package.xml"].decode()
+    assert "<exec_depend>rclpy</exec_depend>" in pxml
+    assert "<exec_depend>sensor_msgs</exec_depend>" in pxml
+
+
+def test_ros2_loop_couplings_autoload_from_sidecar(tmp_path):
+    # the editor's ZIP export calls build_ros_description directly (no model /
+    # no explicit couplings); a loop_couplings.yaml that build() left beside the
+    # package must still get the relay shipped
+    from sw2robot.exporter.ros_export import build_ros_description
+
+    pkg_dir = _make_pkg(tmp_path, robot="sc")
+    (tmp_path / "loop_couplings.yaml").write_text(
+        "couplings:\n"
+        "  - driver: a__b\n"
+        "    followers:\n"
+        "      - joint: c__d\n"
+        "        poly: [0.1, 0.0, 1.3, 0.0]\n",
+        encoding="utf-8")
+    # note: NO loop_couplings kwarg -- must be picked up from the sidecar
+    files = dict(build_ros_description(pkg_dir, "sc", ros_version=2))
+    assert "sc_description/scripts/loop_coupling_relay.py" in files
+    cfg = files["sc_description/config/loop_couplings.yaml"].decode()
+    assert "a__b" in cfg and "c__d" in cfg
+
+
+def test_dae_pure_black_lifted_to_dark_grey(tmp_path):
+    # a pure-black COLLADA material renders as a RED fallback in RViz2/Ogre;
+    # _collada_meshes must lift near-black faces to a dark grey (>=12/255)
+    import numpy as np
+    import trimesh
+
+    from sw2robot.exporter.ros_export import _collada_meshes
+
+    box = trimesh.creation.box(extents=(1, 1, 1))
+    # half the faces pure black, half a real colour (blue) -> two materials
+    fc = np.tile([0, 0, 0, 255], (len(box.faces), 1)).astype(np.uint8)
+    fc[: len(box.faces) // 2] = [0, 0, 200, 255]
+    box.visual.face_colors = fc
+    parts = _collada_meshes(box)
+    allc = np.vstack([p.visual.face_colors for p in parts])
+    # no face is left pure black (RGB all < 12); the blue is untouched
+    assert not ((allc[:, :3] < 12).all(axis=1)).any()
+    assert (allc[:, 2] == 200).any()           # the blue survives
+
+
+def test_ros2_without_couplings_has_no_relay(tmp_path):
+    # the plain ROS 2 package (no loop) keeps the simple GUI -> RSP launch and
+    # ships none of the coupling machinery
+    from sw2robot.exporter.ros_export import build_ros_description
+
+    pkg_dir = _make_pkg(tmp_path, robot="pl")
+    files = dict(build_ros_description(pkg_dir, "pl", ros_version=2))
+    arcs = set(files)
+    assert "pl_description/config/loop_couplings.yaml" not in arcs
+    assert "pl_description/scripts/loop_coupling_relay.py" not in arcs
+    launch = files["pl_description/launch/display.launch.py"].decode()
+    assert "joint_states_source" not in launch
+    pxml = files["pl_description/package.xml"].decode()
+    assert "rclpy" not in pxml
+
+
 def test_glb_ctx_exports_uniform_glb(tmp_path):
     import io
     import xml.etree.ElementTree as ET


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/281cd1c3-120d-4229-ad02-a19a69c06865


Detect a planar **four-bar closed loop** in the CAD graph and couple its passive joints to the driver, so the linkage moves as one mechanism in the exported URDF instead of flying apart as independent free joints.

A closed kinematic loop can't live in a URDF tree, so the spanning tree drops one hinge as a loop closure. Previously the remaining hinges were emitted as **independent free revolute joints** → the linkage had N DOF instead of 1 and didn't hold together. This couples them.

## What it does

- **Detection** (`_auto_loop_mimic`): finds a single 1-DOF planar four-bar (rigid-group cycle of 4 parallel-axis revolute hinges, ground taken from the cycle LCA so it works regardless of which link is the root), solves the linkage to fit each follower's linear `<mimic>` multiplier **plus a cubic coupling polynomial**.
- **Joint limits from the loop**: a non-Grashof four-bar binds at a toggle, so the driver/follower travel is bounded by the linkage geometry instead of the unreachable default ±π. Independent joints outside the loop keep ±π.
- **ROS 2 export**: ships `config/loop_couplings.yaml` + a `loop_coupling_relay` node + a launch wired `joint_state_publisher_gui → relay → robot_state_publisher`, so the follower tracks the **exact (nonlinear)** coupling in RViz. The linear `<mimic>` stays as the universal fallback for tools without the relay.
- **Config round-trip** (`jointcfg`): persists the mimic block (joint/multiplier/offset/poly) in `joints.yaml` so a `--config` rebuild (the editor's path, which skips auto-detection) keeps it.
- **Editor**: a **🔗 re-detect mimic** button merges auto-detected couplings + toggle-derived limits into an existing `joints.yaml` non-destructively (a re-extract reuses the config and never re-detects on its own).

## Fixes folded in

- RViz RobotModel description QoS set to **Transient Local** so meshes load (latched `/robot_description` was being missed → TF-only).
- Lift pure-black `.dae` materials off RViz's red fallback (dark grey instead of flashing red).
- Mark the relay script executable so `colcon build --symlink-install` leaves a runnable libexec entry.

## Tests

- `tests/test_loop_mimic.py` — parallelogram coupling = ±1, driver carries no mimic, loop is open, joints.yaml round-trip.
- `tests/test_ros_export.py` — relay/config shipped (and not, when no loop), sidecar auto-load, pure-black → dark-grey.

Full suite green (pre-existing FCL-dependent tests excepted).

## Follow-up

Generalising beyond the planar four-bar (numerical loop-closure solver for any single 1-DOF loop, then a runtime loop solver in the relay for arbitrary topology) is planned as a next step.
