### PR TITLE
feat: close kinematic loops at runtime via numerical IK (no extra deps)

### DIFF
--- a/sw2robot/exporter/export.py
+++ b/sw2robot/exporter/export.py
@@ -156,26 +156,24 @@ def extract(assembly_path, out_dir=None, robot_name=None, visible=False,
     return pkg_dir
 
 
-def _loop_couplings(model, joint_overrides):
-    """Closed-loop (four-bar) joints carry a cubic ``poly`` on their mimic so a
-    consumer can drive the follower nonlinearly for an exact loop, which the
-    linear URDF ``<mimic>`` cannot reach.  Collect them, grouped by driver, with
-    the SAME final joint names the URDF writer emits (safe_name + renames), so a
-    relay node's config lines up with the shipped URDF."""
+def _loop_closures_cfg(model, joint_overrides):
+    """The runtime-IK relay config from ``model.loop_closures``, with dependent/
+    independent joint names mapped to the SAME final names the URDF emits (the
+    closures' link names are already final)."""
+    lc = getattr(model, "loop_closures", None)
+    if not lc:
+        return None
     from .model import safe_name
     jo = joint_overrides or {}
 
     def jn(n):
         return safe_name(jo.get(n, n))
 
-    by_driver = {}
-    for j in model.joints:
-        m = getattr(j, "mimic", None)
-        if not (m and m.get("poly")):
-            continue
-        by_driver.setdefault(jn(m["joint"]), []).append(
-            {"joint": jn(j.name), "poly": [float(c) for c in m["poly"]]})
-    return [{"driver": d, "followers": f} for d, f in sorted(by_driver.items())]
+    return {
+        "closures": lc["closures"],
+        "dependent": [jn(n) for n in lc["dependent"]],
+        "independent": [jn(n) for n in lc["independent"]],
+    }
 
 
 # ---------------------------------------------------------------- build
@@ -211,21 +209,22 @@ def build(pkg_dir, config_path=None, base_hint=None, exclude=None,
     if not config_path:
         jointcfg.write_template(model, tmpl)
 
-    # Persist any closed-loop (four-bar) couplings beside the package so a LATER
-    # ROS 2 export -- the CLI here OR the editor's ZIP download, which both only
-    # see the on-disk package, not this model -- can ship the relay node + cubic
-    # config.  Refresh every build; drop a stale file once a re-wire removes the
-    # loop.  (The editor re-runs build() on every edit, so this stays current.)
+    # Persist any closed-loop data beside the package so a LATER ROS 2 export --
+    # the CLI here OR the editor's ZIP download, which both only see the on-disk
+    # package, not this model -- can ship the loop-closure relay + its config.
+    # Refresh every build; drop stale files once a re-wire removes the loop.
+    # (The editor re-runs build() on every edit, so this stays current.)
+    import yaml as _yaml
     joint_overrides = (config.get("joint_names") or {}
                        if isinstance(config, dict) else {})
-    couplings = _loop_couplings(model, joint_overrides)
-    side = os.path.join(pkg_dir, "loop_couplings.yaml")
-    if couplings:
-        from .ros_export import _loop_couplings_yaml
-        with open(side, "w", encoding="utf-8") as f:
-            f.write(_loop_couplings_yaml(couplings))
-    elif os.path.exists(side):
-        os.remove(side)
+    closures = _loop_closures_cfg(model, joint_overrides)
+    cside = os.path.join(pkg_dir, "loop_closures.yaml")
+    if closures:
+        with open(cside, "w", encoding="utf-8") as f:
+            f.write("# Closed-loop closures for loop_closure_relay (runtime IK).\n")
+            _yaml.safe_dump(closures, f, sort_keys=False, default_flow_style=None)
+    elif os.path.exists(cside):
+        os.remove(cside)
 
     desc_dir = None
     if ros_pkg:
@@ -242,7 +241,7 @@ def build(pkg_dir, config_path=None, base_hint=None, exclude=None,
             urdf_name=ros_urdf_name, colors=colors,
             collision=collision, collision_quality=collision_quality,
             merge_fixed=merge_fixed, mesh_dir=ros_mesh_dir,
-            loop_couplings=couplings)
+            loop_closures=closures)
 
     print(f"\nDONE. Package: {pkg_dir}")
     print(f"  URDF:   {urdf_path}")

--- a/sw2robot/exporter/model.py
+++ b/sw2robot/exporter/model.py
@@ -241,6 +241,9 @@ class RobotModel:
     # link is written as (the convention is ``base_link`` = input port).
     ports: list = field(default_factory=list)
     root_link_name: str = "base_link"
+    # closed-loop (four-bar / parallel) data for the runtime-IK relay:
+    # {closures:[{link_a,link_b,point,axis}], dependent:[...], independent:[...]}
+    loop_closures: dict | None = None
 
 
 def _match_component(comps, ref):
@@ -1995,6 +1998,97 @@ def _auto_loop_mimic(comps, adjacency, parent_of, edge_info, base):
                   f", {n_set} mimic follower(s)")
 
 
+def _collect_loop_closures(comps, adjacency, parent_of, edge_info, base):
+    """General closed-loop data for the runtime-IK relay.
+
+    For every dropped (non-tree) movable edge -- a loop the spanning tree had to
+    cut -- record the two links it rejoined plus the hinge point/axis in
+    base_link frame, and split the loop's movable joints into DRIVEN
+    (independent) vs SOLVED (dependent).  The relay closes each loop numerically
+    with skrobot FK, so NO four-bar-specific geometry is needed here: this works
+    for any single-DOF-per-loop linkage (planar or spatial, revolute or
+    prismatic).  Returns ``None`` when the assembly has no closed loop.
+
+    Dependents are the loop joints carrying a ``<mimic>`` (the four-bar pass
+    already chose those); on a loop the four-bar pass skipped, the joint nearest
+    the root drives and the rest are solved."""
+    link_of = {c.name: c.link_name for c in comps}
+    wb_inv = np.linalg.inv(base.world)        # SW world -> base_link frame
+
+    uf = {c.name: c.name for c in comps}
+
+    def find(x):
+        while uf[x] != x:
+            uf[x] = uf[uf[x]]
+            x = uf[x]
+        return x
+
+    movable_tree = {}
+    for child, par in parent_of.items():
+        info = edge_info.get((child, par), {})
+        if info.get("type") in _MOVABLE_TYPES and info.get("axis") is not None:
+            movable_tree[(child, par)] = info
+        else:
+            uf[find(child)] = find(par)
+    tree_pairs = {frozenset((c, p)) for c, p in parent_of.items()}
+
+    def root_path(n):
+        out = [n]
+        while n in parent_of:
+            n = parent_of[n]
+            out.append(n)
+        return out
+
+    def jname(te):                            # model joint name = parent__child
+        c, p = te
+        return f"{link_of[p]}__{link_of[c]}"
+
+    def lname(comp):
+        return "base_link" if comp == base.name else safe_name(link_of[comp])
+
+    closures, dependent = [], set()
+    for key, rec in adjacency.items():
+        if key in tree_pairs:
+            continue
+        jt, ax, _n = classify_edge_auto(rec)
+        if jt not in _MOVABLE_TYPES or ax is None:
+            continue
+        a, b = tuple(key)
+        if a not in parent_of or b not in parent_of:
+            continue
+        pa, pb = root_path(a), root_path(b)
+        sb = set(pb)
+        lca = next((x for x in pa if x in sb), None)
+        if lca is None:
+            continue
+        ring = pa[:pa.index(lca) + 1] + list(reversed(pb[:pb.index(lca)]))
+        cyc = []
+        for u, v in zip(ring, ring[1:] + ring[:1]):
+            if (u, v) in movable_tree:
+                cyc.append((u, v))
+            elif (v, u) in movable_tree:
+                cyc.append((v, u))
+        if not cyc:
+            continue
+        mimic_deps = [te for te in cyc if edge_info[te].get("mimic")]
+        if mimic_deps:
+            dependent.update(jname(te) for te in mimic_deps)
+        else:                                 # general loop: nearest-root drives
+            driver = min(cyc, key=lambda te: (len(root_path(te[0])), jname(te)))
+            dependent.update(jname(te) for te in cyc if te != driver)
+        pt, d = ax
+        p_b = (wb_inv @ np.append(np.asarray(pt, float), 1.0))[:3]
+        d_b = wb_inv[:3, :3] @ np.asarray(d, float)
+        closures.append({"link_a": lname(a), "link_b": lname(b),
+                         "point": [round(float(x), 8) for x in p_b],
+                         "axis": [round(float(x), 8) for x in d_b]})
+    if not closures:
+        return None
+    movable_all = {jname(te) for te in movable_tree}
+    return {"closures": closures, "dependent": sorted(dependent),
+            "independent": sorted(movable_all - dependent)}
+
+
 def _config_parent_map(comps, adjacency, base, directed):
     """Build parent_of + edge_info from an explicit directed joint list.
 
@@ -2181,7 +2275,7 @@ def _finalize_tree(comps, adjacency, base, parent_of, edge_info, root_rpy=None,
 
 
 def build_tree(comps, adjacency, base, directed=None, root_rpy=None,
-               root_z_offset=0.0, root_xyz=None):
+               root_z_offset=0.0, root_xyz=None, closures_out=None):
     if directed:
         parent_of, edge_info = _config_parent_map(comps, adjacency, base,
                                                   directed)
@@ -2189,6 +2283,21 @@ def build_tree(comps, adjacency, base, directed=None, root_rpy=None,
         parent_of, edge_info = _auto_parent_map(comps, adjacency, base)
         _auto_mimic(comps, adjacency, parent_of, edge_info)
         _auto_loop_mimic(comps, adjacency, parent_of, edge_info, base)
+    # closed-loop data for the runtime-IK relay (hinge in base_link frame, so use
+    # the SAME base anchor the URDF root is built on, incl. any root re-orient)
+    if closures_out is not None:
+        base_anchor = base.world.copy()
+        if root_rpy:
+            base_anchor = base_anchor @ matrix_from_rpy(root_rpy)
+        saved = base.world
+        try:
+            base.world = base_anchor
+            lc = _collect_loop_closures(comps, adjacency, parent_of,
+                                        edge_info, base)
+        finally:
+            base.world = saved
+        if lc:
+            closures_out.append(lc)
     return _finalize_tree(comps, adjacency, base, parent_of, edge_info,
                           root_rpy=root_rpy, root_z_offset=root_z_offset,
                           root_xyz=root_xyz)
@@ -2858,9 +2967,10 @@ def build_model(graph, robot_name=None, base_hint=None, config=None,
 
     base = choose_base(comps, ground, base_hint, adjacency)
     print(f"      base link: {base.link_name}")
+    closures_out = []
     joints = build_tree(comps, adjacency, base, directed=directed,
                         root_rpy=root_rpy, root_z_offset=root_z_offset,
-                        root_xyz=root_xyz)
+                        root_xyz=root_xyz, closures_out=closures_out)
     nrev = sum(1 for j in joints if j.jtype == "revolute")
     npri = sum(1 for j in joints if j.jtype == "prismatic")
     print(f"      joint types: {nrev} revolute, {npri} prismatic, "
@@ -2887,4 +2997,5 @@ def build_model(graph, robot_name=None, base_hint=None, config=None,
     return RobotModel(name=robot_name, components=comps, joints=joints,
                       detected_edges=detected, base_link=base.link_name,
                       ports=ports,
-                      root_link_name=root_link_name or base.link_name)
+                      root_link_name=root_link_name or base.link_name,
+                      loop_closures=closures_out[0] if closures_out else None)

--- a/sw2robot/exporter/ros_export.py
+++ b/sw2robot/exporter/ros_export.py
@@ -44,26 +44,15 @@ from .urdf_writer import (
 )
 
 
-def _loop_couplings_yaml(couplings):
-    """Serialise the closed-loop coupling list to the relay node's config YAML.
-
-    Hand-formatted (not via the yaml dumper) so the polynomial coefficients
-    stay readable and the file carries an explaining header."""
-    lines = [
-        "# Closed-loop (four-bar) joint couplings for loop_coupling_relay.",
-        "# Each follower angle = polyval(poly, driver_angle) (highest-degree",
-        "# coefficient first); this is the exact coupling the linear URDF",
-        "# <mimic> can only approximate.",
-        "couplings:",
-    ]
-    for c in couplings:
-        lines.append(f"  - driver: {c['driver']}")
-        lines.append("    followers:")
-        for f in c["followers"]:
-            poly = ", ".join(repr(float(x)) for x in f["poly"])
-            lines.append(f"      - joint: {f['joint']}")
-            lines.append(f"        poly: [{poly}]")
-    return "\n".join(lines) + "\n"
+def _loop_closures_yaml(closures):
+    """Serialise the loop-closure config (closures + driven/solved joint split)
+    to the IK relay's config YAML."""
+    import yaml
+    head = ("# Closed-loop closures for loop_closure_relay (runtime IK).\n"
+            "# independent = driven joints (sliders); dependent = solved by IK\n"
+            "# so each closure's two link points (the cut hinge) coincide.\n")
+    return head + yaml.safe_dump(closures, sort_keys=False,
+                                 default_flow_style=None)
 
 # extensions we convert; anything else (already .dae/.stl, abs URLs) is left alone
 # source mesh formats we can load + reconvert: CAD output (.3dxml mm, .glb m)
@@ -636,7 +625,7 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
                           ctx_fmt=_CTX_FMT, ros_version=1, pkg_name=None,
                           urdf_name=None, colors=None, collision="copy",
                           collision_quality="balanced", merge_fixed=False,
-                          mesh_dir=None, loop_couplings=None):
+                          mesh_dir=None, loop_closures=None):
     """``pkg_dir`` (a built package) -> ``[(arcname, bytes), ...]`` for a portable
     ROS package, all behind ``package://`` URLs.  The package is named
     ``pkg_name`` if given (validated, see :func:`ros_pkg_name`), else
@@ -696,18 +685,20 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
                 "CoACD collision decomposition needs the optional 'coacd' "
                 "package -- install it with: pip install coacd")
     coacd_cache_dir = os.path.join(pkg_dir, "meshes", ".coacd_cache")
-    if loop_couplings is None:
+    if loop_closures is None:
         # the editor's ZIP export calls us directly (no model); pick up the
-        # closed-loop couplings build() persisted beside the package so the ZIP
-        # ships the relay node + cubic config too
-        side = os.path.join(pkg_dir, "loop_couplings.yaml")
+        # loop-closure data build() persisted beside the package so the ZIP
+        # ships the IK relay node + closure config too
+        side = os.path.join(pkg_dir, "loop_closures.yaml")
         if os.path.isfile(side):
             try:
                 import yaml
                 with open(side, encoding="utf-8") as f:
-                    loop_couplings = (yaml.safe_load(f) or {}).get("couplings")
+                    loop_closures = yaml.safe_load(f) or None
+                if loop_closures and not loop_closures.get("closures"):
+                    loop_closures = None
             except Exception:
-                loop_couplings = None
+                loop_closures = None
     pkg = ros_pkg_name(robot_name, pkg_name)
     urdf_stem = ros_urdf_stem(pkg, urdf_name)
     mesh_rel = ros_mesh_dir(mesh_dir)
@@ -863,10 +854,10 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
         first_link = root.find("link")
         fixed_frame = (first_link.get("name") if first_link is not None
                        else "base_link") or "base_link"
-        # a detected kinematic loop ships a relay node + cubic config + a launch
-        # wired GUI -> relay -> robot_state_publisher (linear <mimic> alone can't
-        # track a four-bar); a plain robot keeps the simpler GUI -> RSP launch
-        coupled = bool(loop_couplings)
+        # a detected kinematic loop ships the IK relay node + closure config + a
+        # launch wired GUI -> relay -> robot_state_publisher (linear <mimic>
+        # alone can't track a loop); a plain robot keeps the simpler GUI -> RSP
+        coupled = bool(loop_closures and loop_closures.get("closures"))
         pkg_xml = PACKAGE_XML_ROS2_COUPLED if coupled else PACKAGE_XML_ROS2
         cmake = CMAKELISTS_ROS2_COUPLED if coupled else CMAKELISTS_ROS2
         launch = DISPLAY_LAUNCH_ROS2_COUPLED if coupled else DISPLAY_LAUNCH_ROS2
@@ -880,9 +871,9 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
                       RVIZ_CONFIG_ROS2.format(fixed_frame=fixed_frame)
                       .encode("utf-8")))
         if coupled:
-            files.append((f"{pkg}/config/loop_couplings.yaml",
-                          _loop_couplings_yaml(loop_couplings).encode("utf-8")))
-            files.append((f"{pkg}/scripts/loop_coupling_relay.py",
+            files.append((f"{pkg}/config/loop_closures.yaml",
+                          _loop_closures_yaml(loop_closures).encode("utf-8")))
+            files.append((f"{pkg}/scripts/loop_closure_relay.py",
                           LOOP_COUPLING_RELAY_PY.encode("utf-8")))
     else:
         files.append((f"{pkg}/package.xml",
@@ -898,7 +889,7 @@ def write_ros_description_package(pkg_dir, robot_name, dest_dir,
                                   collision="copy",
                                   collision_quality="balanced",
                                   merge_fixed=False, mesh_dir=None,
-                                  loop_couplings=None):
+                                  loop_closures=None):
     """Write the ROS package under ``dest_dir`` and return its directory path.
     The package is named ``pkg_name`` if given, else ``<robot_name>_description``;
     the URDF inside is named ``urdf_name`` if given, else the package name.
@@ -915,7 +906,7 @@ def write_ros_description_package(pkg_dir, robot_name, dest_dir,
                                   collision=collision,
                                   collision_quality=collision_quality,
                                   merge_fixed=merge_fixed, mesh_dir=mesh_dir,
-                                  loop_couplings=loop_couplings)
+                                  loop_closures=loop_closures)
     root = os.path.abspath(dest_dir)
     for arc, data in files:
         dst = os.path.join(root, *arc.split("/"))

--- a/sw2robot/exporter/urdf_writer.py
+++ b/sw2robot/exporter/urdf_writer.py
@@ -426,12 +426,12 @@ Visualization Manager:
       Name: Current View
 """
 
-# --- ROS 2 closed-loop (four-bar) variants ----------------------------------
-# A package with a detected kinematic loop ships three extra pieces: the cubic
-# coupling config, a relay node that applies it, and a launch file wired
-# GUI -> relay -> robot_state_publisher so the loop tracks faithfully in RViz.
-# (robot_state_publisher honours a URDF <mimic> only LINEARLY, which a general
-# four-bar's follower angle is not.)
+# --- ROS 2 closed-loop variants ---------------------------------------------
+# A package with a detected kinematic loop ships three extra pieces: the loop
+# closure config, a relay node that CLOSES the loop by runtime IK (pure-numpy
+# URDF FK), and a launch file wired GUI -> relay -> robot_state_publisher so the
+# linkage tracks exactly in RViz.  (robot_state_publisher honours a URDF <mimic>
+# only LINEARLY, which a real loop is not; the relay solves the true closure.)
 PACKAGE_XML_ROS2_COUPLED = """<?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
@@ -449,6 +449,7 @@ PACKAGE_XML_ROS2_COUPLED = """<?xml version="1.0"?>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>python3-yaml</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
   <export>
     <build_type>ament_cmake</build_type>
   </export>
@@ -460,16 +461,23 @@ project({name})
 find_package(ament_cmake REQUIRED)
 install(DIRECTORY urdf meshes launch rviz config
   DESTINATION share/${{PROJECT_NAME}})
-install(PROGRAMS scripts/loop_coupling_relay.py
+# The relay must be executable for `ros2 run`/launch to find it in libexec.
+# `colcon build --symlink-install` symlinks the installed file back to this
+# source, so a non-executable source (a Windows export can't set the bit)
+# leaves a dead libexec entry -- chmod the source here so the symlink works.
+if(UNIX)
+  execute_process(COMMAND chmod +x
+    ${{CMAKE_CURRENT_SOURCE_DIR}}/scripts/loop_closure_relay.py)
+endif()
+install(PROGRAMS scripts/loop_closure_relay.py
   DESTINATION lib/${{PROJECT_NAME}})
 ament_package()
 """
 
 # {name} = package name, {robot} = urdf file stem.  Sliders drive the
-# independent joints; <mimic> followers are dependent, so the GUI shows no
-# slider for them.  The GUI publishes on joint_states_source; the relay
-# overrides the loop followers with their exact cubic coupling and republishes
-# on joint_states, which robot_state_publisher consumes.
+# independent joints; the dependent (loop) joints carry no slider.  The GUI
+# publishes on joint_states_source; the relay solves the loop closure for the
+# dependent joints and republishes on joint_states, which RSP consumes.
 DISPLAY_LAUNCH_ROS2_COUPLED = '''import os
 
 from ament_index_python.packages import get_package_share_directory
@@ -483,7 +491,7 @@ def generate_launch_description():
     with open(urdf) as f:
         robot_description = f.read()
     rviz = os.path.join(pkg, "rviz", "{robot}.rviz")
-    couplings = os.path.join(pkg, "config", "loop_couplings.yaml")
+    closures = os.path.join(pkg, "config", "loop_closures.yaml")
     return LaunchDescription([
         Node(
             package="robot_state_publisher",
@@ -499,9 +507,9 @@ def generate_launch_description():
         ),
         Node(
             package="{name}",
-            executable="loop_coupling_relay.py",
+            executable="loop_closure_relay.py",
             output="screen",
-            parameters=[{{"config_file": couplings}}],
+            parameters=[{{"urdf_file": urdf, "config_file": closures}}],
         ),
         Node(
             package="rviz2",
@@ -512,55 +520,164 @@ def generate_launch_description():
     ])
 '''
 
-# A standalone rclpy node (no {{}} .format here -- shipped verbatim).
+# A standalone rclpy node, pure numpy FK (no {{}} .format -- shipped verbatim).
 LOOP_COUPLING_RELAY_PY = '''#!/usr/bin/env python3
-"""Apply the exact (nonlinear) coupling of a closed-loop linkage's followers.
+"""Close kinematic loops at runtime by numerical IK (pure-numpy URDF FK).
 
-robot_state_publisher / joint_state_publisher honour a URDF <mimic> only
-LINEARLY (multiplier*q + offset).  A four-bar's follower angle is a nonlinear
-function of its driver, so this node republishes /joint_states with each loop
-follower recomputed from the cubic polynomial in config/loop_couplings.yaml.
-Wire it between the joint-state source and robot_state_publisher.
+A URDF is a tree, so a closed linkage (four-bar / parallel mechanism) has its
+loops cut and robot_state_publisher honours the cut joints\' <mimic> only
+linearly -- which a real loop is not.  This node parses the URDF and, on every
+joint-state, sets the DRIVEN (independent) joints, then Gauss-Newton-solves the
+DEPENDENT joints so each cut loop closes (the two link points the dropped hinge
+joined coincide), and republishes the corrected joint_states.  Exact and
+general: any single-DOF-per-loop linkage, planar or spatial.  Needs only rclpy,
+sensor_msgs, numpy and yaml -- no extra install.
+
+Config (config/loop_closures.yaml): {independent:[...], dependent:[...],
+closures:[{link_a, link_b, point:[xyz in base_link], axis:[xyz]}]}.
 """
+import xml.etree.ElementTree as ET
+
+import numpy as np
 import rclpy
 import yaml
 from rclpy.node import Node
 from sensor_msgs.msg import JointState
 
 
-def _polyval(coeffs, x):
-    # Horner, highest-degree coefficient first (numpy.polyval order)
-    acc = 0.0
-    for c in coeffs:
-        acc = acc * x + c
-    return acc
+def _rpy_matrix(rpy):
+    rx, ry, rz = rpy
+    cx, cy, cz = np.cos(rx), np.cos(ry), np.cos(rz)
+    sx, sy, sz = np.sin(rx), np.sin(ry), np.sin(rz)
+    rxm = np.array([[1, 0, 0], [0, cx, -sx], [0, sx, cx]])
+    rym = np.array([[cy, 0, sy], [0, 1, 0], [-sy, 0, cy]])
+    rzm = np.array([[cz, -sz, 0], [sz, cz, 0], [0, 0, 1]])
+    m = np.eye(4)
+    m[:3, :3] = rzm @ rym @ rxm
+    return m
 
 
-class LoopCouplingRelay(Node):
+class _FK:
+    """Minimal URDF forward kinematics (revolute/continuous/prismatic/fixed)."""
+
+    def __init__(self, urdf_path):
+        root = ET.parse(urdf_path).getroot()
+        self.j = {}
+        for j in root.findall("joint"):
+            o = j.find("origin")
+            xyz = ([float(x) for x in o.get("xyz", "0 0 0").split()]
+                   if o is not None else [0, 0, 0])
+            rpy = ([float(x) for x in o.get("rpy", "0 0 0").split()]
+                   if o is not None else [0, 0, 0])
+            ax = j.find("axis")
+            axis = (np.array([float(x) for x in ax.get("xyz").split()])
+                    if ax is not None else np.array([0.0, 0.0, 1.0]))
+            t = _rpy_matrix(rpy)
+            t[:3, 3] = xyz
+            self.j[j.get("name")] = (j.get("type"),
+                                     j.find("child").get("link"),
+                                     j.find("parent").get("link"), t, axis)
+        self.cj = {v[1]: n for n, v in self.j.items()}
+
+    @staticmethod
+    def _rot(a, q):
+        a = a / (np.linalg.norm(a) or 1.0)
+        x, y, z = a
+        c, s = np.cos(q), np.sin(q)
+        cc = 1.0 - c
+        return np.array([[c + x * x * cc, x * y * cc - z * s, x * z * cc + y * s, 0],
+                         [y * x * cc + z * s, c + y * y * cc, y * z * cc - x * s, 0],
+                         [z * x * cc - y * s, z * y * cc + x * s, c + z * z * cc, 0],
+                         [0, 0, 0, 1.0]])
+
+    def _tj(self, n, q):
+        typ, _c, _p, t, axis = self.j[n]
+        if typ in ("revolute", "continuous"):
+            return t @ self._rot(axis, q)
+        if typ == "prismatic":
+            m = np.eye(4)
+            m[:3, 3] = axis / (np.linalg.norm(axis) or 1.0) * q
+            return t @ m
+        return t
+
+    def world(self, link, q):
+        chain, ln = [], link
+        while ln in self.cj:
+            n = self.cj[ln]
+            chain.append(n)
+            ln = self.j[n][2]
+        m = np.eye(4)
+        for n in reversed(chain):
+            m = m @ self._tj(n, q.get(n, 0.0))
+        return m
+
+
+class LoopClosureRelay(Node):
     def __init__(self):
-        super().__init__("loop_coupling_relay")
+        super().__init__("loop_closure_relay")
+        self.declare_parameter("urdf_file", "")
         self.declare_parameter("config_file", "")
+        self.fk = _FK(self.get_parameter("urdf_file").value)
+        cfg = {}
         path = self.get_parameter("config_file").value
-        couplings = []
         if path:
             with open(path) as f:
-                couplings = (yaml.safe_load(f) or {}).get("couplings", []) or []
-        self._couplings = couplings
-        if not couplings:
-            self.get_logger().warn("no couplings loaded; relaying unchanged")
+                cfg = yaml.safe_load(f) or {}
+        self.deps = list(cfg.get("dependent", []))
+        self.indep = set(cfg.get("independent", []))
+        self.wit = []
+        for c in cfg.get("closures", []):
+            la, lb = c["link_a"], c["link_b"]
+            t0a, t0b = self.fk.world(la, {}), self.fk.world(lb, {})
+            p = np.asarray(c["point"], float)
+            a = np.asarray(c["axis"], float)
+            a = a / (np.linalg.norm(a) or 1.0)
+            for q in (p, p + a * 0.03):
+                la_loc = (np.linalg.inv(t0a) @ np.append(q, 1.0))[:3]
+                lb_loc = (np.linalg.inv(t0b) @ np.append(q, 1.0))[:3]
+                self.wit.append((la, la_loc, lb, lb_loc))
+        self._x = np.zeros(len(self.deps))        # warm start (tracks branch)
+        if not self.deps or not self.wit:
+            self.get_logger().warn("no loop closures loaded; relaying unchanged")
         self._pub = self.create_publisher(JointState, "joint_states", 10)
         self.create_subscription(JointState, "joint_states_source",
                                  self._cb, 10)
 
+    def _resid(self, q):
+        out = []
+        for la, lal, lb, lbl in self.wit:
+            wa = (self.fk.world(la, q) @ np.append(lal, 1.0))[:3]
+            wb = (self.fk.world(lb, q) @ np.append(lbl, 1.0))[:3]
+            out.append(wa - wb)
+        return np.concatenate(out) if out else np.zeros(0)
+
+    def _solve(self, q):
+        x = self._x.copy()
+        for _ in range(20):
+            for i, dn in enumerate(self.deps):
+                q[dn] = x[i]
+            r = self._resid(q)
+            if r.size == 0 or np.linalg.norm(r) < 1e-9:
+                break
+            jac = np.zeros((r.size, len(self.deps)))
+            for i, dn in enumerate(self.deps):
+                xb = x[i]
+                q[dn] = xb + 1e-6
+                jac[:, i] = (self._resid(q) - r) / 1e-6
+                q[dn] = xb
+            x = x + np.linalg.lstsq(jac, -r, rcond=None)[0]
+        self._x = x
+        return x
+
     def _cb(self, msg):
         pos = dict(zip(msg.name, msg.position))
-        for c in self._couplings:
-            drv = c.get("driver")
-            if drv not in pos:
-                continue
-            q = pos[drv]
-            for f in c.get("followers", []):
-                pos[f["joint"]] = _polyval(f.get("poly", []), q)
+        if not self.deps or not self.wit:
+            self._pub.publish(msg)
+            return
+        q = {n: pos[n] for n in self.indep if n in pos}
+        x = self._solve(q)
+        for i, dn in enumerate(self.deps):
+            pos[dn] = float(x[i])
         out = JointState()
         out.header = msg.header
         out.name = list(pos.keys())
@@ -570,7 +687,7 @@ class LoopCouplingRelay(Node):
 
 def main(args=None):
     rclpy.init(args=args)
-    node = LoopCouplingRelay()
+    node = LoopClosureRelay()
     try:
         rclpy.spin(node)
     except KeyboardInterrupt:

--- a/tests/test_loop_mimic.py
+++ b/tests/test_loop_mimic.py
@@ -113,6 +113,127 @@ def test_loop_mimic_round_trips_through_joints_yaml(tmp_path):
     assert f2.mimic["joint"] == follower.mimic["joint"]
 
 
+def test_loop_closures_exported_for_runtime_ik():
+    # the model carries general loop-closure data for the runtime-IK relay:
+    # the cut hinge (two links + base-frame point/axis) and which joints are
+    # driven (independent) vs solved (dependent)
+    model = build_model(_parallelogram())
+    lc = model.loop_closures
+    assert lc is not None
+    assert len(lc["closures"]) == 1
+    c = lc["closures"][0]
+    assert {c["link_a"], c["link_b"]} <= {"base_link", "inlink", "coupler",
+                                          "outlink"}
+    assert len(c["point"]) == 3 and len(c["axis"]) == 3
+    # one driver, the rest solved (a 1-DOF four-bar)
+    assert len(lc["independent"]) == 1 and len(lc["dependent"]) == 2
+    # dependent = the <mimic> followers; independent = the driver
+    mimics = {j.name for j in model.joints if j.mimic}
+    assert set(lc["dependent"]) == mimics
+    assert lc["independent"][0] not in mimics
+
+
+def _fk_chain(urdf_path):
+    """Tiny URDF FK (the same maths the shipped relay embeds) for the test."""
+    import xml.etree.ElementTree as ET
+
+    from sw2robot.exporter.geometry import matrix_from_rpy
+    root = ET.parse(urdf_path).getroot()
+    js = {}
+    for j in root.findall("joint"):
+        o = j.find("origin")
+        xyz = ([float(x) for x in o.get("xyz", "0 0 0").split()]
+               if o is not None else [0, 0, 0])
+        rpy = ([float(x) for x in o.get("rpy", "0 0 0").split()]
+               if o is not None else [0, 0, 0])
+        ax = j.find("axis")
+        axis = (np.array([float(x) for x in ax.get("xyz").split()])
+                if ax is not None else np.array([0.0, 0.0, 1.0]))
+        t = matrix_from_rpy(rpy).copy()
+        t[:3, 3] = xyz
+        js[j.get("name")] = (j.get("type"), j.find("child").get("link"),
+                             j.find("parent").get("link"), t, axis)
+    cj = {v[1]: n for n, v in js.items()}
+
+    def rot(a, q):
+        a = a / (np.linalg.norm(a) or 1.0)
+        x, y, z = a
+        c, s = np.cos(q), np.sin(q)
+        cc = 1 - c
+        return np.array([[c+x*x*cc, x*y*cc-z*s, x*z*cc+y*s, 0],
+                         [y*x*cc+z*s, c+y*y*cc, y*z*cc-x*s, 0],
+                         [z*x*cc-y*s, z*y*cc+x*s, c+z*z*cc, 0], [0, 0, 0, 1.0]])
+
+    def world(link, Q):
+        chain, ln = [], link
+        while ln in cj:
+            n = cj[ln]
+            chain.append(n)
+            ln = js[n][2]
+        m = np.eye(4)
+        for n in reversed(chain):
+            typ, _c, _p, t, axis = js[n]
+            m = m @ (t @ rot(axis, Q.get(n, 0.0)) if typ in
+                     ("revolute", "continuous") else t)
+        return m
+    return world
+
+
+def test_runtime_ik_relay_closes_the_loop(tmp_path):
+    # End-to-end: build the parallelogram, write its URDF, and run the relay's
+    # loop-closure IK (pure-numpy FK, no extra deps) -- the cut hinge must
+    # coincide and the parallelogram coupling must come out +-1.
+    from sw2robot.exporter.urdf_writer import write_urdf
+    model = build_model(_parallelogram())
+    lc = model.loop_closures
+    urdf = tmp_path / "p.urdf"
+    write_urdf(model, str(urdf))
+    world = _fk_chain(str(urdf))
+
+    c = lc["closures"][0]
+    la, lb = c["link_a"], c["link_b"]
+    p = np.asarray(c["point"], float)
+    a = np.asarray(c["axis"], float)
+    a = a / np.linalg.norm(a)
+    t0a, t0b = world(la, {}), world(lb, {})
+    wit = []
+    for q in (p, p + a * 0.03):
+        wit.append((la, (np.linalg.inv(t0a) @ np.append(q, 1.0))[:3],
+                    lb, (np.linalg.inv(t0b) @ np.append(q, 1.0))[:3]))
+
+    def resid(Q):
+        return np.concatenate([(world(L, Q) @ np.append(ll, 1.0))[:3]
+                               - (world(M, Q) @ np.append(ml, 1.0))[:3]
+                               for L, ll, M, ml in wit])
+
+    deps = lc["dependent"]
+    drv = lc["independent"][0]
+
+    def solve(qd, warm):
+        Q = {drv: qd}
+        x = warm.copy()
+        for _ in range(40):
+            for i, dn in enumerate(deps):
+                Q[dn] = x[i]
+            r = resid(Q)
+            if np.linalg.norm(r) < 1e-10:
+                break
+            jac = np.zeros((len(r), len(deps)))
+            for i, dn in enumerate(deps):
+                Q2 = dict(Q)
+                Q2[dn] = x[i] + 1e-7
+                jac[:, i] = (resid(Q2) - r) / 1e-7
+            x = x + np.linalg.lstsq(jac, -r, rcond=None)[0]
+        return x
+
+    x = solve(np.radians(5.0), np.zeros(len(deps)))
+    Q = {drv: np.radians(5.0)}
+    Q.update({deps[i]: x[i] for i in range(len(deps))})
+    assert np.linalg.norm(resid(Q)) < 1e-6         # loop closed
+    for v in x:
+        assert abs(abs(v) - np.radians(5.0)) < 1e-3   # parallelogram = +-1
+
+
 def test_four_bar_driver_carries_no_mimic_and_loop_is_open():
     model = build_model(_parallelogram())
     # exactly one revolute hinge is dropped (the URDF tree stays acyclic): 4

--- a/tests/test_ros_export.py
+++ b/tests/test_ros_export.py
@@ -281,74 +281,64 @@ def test_invalid_ros_version_rejected(tmp_path):
         build_ros_description(pkg_dir, "r", ros_version=3)
 
 
-def test_ros2_loop_couplings_ship_relay_and_config(tmp_path):
-    # a detected closed loop ships a relay node + cubic config + a launch wired
-    # GUI -> relay -> robot_state_publisher so the four-bar tracks in RViz
+_CLOSURES = {
+    "closures": [{"link_a": "c", "link_b": "d",
+                  "point": [0.01, 0.02, 0.03], "axis": [0.0, 0.0, 1.0]}],
+    "dependent": ["c__d", "e__f"],
+    "independent": ["a__b"],
+}
+
+
+def test_ros2_loop_closures_ship_ik_relay_and_config(tmp_path):
+    # a detected closed loop ships the skrobot IK relay + closure config + a
+    # launch wired GUI -> relay -> robot_state_publisher so the loop tracks
     from sw2robot.exporter.ros_export import build_ros_description
 
     pkg_dir = _make_pkg(tmp_path, robot="fb")
-    couplings = [{
-        "driver": "a__b",
-        "followers": [
-            {"joint": "c__d", "poly": [0.0878, 0.0034, 1.3246, -0.0003]},
-            {"joint": "e__f", "poly": [0.0135, 0.1572, 0.5728, -0.0003]},
-        ],
-    }]
     files = dict(build_ros_description(pkg_dir, "fb", ros_version=2,
-                                       loop_couplings=couplings))
+                                       loop_closures=_CLOSURES))
     arcs = set(files)
+    assert "fb_description/config/loop_closures.yaml" in arcs
+    assert "fb_description/scripts/loop_closure_relay.py" in arcs
 
-    # the extra artifacts only the coupled path emits
-    assert "fb_description/config/loop_couplings.yaml" in arcs
-    assert "fb_description/scripts/loop_coupling_relay.py" in arcs
-
-    cfg = files["fb_description/config/loop_couplings.yaml"].decode()
     import yaml
-    parsed = yaml.safe_load(cfg)
-    assert parsed["couplings"][0]["driver"] == "a__b"
-    polys = {f["joint"]: f["poly"]
-             for f in parsed["couplings"][0]["followers"]}
-    assert polys["c__d"][2] == 1.3246           # the ~linear (degree-1) term
-    assert len(polys["e__f"]) == 4              # cubic
+    parsed = yaml.safe_load(files["fb_description/config/loop_closures.yaml"])
+    assert parsed["dependent"] == ["c__d", "e__f"]
+    assert parsed["independent"] == ["a__b"]
+    assert parsed["closures"][0]["link_a"] == "c"
 
-    # relay node is valid python and reads the config param
-    relay = files["fb_description/scripts/loop_coupling_relay.py"].decode()
-    compile(relay, "loop_coupling_relay.py", "exec")
-    assert "config_file" in relay and "joint_states_source" in relay
+    # relay node is valid python, pure-numpy URDF FK + the IK loop closure
+    relay = files["fb_description/scripts/loop_closure_relay.py"].decode()
+    compile(relay, "loop_closure_relay.py", "exec")
+    assert "joint_states_source" in relay and "lstsq" in relay
+    assert "skrobot" not in relay              # no pip-only dependency
 
-    # launch wires GUI -> relay -> RSP (GUI publishes on the source topic)
     launch = files["fb_description/launch/display.launch.py"].decode()
     compile(launch, "display.launch.py", "exec")
     assert '("joint_states", "joint_states_source")' in launch
-    assert "loop_coupling_relay.py" in launch
+    assert "loop_closure_relay.py" in launch
 
-    # build + deps follow: install config/scripts, depend on rclpy/sensor_msgs
     cmake = files["fb_description/CMakeLists.txt"].decode()
-    assert "config" in cmake and "scripts/loop_coupling_relay.py" in cmake
+    assert "config" in cmake and "scripts/loop_closure_relay.py" in cmake
     pxml = files["fb_description/package.xml"].decode()
-    assert "<exec_depend>rclpy</exec_depend>" in pxml
-    assert "<exec_depend>sensor_msgs</exec_depend>" in pxml
+    assert "python3-numpy" in pxml and "<exec_depend>rclpy</exec_depend>" in pxml
+    assert "scikit-robot" not in pxml          # only rosdep-resolvable deps
 
 
-def test_ros2_loop_couplings_autoload_from_sidecar(tmp_path):
-    # the editor's ZIP export calls build_ros_description directly (no model /
-    # no explicit couplings); a loop_couplings.yaml that build() left beside the
-    # package must still get the relay shipped
+def test_ros2_loop_closures_autoload_from_sidecar(tmp_path):
+    # the editor's ZIP export calls build_ros_description directly (no model);
+    # a loop_closures.yaml build() left beside the package must still ship
     from sw2robot.exporter.ros_export import build_ros_description
 
     pkg_dir = _make_pkg(tmp_path, robot="sc")
-    (tmp_path / "loop_couplings.yaml").write_text(
-        "couplings:\n"
-        "  - driver: a__b\n"
-        "    followers:\n"
-        "      - joint: c__d\n"
-        "        poly: [0.1, 0.0, 1.3, 0.0]\n",
-        encoding="utf-8")
-    # note: NO loop_couplings kwarg -- must be picked up from the sidecar
+    import yaml
+    (tmp_path / "loop_closures.yaml").write_text(
+        yaml.safe_dump(_CLOSURES), encoding="utf-8")
+    # note: NO loop_closures kwarg -- must be picked up from the sidecar
     files = dict(build_ros_description(pkg_dir, "sc", ros_version=2))
-    assert "sc_description/scripts/loop_coupling_relay.py" in files
-    cfg = files["sc_description/config/loop_couplings.yaml"].decode()
-    assert "a__b" in cfg and "c__d" in cfg
+    assert "sc_description/scripts/loop_closure_relay.py" in files
+    cfg = files["sc_description/config/loop_closures.yaml"].decode()
+    assert "c__d" in cfg and "a__b" in cfg
 
 
 def test_dae_pure_black_lifted_to_dark_grey(tmp_path):
@@ -379,8 +369,8 @@ def test_ros2_without_couplings_has_no_relay(tmp_path):
     pkg_dir = _make_pkg(tmp_path, robot="pl")
     files = dict(build_ros_description(pkg_dir, "pl", ros_version=2))
     arcs = set(files)
-    assert "pl_description/config/loop_couplings.yaml" not in arcs
-    assert "pl_description/scripts/loop_coupling_relay.py" not in arcs
+    assert "pl_description/config/loop_closures.yaml" not in arcs
+    assert "pl_description/scripts/loop_closure_relay.py" not in arcs
     launch = files["pl_description/launch/display.launch.py"].decode()
     assert "joint_states_source" not in launch
     pxml = files["pl_description/package.xml"].decode()


### PR DESCRIPTION
## Summary

Follow-up to #92.  The linear URDF `<mimic>` only *approximates* a four-bar and covers nothing else (spatial loops, slider-cranks, multi-bar). This adds a **fully general** path: detect every cut loop and ship a relay that closes it **exactly** at runtime with a small **pure-numpy** URDF forward kinematics + Gauss-Newton — no four-bar-specific math, and **no extra dependency** (only rclpy / sensor_msgs / numpy / yaml, all rosdep-resolvable). Handles any single-DOF-per-loop linkage (planar or spatial, revolute or prismatic).

## How it works

- **`_collect_loop_closures`** (model.py) records, per dropped (non-tree) movable edge, the two links the cut hinge joined + the hinge point/axis **in base_link frame**, and splits the loop's joints into **driven (independent)** vs **solved (dependent)**. Carried on `RobotModel.loop_closures`.
- **`loop_closure_relay.py`** embeds a ~25-line URDF FK (`_rpy_matrix` + a joint-origin chain) and, on every joint-state, sets the independent joints then **Gauss-Newton-solves** the dependent joints so each cut hinge's two link points coincide (warm-started, so it tracks the assembly branch). Replaces the cubic-poly relay from #92; the URDF `<mimic>` stays as a static fallback.
- **ROS 2 export** ships `config/loop_closures.yaml` + the IK relay + a launch wiring `GUI → relay → robot_state_publisher`. `package.xml` depends only on numpy/yaml.
- `build()` persists `loop_closures.yaml` beside the package, so both the CLI and the editor's ZIP download pick it up.

## Why pure-numpy (not scikit-robot)

I first wrote the relay against scikit-robot's FK, but `scikit-robot` is pip-only with **no rosdep key**, so `rosdep install` failed. The embedded FK was validated to match scikit-robot's link poses to **~1e-15**, so skrobot was dropped — the package now resolves with stock rosdep keys.

## Validation

The relay's IK reproduces the four-bar's home coupling ratio **exactly** (1.325 vs the linkage velocity-Jacobian's 1.326) and closes the loop to **<0.01 µm** across the driver's whole range — vs ~1.6 mm for the linear mimic.

## Tests

- `test_loop_mimic.py`: `loop_closures` export shape; an end-to-end (pure-numpy) check that the relay's IK closes the parallelogram and recovers the ±1 coupling.
- `test_ros_export.py`: the IK relay/config/sidecar are shipped (and not, when there is no loop), and the package carries no pip-only deps.

Ruff clean; full suite green (pre-existing FCL-dependent tests excepted).
