### PR TITLE
fix: loop-closure IK flips assembly branch at the toggle / on big jumps

### DIFF
--- a/sw2robot/exporter/urdf_writer.py
+++ b/sw2robot/exporter/urdf_writer.py
@@ -527,9 +527,10 @@ LOOP_COUPLING_RELAY_PY = '''#!/usr/bin/env python3
 A URDF is a tree, so a closed linkage (four-bar / parallel mechanism) has its
 loops cut and robot_state_publisher honours the cut joints\' <mimic> only
 linearly -- which a real loop is not.  This node parses the URDF and, on every
-joint-state, sets the DRIVEN (independent) joints, then Gauss-Newton-solves the
-DEPENDENT joints so each cut loop closes (the two link points the dropped hinge
-joined coincide), and republishes the corrected joint_states.  Exact and
+joint-state, sets the DRIVEN (independent) joints, then solves (damped
+least-squares, sub-stepped to stay on the assembly branch) the DEPENDENT joints
+so each cut loop closes (the two link points the dropped hinge joined coincide),
+and republishes the corrected joint_states.  Exact and
 general: any single-DOF-per-loop linkage, planar or spatial.  Needs only rclpy,
 sensor_msgs, numpy and yaml -- no extra install.
 
@@ -637,6 +638,7 @@ class LoopClosureRelay(Node):
                 lb_loc = (np.linalg.inv(t0b) @ np.append(q, 1.0))[:3]
                 self.wit.append((la, la_loc, lb, lb_loc))
         self._x = np.zeros(len(self.deps))        # warm start (tracks branch)
+        self._indep_prev = None                   # previous driven-joint values
         if not self.deps or not self.wit:
             self.get_logger().warn("no loop closures loaded; relaying unchanged")
         self._pub = self.create_publisher(JointState, "joint_states", 10)
@@ -652,20 +654,36 @@ class LoopClosureRelay(Node):
         return np.concatenate(out) if out else np.zeros(0)
 
     def _solve(self, q):
-        x = self._x.copy()
-        for _ in range(20):
+        x0 = self._x.copy()
+        x = x0.copy()
+        n = len(self.deps)
+        for _ in range(50):
             for i, dn in enumerate(self.deps):
                 q[dn] = x[i]
             r = self._resid(q)
-            if r.size == 0 or np.linalg.norm(r) < 1e-9:
+            if r.size == 0 or np.linalg.norm(r) < 1e-10:
                 break
-            jac = np.zeros((r.size, len(self.deps)))
+            jac = np.zeros((r.size, n))
             for i, dn in enumerate(self.deps):
                 xb = x[i]
                 q[dn] = xb + 1e-6
                 jac[:, i] = (self._resid(q) - r) / 1e-6
                 q[dn] = xb
-            x = x + np.linalg.lstsq(jac, -r, rcond=None)[0]
+            # damped least squares (Levenberg-Marquardt) + a step clamp keep the
+            # solver on the CURRENT assembly branch: near a singularity (a
+            # four-bar toggle) plain Gauss-Newton jumps/spins to the other mode
+            dx = np.linalg.solve(jac.T @ jac + 1e-6 * np.eye(n), -jac.T @ r)
+            s = float(np.linalg.norm(dx))
+            if s > 0.15:
+                dx *= 0.15 / s
+            x = x + dx
+        # at / past a toggle the loop has NO solution; rather than accept a
+        # diverged (wrapped) config that warm-start would then lock in forever,
+        # hold the last valid pose -- the linkage just stops at its limit
+        for i, dn in enumerate(self.deps):
+            q[dn] = x[i]
+        if np.linalg.norm(self._resid(q)) > 1e-5:
+            x = x0
         self._x = x
         return x
 
@@ -674,8 +692,22 @@ class LoopClosureRelay(Node):
         if not self.deps or not self.wit:
             self._pub.publish(msg)
             return
-        q = {n: pos[n] for n in self.indep if n in pos}
-        x = self._solve(q)
+        target = {n: pos[n] for n in self.indep if n in pos}
+        # SUB-STEP the driven joints from their previous values: a big jump (a
+        # fast slider drag, or clicking a far value) solved in one shot walks to
+        # the WRONG assembly branch and sticks; stepping it in small increments
+        # keeps the warm-started solver on the current branch.
+        prev = self._indep_prev if self._indep_prev is not None else target
+        maxd = max((abs(target[k] - prev.get(k, target[k])) for k in target),
+                   default=0.0)
+        steps = max(1, int(maxd / 0.05))          # ~3 deg per sub-step
+        x = self._x
+        for s in range(1, steps + 1):
+            f = s / steps
+            q = {k: prev.get(k, target[k])
+                 + (target[k] - prev.get(k, target[k])) * f for k in target}
+            x = self._solve(q)
+        self._indep_prev = dict(target)
         for i, dn in enumerate(self.deps):
             pos[dn] = float(x[i])
         out = JointState()

--- a/tests/test_loop_mimic.py
+++ b/tests/test_loop_mimic.py
@@ -66,6 +66,24 @@ def _parallelogram():
     return _graph([base, inl, cpl, outl], edges, ground=["base"])
 
 
+def _crank_rocker():
+    # a NON-parallelogram four-bar (unequal bars) -> a triple rocker that BINDS
+    # at a toggle within its travel, the case where a naive IK flips assembly
+    # branch.  Pivots A,B,C,D (m).
+    A, B, C, D = (0, 0, 0), (0.4, 0.4, 0), (1.2, 0.7, 0), (1.5, 0, 0)
+    base = _comp("base", fixed=True)
+    inl = _comp("inlink", A)
+    cpl = _comp("coupler", B)
+    outl = _comp("outlink", C)
+    edges = [
+        _hinge_z("base", "inlink", A),
+        _hinge_z("inlink", "coupler", B),
+        _hinge_z("coupler", "outlink", C),
+        _hinge_z("outlink", "base", D),
+    ]
+    return _graph([base, inl, cpl, outl], edges, ground=["base"])
+
+
 def test_four_bar_loop_becomes_driver_plus_two_mimics():
     model = build_model(_parallelogram())
     rev = [j for j in model.joints if j.jtype == "revolute"]
@@ -232,6 +250,83 @@ def test_runtime_ik_relay_closes_the_loop(tmp_path):
     assert np.linalg.norm(resid(Q)) < 1e-6         # loop closed
     for v in x:
         assert abs(abs(v) - np.radians(5.0)) < 1e-3   # parallelogram = +-1
+
+
+def test_runtime_ik_relay_holds_at_toggle_no_branch_flip(tmp_path):
+    # A non-parallelogram four-bar BINDS at a toggle.  Driving the driver out
+    # PAST the toggle and back must NOT flip the assembly branch / spin the
+    # dependent joints (the bug): the relay's damped + step-clamped solve holds
+    # the last valid pose past the toggle and tracks back to zero.
+    from sw2robot.exporter.urdf_writer import write_urdf
+    model = build_model(_crank_rocker())
+    lc = model.loop_closures
+    urdf = tmp_path / "cr.urdf"
+    write_urdf(model, str(urdf))
+    world = _fk_chain(str(urdf))
+    c = lc["closures"][0]
+    la, lb = c["link_a"], c["link_b"]
+    p = np.asarray(c["point"], float)
+    a = np.asarray(c["axis"], float) / np.linalg.norm(c["axis"])
+    t0a, t0b = world(la, {}), world(lb, {})
+    wit = [(la, (np.linalg.inv(t0a) @ np.append(q, 1.0))[:3],
+            lb, (np.linalg.inv(t0b) @ np.append(q, 1.0))[:3])
+           for q in (p, p + a * 0.03)]
+
+    def resid(Q):
+        return np.concatenate([(world(L, Q) @ np.append(ll, 1.0))[:3]
+                               - (world(M, Q) @ np.append(ml, 1.0))[:3]
+                               for L, ll, M, ml in wit])
+
+    deps = lc["dependent"]
+    drv = lc["independent"][0]
+
+    def solve(qd, warm):                       # == the shipped relay's _solve
+        x0 = warm.copy()
+        x = x0.copy()
+        nd = len(deps)
+        Q = {drv: qd}
+        for _ in range(50):
+            for i, dn in enumerate(deps):
+                Q[dn] = x[i]
+            r = resid(Q)
+            if np.linalg.norm(r) < 1e-10:
+                break
+            jac = np.zeros((len(r), nd))
+            for i, dn in enumerate(deps):
+                Q2 = dict(Q)
+                Q2[dn] = x[i] + 1e-7
+                jac[:, i] = (resid(Q2) - r) / 1e-7
+            dx = np.linalg.solve(jac.T @ jac + 1e-6 * np.eye(nd), -jac.T @ r)
+            s = float(np.linalg.norm(dx))
+            if s > 0.15:
+                dx *= 0.15 / s
+            x = x + dx
+        for i, dn in enumerate(deps):
+            Q[dn] = x[i]
+        if np.linalg.norm(resid(Q)) > 1e-5:    # can't close -> hold last valid
+            return x0
+        return x
+
+    # drive in BIG jumps per callback (a fast slider drag / clicking a far
+    # value) -- the case that flips: each callback sub-steps the driver like the
+    # relay's _cb, out well past the toggle and back to zero
+    state = {"warm": np.zeros(len(deps)), "prev": None}
+
+    def step(qd):
+        prev = state["prev"] if state["prev"] is not None else qd
+        nsub = max(1, int(abs(qd - prev) / 0.05))
+        for k in range(1, nsub + 1):
+            state["warm"] = solve(prev + (qd - prev) * k / nsub, state["warm"])
+        state["prev"] = qd
+        return state["warm"]
+
+    peak = 0.0
+    for qd in (0.0, 1.4, -1.4, 1.4, 0.7, 0.0):     # big jumps incl past toggle
+        peak = max(peak, float(np.max(np.abs(step(qd)))))
+    # never wrapped/spun (a flip sends deps to many radians), and it came back
+    assert peak < 2.5, f"dependent joints spun ({peak} rad) -- branch flip"
+    assert np.max(np.abs(state["warm"])) < 1e-3, \
+        "did not return to home after the toggle"
 
 
 def test_four_bar_driver_carries_no_mimic_and_loop_is_open():

--- a/tests/test_ros_export.py
+++ b/tests/test_ros_export.py
@@ -310,7 +310,7 @@ def test_ros2_loop_closures_ship_ik_relay_and_config(tmp_path):
     # relay node is valid python, pure-numpy URDF FK + the IK loop closure
     relay = files["fb_description/scripts/loop_closure_relay.py"].decode()
     compile(relay, "loop_closure_relay.py", "exec")
-    assert "joint_states_source" in relay and "lstsq" in relay
+    assert "joint_states_source" in relay and "_resid" in relay
     assert "skrobot" not in relay              # no pip-only dependency
 
     launch = files["fb_description/launch/display.launch.py"].decode()


### PR DESCRIPTION
## The bug

With the runtime loop-closure relay, the dependent joints could flip to the **other assembly branch and never return** in two cases:

1. Driving the driver to ~`0.628` (its limit, near the four-bar toggle) and back.
2. **Jumping the driver a long way in one callback** — a fast slider drag, or clicking a far slider value.

Root causes (reproduced on the surgenoid loop):
- **Past the toggle the loop has no solution.** Plain Gauss-Newton diverges — the dependent joints spin to thousands of degrees (observed 2176°) — and warm-start locks that wrapped pose in.
- **A single large Newton step walks straight onto the other branch.** A big jump `0→36°` in one solve landed at `[48°, 56°]` (wrong branch, also closes) instead of the correct `[26°, 50°]`, and stuck.

## The fix (relay `_solve` + `_cb`)

- **Damped least squares (Levenberg-Marquardt) + per-iteration step clamp** — a step can't jump/spin across the toggle to the other branch.
- **Sub-step the driven joints** from their previous values each callback, so a big jump is tracked as many small warm-started steps and stays on the current branch.
- **Hold the last valid pose** when the loop can't close (at/past the toggle), instead of accepting the diverged config — the linkage stops at its limit and tracks straight back when the driver returns.

After the fix, every scenario (smooth sweep, big jump `0→36→0`, `+36→−36→+36`, oscillation near the limit, driving past the toggle) returns to the correct pose with no spin and no flip.

## Test

`test_runtime_ik_relay_holds_at_toggle_no_branch_flip`: a non-parallelogram crank-rocker (binds at a toggle within travel) is driven in **big jumps** out past the toggle and back; the dependent joints stay bounded (no wrap/flip) and return to zero.

Ruff clean; full suite green (pre-existing FCL-dependent tests excepted).
