### PR TITLE
feat: one-liner curl|bash to build + launch the ROS 2 package

### DIFF
--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -738,6 +738,15 @@ joints.yaml -- keeping your types/renames/base. Use it to pick up the couplings
 on a package that was extracted before the feature existed (a re-extract reuses
 the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect mimic</button>
       </div>
+      <!-- one-liner: build + launch the ROS 2 package on a ROS box (curl|bash) -->
+      <div style="margin-top:6px">
+        <div style="color:#8a93a3;font-size:10px;margin-bottom:2px"
+             data-i18n="ui.launchit">🚀 build + launch on a ROS 2 machine (curl | bash):</div>
+        <code id="launchitcmd" title="copies to clipboard"
+              style="display:block;background:#15171a;color:#8fd99f;border:1px solid #2d4a35;
+                     border-radius:3px;padding:4px 6px;font-size:10px;cursor:pointer;
+                     overflow-x:auto;white-space:nowrap"></code>
+      </div>
     </div>
     <div id="hint" data-i18n="ui.hint">left-drag: 視点回転 · right-drag: pan · wheel: zoom ·
       クリックでリンク選択 · 関節はパネルのスライダーで操作
@@ -1254,6 +1263,9 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     't.selexclude': { en: 'exclude from the URDF (adds to yaml exclude:, Ctrl+Z to undo)',
                       ja: 'URDFから除外する (yaml exclude: に追加、Ctrl+Zで戻る)' },
     'ui.redetectmimic': { en: '🔗 re-detect mimic', ja: '🔗 mimic再検出' },
+    'ui.launchit': { en: '🚀 build + launch on a ROS 2 machine (curl | bash):',
+                     ja: '🚀 ROS 2マシンでビルド＆起動 (curl | bash):' },
+    'launchit.copied': { en: 'copied — run it on your ROS 2 box', ja: 'コピーしました — ROS 2マシンで実行' },
     't.redetectmimic': { en: 'auto-detect closed-loop (four-bar) couplings from the CAD graph and merge them into joints.yaml (keeps your edits)',
                          ja: 'CADグラフから閉ループ(四節)のmimicを自動検出し、joints.yamlにマージ（編集は保持）' },
     'redetect.start': { en: 're-detecting closed-loop couplings …', ja: '閉ループmimicを再検出中 …' },
@@ -4579,6 +4591,30 @@ async function redetectMimic() {
 }
 document.getElementById('redetectmimic')
   ?.addEventListener('click', redetectMimic);
+
+// one-liner that downloads the ROS 2 package zip, colcon-builds it and brings
+// up display.launch.py on a ROS 2 machine (served by /api/launch_it.sh)
+(function () {
+  const el = document.getElementById('launchitcmd');
+  if (!el) { return; }
+  // Robust across WSL networking modes (and a LAN box) without the user caring:
+  // try the browser's host, then localhost (mirrored WSL / same machine), then
+  // the WSL2 NAT gateway -- the first that responds wins, and launch_it.sh
+  // derives its zip URL from that same host, so it all stays consistent.
+  const port = location.port || '8090';
+  const lh = 'localhost:' + port;
+  const gw = `$(ip route show default 2>/dev/null|awk '{print $3}'):${port}`;
+  const hosts = (location.host === lh) ? [lh, gw] : [location.host, lh, gw];
+  const cmd = 'bash <(' + hosts.map(
+    h => `curl -fs http://${h}/api/launch_it.sh`).join(' || ') + ')';
+  el.textContent = cmd;
+  el.addEventListener('click', async () => {
+    try {
+      await navigator.clipboard.writeText(cmd);
+      log(t('launchit.copied'), 'ok');
+    } catch (e) { /* clipboard blocked -- user can still select the text */ }
+  });
+})();
 
 // ---- 3D hover: name the link under the cursor, R = make it root,
 // double-click = jump to its row in the tree -------------------------------

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -4597,16 +4597,19 @@ document.getElementById('redetectmimic')
 (function () {
   const el = document.getElementById('launchitcmd');
   if (!el) { return; }
-  // Robust across WSL networking modes (and a LAN box) without the user caring:
-  // try the browser's host, then localhost (mirrored WSL / same machine), then
-  // the WSL2 NAT gateway -- the first that responds wins, and launch_it.sh
-  // derives its zip URL from that same host, so it all stays consistent.
+  // Works in any shell (bash / zsh / fish) AND across WSL networking modes,
+  // without the user caring: the outer shell only sees `bash -c '...' | bash`
+  // (no process substitution), and the host detection runs inside that bash.
+  // It tries the browser host, then localhost (mirrored WSL / same machine),
+  // then the WSL2 NAT gateway; the first that responds wins, and launch_it.sh
+  // derives its zip URL from that same host so the whole flow stays consistent.
   const port = location.port || '8090';
   const lh = 'localhost:' + port;
-  const gw = `$(ip route show default 2>/dev/null|awk '{print $3}'):${port}`;
-  const hosts = (location.host === lh) ? [lh, gw] : [location.host, lh, gw];
-  const cmd = 'bash <(' + hosts.map(
-    h => `curl -fs http://${h}/api/launch_it.sh`).join(' || ') + ')';
+  const heads = (location.host === lh) ? [lh] : [location.host, lh];
+  const hostList = heads.join(' ')
+    + ` $(ip route show default 2>/dev/null | cut -d" " -f3):${port}`;
+  const cmd = `bash -c 'for H in ${hostList}; do `
+    + `curl -fs http://$H/api/launch_it.sh && break; done' | bash`;
   el.textContent = cmd;
   el.addEventListener('click', async () => {
     try {

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -519,22 +519,27 @@ def _read_root_pose(txt):
 #   curl -s http://<host>/api/launch_it.sh | bash
 _LAUNCH_IT_SH = r"""#!/bin/bash
 set -e
-G='\033[0;32m'; N='\033[0m'
+G='\033[0;32m'; R='\033[0;31m'; N='\033[0m'
 PKG="{pkg}"
 ZIP_URL="{zip_url}"
-echo -e "${{G}}sw2robot: build + launch ${{PKG}}${{N}}"
+# safety: PKG must be a plain package name (never empty, a slash or '..'), so the
+# scoped removals below can only ever touch <ws>/{{src,build,install}}/$PKG
+case "$PKG" in ""|*/*|*..*) echo -e "${{R}}refusing: unsafe package name${{N}}"; exit 1 ;; esac
 WS="$(pwd)/${{PKG}}_ws"
-[ -d "$WS" ] && echo "wiping $WS" && rm -rf "$WS"
+echo -e "${{G}}sw2robot: build + launch ${{PKG}}${{N}}  ($WS)"
 mkdir -p "$WS/src"
+# replace ONLY this package (never wipe the whole workspace) -- any other
+# packages or files you keep in ${{PKG}}_ws are left untouched
+rm -rf "$WS/src/$PKG" "$WS/build/$PKG" "$WS/install/$PKG"
 cd "$WS"
 echo -e "${{G}}downloading package zip ...${{N}}"
 code=$(curl -sSL -w "%{{http_code}}" -o robot.zip "$ZIP_URL")
-if [ "$code" != "200" ]; then echo "download failed (HTTP $code)"; cat robot.zip; exit 1; fi
-( cd src && unzip -oq ../robot.zip ) && rm robot.zip
+if [ "$code" != "200" ]; then echo -e "${{R}}download failed (HTTP $code)${{N}}"; cat robot.zip; rm -f robot.zip; exit 1; fi
+( cd src && unzip -oq ../robot.zip ) && rm -f robot.zip
 source "/opt/ros/${{ROS_DISTRO:-humble}}/setup.bash"
 echo -e "${{G}}rosdep + colcon build ...${{N}}"
 rosdep install --from-paths src --ignore-src -r -y 2>/dev/null || true
-colcon build --symlink-install
+colcon build --symlink-install --packages-select "$PKG"
 source install/setup.bash
 echo -e "${{G}}launching display.launch.py ...${{N}}"
 exec ros2 launch "$PKG" display.launch.py

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -514,6 +514,33 @@ def _read_root_pose(txt):
             float(m.group(1)) if m else 0.0)
 
 
+# Build-and-launch one-liner (robot-compiler style).  {pkg} = ROS 2 package
+# name, {zip_url} = this server's /api/export/zip URL.  Run with:
+#   curl -s http://<host>/api/launch_it.sh | bash
+_LAUNCH_IT_SH = r"""#!/bin/bash
+set -e
+G='\033[0;32m'; N='\033[0m'
+PKG="{pkg}"
+ZIP_URL="{zip_url}"
+echo -e "${{G}}sw2robot: build + launch ${{PKG}}${{N}}"
+WS="$(pwd)/${{PKG}}_ws"
+[ -d "$WS" ] && echo "wiping $WS" && rm -rf "$WS"
+mkdir -p "$WS/src"
+cd "$WS"
+echo -e "${{G}}downloading package zip ...${{N}}"
+code=$(curl -sSL -w "%{{http_code}}" -o robot.zip "$ZIP_URL")
+if [ "$code" != "200" ]; then echo "download failed (HTTP $code)"; cat robot.zip; exit 1; fi
+( cd src && unzip -oq ../robot.zip ) && rm robot.zip
+source "/opt/ros/${{ROS_DISTRO:-humble}}/setup.bash"
+echo -e "${{G}}rosdep + colcon build ...${{N}}"
+rosdep install --from-paths src --ignore-src -r -y 2>/dev/null || true
+colcon build --symlink-install
+source install/setup.bash
+echo -e "${{G}}launching display.launch.py ...${{N}}"
+exec ros2 launch "$PKG" display.launch.py
+"""
+
+
 def _export_zip(pkg_dir, robot_name, mesh_fmt="dae", ros_version=1,
                 pkg_name=None, urdf_name=None, colors=None,
                 collision="copy", collision_quality="balanced",
@@ -2008,6 +2035,30 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 self.send_header("Content-Length", str(len(data)))
                 self.end_headers()
                 self.wfile.write(data)
+                return None
+            if path == "/api/launch_it.sh":
+                # one-liner build+launch (robot-compiler style):
+                #   curl -s http://<host>/api/launch_it.sh | bash
+                # downloads the ROS 2 package zip from /api/export/zip, builds it
+                # with colcon and brings up display.launch.py
+                cls = type(self)
+                if not cls.pkg_dir:
+                    return self._send_json({"error": "no package open"}, 400)
+                from sw2robot.exporter.ros_export import ros_pkg_name
+                pkg_name = (query.get("name") or [""])[0].strip() or None
+                pkg = ros_pkg_name(cls.robot_name, pkg_name)
+                host = self.headers.get("Host") or "localhost:8090"
+                zip_q = "ros=2&meshes=dae"
+                if pkg_name:
+                    zip_q += "&name=" + pkg_name
+                zip_url = f"http://{host}/api/export/zip?{zip_q}"
+                script = _LAUNCH_IT_SH.format(pkg=pkg, zip_url=zip_url)
+                body = script.encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "text/x-shellscript")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
                 return None
             if path == "/api/collision/coacd/init":
                 cls = type(self)


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/d8413bb2-901d-4be9-8d20-f0a7c919c750


Like robot-compiler's `launch_it.sh`, a single `curl | bash` builds and runs the exported ROS 2 package on a ROS 2 machine — and it works **whether you're on WSL (NAT or mirrored) or a LAN box, without thinking about which**.

## Endpoint

New GET **`/api/launch_it.sh`** returns a bash script that: makes a `<pkg>_ws` workspace, downloads the package zip from `/api/export/zip?ros=2`, `rosdep install` + `colcon build --symlink-install`, sources, and `ros2 launch <pkg> display.launch.py`. The zip URL is derived from the request **Host**, so it stays consistent with whatever host reached the editor.

## The one-liner (shown in the editor, click to copy)

```bash
bash <(curl -fs http://<browser-host>/api/launch_it.sh \
    || curl -fs http://localhost:8090/api/launch_it.sh \
    || curl -fs http://$(ip route show default|awk '{print $3}'):8090/api/launch_it.sh)
```

It tries, in order: the browser's host → `localhost` (mirrored WSL / same machine) → the **WSL2 NAT gateway**. The first that responds wins; because `launch_it.sh` builds its zip URL from that same host, the whole flow stays on one reachable host. So mode 1 (NAT) and mode 2 (mirrored) both just work.

## Validation

- Live test against a running editor: the one-liner fetched the script, downloaded the zip, and reached the build step (stopped only at `/opt/ros/...` since the test host has no ROS — on a ROS box it proceeds).
- Served script passes `bash -n`; the `||` host-fallback verified.
- Ruff clean; webserver/export tests green.

Note: if nothing happens, the editor port is likely blocked by Windows Firewall — allow it once:
`New-NetFirewallRule -DisplayName sw2robot-web -Direction Inbound -LocalPort 8090 -Protocol TCP -Action Allow`
