### PR TITLE
Fix mimic coupling when flipping a four-bar driver joint's axis

### DIFF
--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -949,6 +949,8 @@ def _flip_axis_in_urdf(pkg_dir, urdf_rel, joint_name):
     body = re.sub(r'<limit\b[^>]*?>', lim_repl, body)
 
     def mim_repl(mm):                             # follower stays in phase: negate both
+        # this joint is itself a FOLLOWER (q_f' = -q_f for its reversed axis):
+        # q_f = M*q_d + off  ->  q_f' = (-M)*q_d + (-off), so negate both
         seg = mm.group(0)
         for attr in ("multiplier", "offset"):
             a = re.search(rf'\b{attr}="([^"]*)"', seg)
@@ -958,8 +960,25 @@ def _flip_axis_in_urdf(pkg_dir, urdf_rel, joint_name):
         return seg
     body = re.sub(r'<mimic\b[^>]*?>', mim_repl, body)
 
+    full = txt[:m.start()] + head + body + tail + txt[m.end():]
+
+    # this joint may also be the DRIVER that OTHER joints mimic -- their
+    # <mimic joint="this"> tags live in THEIR blocks, not here, so flipping this
+    # joint's axis must negate each follower's multiplier (offset unchanged):
+    # q_f = M*q_d + off, and after q_d -> -q_d', q_f = (-M)*q_d' + off.
+    def drv_repl(mm):
+        seg = mm.group(0)
+        a = re.search(r'\bmultiplier="([^"]*)"', seg)
+        if a:
+            seg = re.sub(r'\bmultiplier="[^"]*"',
+                         f'multiplier="{_fmt_num(-float(a.group(1)))}"', seg)
+        return seg
+    full = re.sub(
+        r'<mimic\b[^>]*\bjoint="' + re.escape(joint_name) + r'"[^>]*>',
+        drv_repl, full)
+
     with open(path, "w", encoding="utf-8") as f:
-        f.write(txt[:m.start()] + head + body + tail + txt[m.end():])
+        f.write(full)
     return na
 
 

--- a/tests/test_loop_mimic.py
+++ b/tests/test_loop_mimic.py
@@ -338,3 +338,87 @@ def test_four_bar_driver_carries_no_mimic_and_loop_is_open():
     rev = [j for j in model.joints if j.jtype == "revolute"]
     driver = next(j for j in rev if not j.mimic)
     assert driver.mimic is None
+
+
+# --- flipping a joint's axis must keep the mimic coupling consistent ---------
+_MIMIC_URDF = '''<?xml version="1.0"?>
+<robot name="fb">
+  <link name="base_link"/>
+  <link name="L1"/><link name="L2"/><link name="L3"/>
+  <joint name="drv" type="revolute">
+    <parent link="base_link"/><child link="L1"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-0.3" upper="0.45" effort="0" velocity="0"/>
+  </joint>
+  <joint name="f1" type="revolute">
+    <parent link="L1"/><child link="L2"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-0.85" upper="0.88" effort="0" velocity="0"/>
+    <mimic joint="drv" multiplier="1.35269" offset="0.1"/>
+  </joint>
+  <joint name="f2" type="revolute">
+    <parent link="L1"/><child link="L3"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-0.3" upper="0.45" effort="0" velocity="0"/>
+    <mimic joint="drv" multiplier="0.581031" offset="0"/>
+  </joint>
+</robot>
+'''
+
+
+def _mults(txt):
+    import re
+    return {m.group(1): float(m.group(2)) for m in re.finditer(
+        r'<joint name="(f\d)".*?multiplier="([^"]*)".*?offset="([^"]*)"',
+        txt, re.DOTALL)}
+
+
+def _offsets(txt):
+    import re
+    return {m.group(1): float(m.group(2)) for m in re.finditer(
+        r'<joint name="(f\d)".*?offset="([^"]*)"', txt, re.DOTALL)}
+
+
+def _write(tmp_path):
+    (tmp_path / "urdf").mkdir(exist_ok=True)
+    (tmp_path / "urdf" / "fb.urdf").write_text(_MIMIC_URDF, encoding="utf-8")
+    return str(tmp_path)
+
+
+def test_flip_driver_negates_follower_multipliers(tmp_path):
+    """Flipping the DRIVER (master) joint must negate every follower's mimic
+    multiplier (offset unchanged), or the coupled links move the wrong way."""
+    from sw2robot.editor.webserver import _flip_axis_in_urdf
+    pkg = _write(tmp_path)
+    n = _flip_axis_in_urdf(pkg, "urdf/fb.urdf", "drv")
+    assert n == 1
+    txt = (tmp_path / "urdf" / "fb.urdf").read_text(encoding="utf-8")
+    # driver axis negated, limits swapped+negated
+    import re
+    drv = re.search(r'<joint name="drv".*?</joint>', txt, re.DOTALL).group(0)
+    assert 'xyz="0 0 -1"' in drv
+    assert 'lower="-0.45"' in drv and 'upper="0.3"' in drv
+    # followers: multiplier negated, offset kept
+    assert _mults(txt) == {"f1": -1.35269, "f2": -0.581031}
+    assert _offsets(txt) == {"f1": 0.1, "f2": 0.0}
+
+
+def test_flip_driver_is_self_inverse(tmp_path):
+    from sw2robot.editor.webserver import _flip_axis_in_urdf
+    pkg = _write(tmp_path)
+    _flip_axis_in_urdf(pkg, "urdf/fb.urdf", "drv")
+    _flip_axis_in_urdf(pkg, "urdf/fb.urdf", "drv")
+    after = (tmp_path / "urdf" / "fb.urdf").read_text(encoding="utf-8")
+    assert _mults(after) == {"f1": 1.35269, "f2": 0.581031}
+    assert _offsets(after) == {"f1": 0.1, "f2": 0.0}
+
+
+def test_flip_follower_negates_its_own_mimic(tmp_path):
+    """Flipping a FOLLOWER negates its OWN multiplier AND offset (its axis
+    reversed); the driver and the other follower are untouched."""
+    from sw2robot.editor.webserver import _flip_axis_in_urdf
+    pkg = _write(tmp_path)
+    _flip_axis_in_urdf(pkg, "urdf/fb.urdf", "f1")
+    txt = (tmp_path / "urdf" / "fb.urdf").read_text(encoding="utf-8")
+    assert _mults(txt) == {"f1": -1.35269, "f2": 0.581031}   # f2 untouched
+    assert _offsets(txt) == {"f1": -0.1, "f2": 0.0}          # f1 offset negated


### PR DESCRIPTION
## Problem

Flipping a servo (driver) joint's + direction in the editor made the coupled
four-bar links move the wrong way. On `surgenoid_needle_holder`, flipping
`XL_XC_330_1__small_needle_holder_link1_1` broke the `<mimic>` motion of the two
follower links.

## Cause

`_flip_axis_in_urdf` (the `/api/set_axis` path) negated the `<mimic>` tag only
inside the flipped joint's **own** block. That is right when the flipped joint
is a **follower** (its axis reversed → negate its own multiplier and offset).

But a four-bar **driver** carries no `<mimic>` tag — the followers reference it
from *their* blocks — so flipping the driver negated nothing, leaving the
followers' multipliers stale. With the driver's axis reversed but the
multipliers unchanged, the followers tracked the driver backwards and the loop
came apart.

## Fix

`_flip_axis_in_urdf` now also negates the `multiplier` of every
`<mimic joint="<flipped>">` elsewhere in the URDF (offset unchanged):

```
q_f = M·q_d + offset,   and after q_d → −q_d'   ⇒   q_f = (−M)·q_d' + offset
```

So the driver-flip case negates the multiplier (keeps offset); the existing
follower-flip case (negate its own multiplier *and* offset) is unchanged. The
operation stays self-inverse.

Scope note: the ROS 2 loop relay solves the closure by runtime IK and does not
use these multipliers (and the cubic `poly` lives only in `joints.yaml`, is not
shipped, and is not consumed at runtime), so no change is needed there.

## Testing

- New unit tests in `tests/test_loop_mimic.py`: driver-flip negates both
  followers' multipliers (offset kept) and is self-inverse; follower-flip
  negates only its own multiplier and offset.
- Verified end-to-end through the running web editor: `POST /api/set_axis` on
  the surgenoid servo toggles the follower multipliers (`±0.581`, `±1.353`)
  correctly.
- Full suite passes (the two pre-existing failures are unrelated — they need
  the optional `python-fcl` package).