### PR TITLE
Auto-detect the ROS 2 distro in the launch_it.sh one-liner

### DIFF
--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -536,7 +536,34 @@ echo -e "${{G}}downloading package zip ...${{N}}"
 code=$(curl -sSL -w "%{{http_code}}" -o robot.zip "$ZIP_URL")
 if [ "$code" != "200" ]; then echo -e "${{R}}download failed (HTTP $code)${{N}}"; cat robot.zip; rm -f robot.zip; exit 1; fi
 ( cd src && unzip -oq ../robot.zip ) && rm -f robot.zip
-source "/opt/ros/${{ROS_DISTRO:-humble}}/setup.bash"
+# pick a ROS 2 distro: an already-sourced $ROS_DISTRO wins; else choose by the
+# Ubuntu release (focal->foxy, jammy->humble, noble->jazzy) when that distro is
+# installed, else fall back to whatever is under /opt/ros.  (Hard-coding humble
+# broke `curl | bash` on any non-22.04 box -- no /opt/ros/humble there.)
+ros_setup=""
+if [ -n "$ROS_DISTRO" ] && [ -f "/opt/ros/$ROS_DISTRO/setup.bash" ]; then
+  ros_setup="/opt/ros/$ROS_DISTRO/setup.bash"
+else
+  codename=$(. /etc/os-release 2>/dev/null && echo "$VERSION_CODENAME")
+  case "$codename" in
+    focal) cand=foxy ;;
+    jammy) cand=humble ;;
+    noble) cand=jazzy ;;
+    *)     cand= ;;
+  esac
+  if [ -n "$cand" ] && [ -f "/opt/ros/$cand/setup.bash" ]; then
+    ros_setup="/opt/ros/$cand/setup.bash"
+  else
+    for s in /opt/ros/*/setup.bash; do
+      if [ -f "$s" ]; then ros_setup="$s"; break; fi
+    done
+  fi
+fi
+if [ -z "$ros_setup" ]; then
+  echo -e "${{R}}no ROS 2 found under /opt/ros -- install ROS 2 (or source it) first${{N}}"; exit 1
+fi
+echo -e "${{G}}using ROS: $ros_setup${{N}}"
+source "$ros_setup"
 echo -e "${{G}}rosdep + colcon build ...${{N}}"
 rosdep install --from-paths src --ignore-src -r -y 2>/dev/null || true
 colcon build --symlink-install --packages-select "$PKG"


### PR DESCRIPTION
## Problem

Running the build-and-launch one-liner without first sourcing a ROS environment
failed on anything that isn't Ubuntu 22.04:

```
$ curl -fs http://<host>/api/launch_it.sh | bash
...
bash: line 20: /opt/ros/humble/setup.bash: No such file or directory
```

The script sourced `/opt/ros/${ROS_DISTRO:-humble}/setup.bash`, so an unset
`ROS_DISTRO` (the normal case for `curl | bash`) defaulted to **humble**, which
only exists on 22.04.

## Fix

Pick the distro instead of hard-coding one:

1. An already-set `$ROS_DISTRO` (a sourced environment) wins.
2. Otherwise choose by the Ubuntu release — `focal→foxy`, `jammy→humble`,
   `noble→jazzy` — when that distro is installed.
3. Otherwise fall back to whatever is under `/opt/ros`.
4. If nothing is found, exit with a clear message.

## Testing

- Template renders and `bash -n` passes; `ruff` is clean.
- Simulated the selection across combinations: jammy→humble, noble→jazzy,
  noble-with-only-humble→fallback humble, focal→foxy, preset `$ROS_DISTRO`
  wins, unknown codename→fallback, and nothing-installed→clear error.