### PR TITLE
Feat/visual mesh format

### DIFF
--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -734,21 +734,40 @@ colour-coded) on top of the visual meshes.">
           <span data-i18n="ui.mergefixed">merge fixed links</span>
         </label>
       </div>
+      <div style="display:flex;gap:6px;align-items:center;margin-bottom:4px;flex-wrap:wrap">
+        <span style="color:#8a93a3;min-width:54px" data-i18n="ui.expvisfmt">visual</span>
+        <select id="expvisfmt" data-i18n-title="t.expvisfmt"
+                title="visual mesh format. dae = colour COLLADA (RViz/Gazebo).
+stl = plain STL; colour is emitted as a URDF <material> (override, else the mesh's
+own colour). glb = colour kept in the mesh (three.js / native-mesh; not RViz-loadable)."
+                style="background:#15171a;color:#cfe3ff;border:1px solid #2d4a35;
+                       border-radius:3px;padding:2px 4px;font-size:11px">
+          <option value="dae">dae</option>
+          <option value="stl">stl</option>
+          <option value="glb">glb</option>
+        </select>
+        <span style="color:#8a93a3" data-i18n="ui.expcolfmt">collision</span>
+        <select id="expcolfmt" data-i18n-title="t.expcolfmt"
+                title="collision mesh format (independent of visual). stl is the ROS
+convention; glb for native-mesh consumers. (CoACD always emits stl parts.)"
+                style="background:#15171a;color:#cfe3ff;border:1px solid #2d4a35;
+                       border-radius:3px;padding:2px 4px;font-size:11px">
+          <option value="stl">stl</option>
+          <option value="glb">glb</option>
+        </select>
+      </div>
       <div style="display:flex;gap:4px;flex-wrap:wrap;align-items:center">
-        <a id="expdae" href="/api/export/zip?meshes=dae&ros=1" download>
+        <a id="expdae" href="/api/export/zip?ros=1" download>
           <button data-i18n="ui.expdae" data-i18n-title="t.expdae"
-                  title="portable ROS 1 (catkin) package (<name>_description): package://
-URLs, visual = colour COLLADA .dae, collision = .stl (loads in RViz/Gazebo)">
+                  title="portable ROS 1 (catkin) package (<name>_description):
+package:// URLs, meshes in the chosen format">
             ⬇ ROS1 package</button></a>
-        <a id="expros2" href="/api/export/zip?meshes=dae&ros=2" download>
+        <a id="expros2" href="/api/export/zip?ros=2" download>
           <button data-i18n="ui.expros2" data-i18n-title="t.expros2"
                   title="portable ROS 2 (ament_cmake) package (<name>_description):
-package:// URLs, .dae/.stl meshes, plus launch/display.launch.py + rviz config
-(run: ros2 launch <name>_description display.launch.py)">
+package:// URLs, meshes in the chosen format, plus launch/display.launch.py + rviz
+config (run: ros2 launch <name>_description display.launch.py)">
             ⬇ ROS2 package</button></a>
-        <a id="expglb" href="/api/export/zip?meshes=glb&ros=1" download>
-          <button data-i18n-title="t.expglb" title="uniform .glb meshes (colour kept) for three.js /
-skrobot / native-mesh consumers (not RViz-loadable)">⬇ glb</button></a>
       </div>
       <div style="display:flex;gap:4px;flex-wrap:wrap;align-items:center;margin-top:4px">
         <button id="redetectmimic" data-i18n="ui.redetectmimic"
@@ -1365,14 +1384,18 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     'ui.expmeshdir': { en: 'mesh dir', ja: 'メッシュ' },
     't.expmeshdir': { en: "package-relative directory the meshes go in, and that the URDF's package:// refs point at (default 'meshes'). Set it to match a robot whose mesh layout differs, e.g. 'urdf/mesh'. A '/' makes subdirectories.",
                       ja: 'メッシュを置くパッケージ相対ディレクトリ。URDF の package:// 参照もここを指します（既定: meshes）。メッシュ配置がロボットによって異なる場合に設定（例: urdf/mesh）。/ でサブディレクトリ。' },
-    't.expdae': { en: 'portable ROS 1 (catkin) package (<name>_description): package:// URLs, visual = colour COLLADA .dae, collision = .stl (loads in RViz/Gazebo)',
-                  ja: 'ポータブルな ROS 1 (catkin) パッケージ (<name>_description): package:// URL、visual = カラー COLLADA .dae、collision = .stl（RViz/Gazebo で読込可）' },
+    'ui.expvisfmt': { en: 'visual', ja: 'ビジュアル' },
+    't.expvisfmt': { en: "visual mesh format. dae = colour COLLADA (RViz/Gazebo). stl = plain STL; colour is emitted as a URDF <material> (the override, else the mesh's own colour). glb = colour kept in the mesh (three.js / native-mesh; not RViz-loadable).",
+                     ja: 'ビジュアルメッシュ形式。dae = カラー COLLADA（RViz/Gazebo）。stl = STL；色は URDF <material> として出力（オーバーライド、なければメッシュ自身の色）。glb = 色をメッシュに保持（three.js / ネイティブメッシュ向け、RViz 不可）。' },
+    'ui.expcolfmt': { en: 'collision', ja: 'コリジョン' },
+    't.expcolfmt': { en: 'collision mesh format (independent of visual). stl is the ROS convention; glb for native-mesh consumers. (CoACD always emits stl parts.)',
+                     ja: 'コリジョンメッシュ形式（ビジュアルとは独立）。stl が ROS の慣例。glb はネイティブメッシュ向け。（CoACD は常に stl パーツを出力）。' },
+    't.expdae': { en: 'portable ROS 1 (catkin) package (<name>_description): package:// URLs, meshes in the chosen format (loads in RViz/Gazebo)',
+                  ja: 'ポータブルな ROS 1 (catkin) パッケージ (<name>_description): package:// URL、選択した形式のメッシュ（RViz/Gazebo で読込可）' },
     'ui.expdae': { en: '⬇ ROS1 package', ja: '⬇ ROS1 パッケージ' },
-    't.expros2': { en: 'portable ROS 2 (ament_cmake) package (<name>_description): package:// URLs, .dae/.stl meshes, plus launch/display.launch.py + rviz config (run: ros2 launch <name>_description display.launch.py)',
-                  ja: 'ポータブルな ROS 2 (ament_cmake) パッケージ (<name>_description): package:// URL、.dae/.stl メッシュ、launch/display.launch.py + rviz 設定付き（実行: ros2 launch <name>_description display.launch.py）' },
+    't.expros2': { en: 'portable ROS 2 (ament_cmake) package (<name>_description): package:// URLs, meshes in the chosen format, plus launch/display.launch.py + rviz config (run: ros2 launch <name>_description display.launch.py)',
+                  ja: 'ポータブルな ROS 2 (ament_cmake) パッケージ (<name>_description): package:// URL、選択した形式のメッシュ、launch/display.launch.py + rviz 設定付き（実行: ros2 launch <name>_description display.launch.py）' },
     'ui.expros2': { en: '⬇ ROS2 package', ja: '⬇ ROS2 パッケージ' },
-    't.expglb': { en: 'uniform .glb meshes (colour kept) for three.js / skrobot / native-mesh consumers (not RViz-loadable)',
-                  ja: '均一な .glb メッシュ（色は保持）three.js / skrobot / ネイティブメッシュ向け（RVizでは読込不可）' },
     'ui.coacd': { en: 'CoACD collision', ja: 'CoACD 衝突形状' },
     't.coacd': { en: 'Replace <collision> meshes with CoACD convex parts (what physics engines want). Slower: tens of seconds per link, but cached after the first run. Applies to the ROS1/ROS2 packages (not glb); needs the coacd package server-side.',
                  ja: '<collision> メッシュを CoACD の凸パーツ群に置き換えます（物理エンジン向け）。1リンクあたり数十秒と遅いですが、初回以降はキャッシュされます。ROS1/ROS2 パッケージのみ（glb は対象外）。サーバー側に coacd パッケージが必要です。' },
@@ -4256,8 +4279,10 @@ autolimitsBtn.addEventListener('click', async () => {
 const exppkg = document.getElementById('exppkg');
 const expurdf = document.getElementById('expurdf');
 const expmeshdir = document.getElementById('expmeshdir');
-const expLinks = ['expdae', 'expros2', 'expglb']
+const expLinks = ['expdae', 'expros2']
   .map(id => document.getElementById(id)).filter(Boolean);
+const expVisFmt = document.getElementById('expvisfmt');
+const expColFmt = document.getElementById('expcolfmt');
 function exportDefaultName() {
   // mirror the server: sanitise the assembly name to a valid ROS package name
   // ('Assem1' -> 'assem1_description') so the placeholder matches what ships
@@ -4513,22 +4538,23 @@ mergeViewBtn?.addEventListener('click', () => {
 });
 expLinks.forEach(a => a.addEventListener('click', async ev => {
   ev.preventDefault();
-  const base = a.getAttribute('href')
-    .split('&name=')[0].split('&urdf=')[0].split('&meshdir=')[0];
+  // mesh format is orthogonal to ROS version: the button picks the version,
+  // the selectors pick visual + collision format independently
+  const ros = a.id === 'expros2' ? 2 : 1;
+  const vfmt = expVisFmt?.value || 'dae';
+  const cfmt = expColFmt?.value || 'stl';
   const name = (exppkg?.value || '').trim();
   const urdf = (expurdf?.value || '').trim();
   const meshdir = (expmeshdir?.value || '').trim().replace(/^\/+|\/+$/g, '');
-  // coacd + merge-fixed apply to the ROS (.dae) packages, not the uniform glb
-  const coacd = a.id !== 'expglb' && !!coacdBox?.checked;
-  const mergeFixed = a.id !== 'expglb' && !!mergeFixedBox?.checked;
-  const url = base
+  const coacd = !!coacdBox?.checked;
+  const mergeFixed = !!mergeFixedBox?.checked;
+  const url = `/api/export/zip?ros=${ros}&meshes=${vfmt}&colfmt=${cfmt}`
     + (name ? `&name=${encodeURIComponent(name)}` : '')
     + (urdf ? `&urdf=${encodeURIComponent(urdf)}` : '')
     + (meshdir ? `&meshdir=${encodeURIComponent(meshdir)}` : '')
     + (coacd ? `&collision=coacd&cquality=${cqualitySel?.value || 'balanced'}` : '')
     + (mergeFixed ? '&mergefixed=1' : '');
-  const what = a.id === 'expglb' ? 'glb'
-    : a.id === 'expros2' ? 'ROS 2' : 'ROS 1';
+  const what = ros === 2 ? 'ROS 2' : 'ROS 1';
   showLoadbar(t('export.bar', { what }), { indet: true });
   log(t('export.start', { what }));
   try {

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -2029,15 +2029,16 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 cls = type(self)
                 if not cls.pkg_dir:
                     return self._send_json({"error": "no package open"}, 400)
-                visuaL_fmt = (query.get("meshes") or ["dae"])[0]
-                if visuaL_fmt not in ("dae", "stl", "glb"):
+                visual_fmt = (query.get("meshes") or ["dae"])[0]
+                if visual_fmt not in ("dae", "stl", "glb"):
                     return self._send_json(
-                        {"error": f"unsupported visual mesh format: {fmt}"}, 400)
+                        {"error": f"unsupported visual mesh format: {visual_fmt}"},
+                        400)
                 collision_fmt = (query.get("colfmt") or ["stl"])[0]
                 if collision_fmt not in ("stl", "glb"):
                     return self._send_json(
-                        {"error": f"unsupported collision mesh format: {colfmt}"},
-                        400)
+                        {"error": f"unsupported collision mesh format: "
+                         f"{collision_fmt}"}, 400)
                 ros = (query.get("ros") or ["1"])[0]
                 if ros not in ("1", "2"):
                     return self._send_json(
@@ -2074,7 +2075,7 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                               if _cad_mode(cls.pkg_dir)
                               else _um_colors(_um["state"]))
                     with _um_materialized(cls.pkg_dir, cls.urdf_rel):
-                        pkg, data = _export_zip(cls.pkg_dir, cls.robot_name, visuaL_fmt,
+                        pkg, data = _export_zip(cls.pkg_dir, cls.robot_name, visual_fmt,
                                                 collision_fmt,
                                                 ros_version=ros_version,
                                                 pkg_name=pkg_name,
@@ -2087,7 +2088,7 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 except ValueError as e:
                     return self._send_json({"error": str(e)}, 400)
                 fname = (f"{cls.robot_name}_glb.zip"
-                         if visuaL_fmt == "glb" and collision_fmt == "glb"
+                         if visual_fmt == "glb" and collision_fmt == "glb"
                          else f"{pkg}.zip")
                 self.send_response(200)
                 self.send_header("Content-Type", "application/zip")

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -573,35 +573,38 @@ exec ros2 launch "$PKG" display.launch.py
 """
 
 
-def _export_zip(pkg_dir, robot_name, mesh_fmt="dae", ros_version=1,
-                pkg_name=None, urdf_name=None, colors=None,
+def _export_zip(pkg_dir, robot_name, visual_fmt="dae", collision_fmt="stl",
+                ros_version=1, pkg_name=None, urdf_name=None, colors=None,
                 collision="copy", collision_quality="balanced",
                 merge_fixed=False, mesh_dir=None):
     """ZIP a portable ROS package (package:// URLs), named ``pkg_name`` if given
     else ``<robot_name>_description``; the URDF inside is named ``urdf_name`` if
     given, else the package name.
 
-    ``mesh_fmt='dae'`` (default): ``<visual>`` as colour COLLADA ``.dae`` +
-    ``<collision>`` as plain ``.stl`` -- the RViz/Gazebo-ready variant.
-    ``mesh_fmt='glb'``: a uniform ``.glb`` package (colour kept) for three.js /
-    skrobot / native-mesh consumers (not RViz-loadable).
+    ``visual_fmt`` (``dae`` default / ``stl`` / ``glb``) and ``collision_fmt``
+    (``stl`` default / ``glb``) pick the mesh format per context, independently.
+    ``dae`` visual keeps colour as COLLADA; ``stl`` visual is colourless, so the
+    per-link colour is emitted as a URDF ``<material>`` instead (RViz-friendly);
+    ``glb`` keeps colour in the mesh (three.js / native-mesh consumers; not
+    RViz-loadable).
 
     ``ros_version`` (1 = catkin, 2 = ament_cmake) selects the build files.
     Returns ``(pkg, bytes)`` so the caller can name the download after the
     actual package."""
-    if mesh_fmt not in ("dae", "glb"):
-        raise ValueError(f"unsupported mesh format: {mesh_fmt}")
+    if visual_fmt not in ("dae", "stl", "glb"):
+        raise ValueError(f"unsupported visual mesh format: {visual_fmt}")
+    if collision_fmt not in ("stl", "glb"):
+        raise ValueError(f"unsupported collision mesh format: {collision_fmt}")
 
     import io as _io
     import zipfile
 
     from sw2robot.exporter.ros_export import (
-        GLB_CTX_FMT,
         build_ros_description,
         ros_pkg_name,
     )
     pkg = ros_pkg_name(robot_name, pkg_name)
-    kwargs = {"ctx_fmt": GLB_CTX_FMT} if mesh_fmt == "glb" else {}
+    ctx_fmt = (("visual", visual_fmt), ("collision", collision_fmt))
     buf = _io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
         for arc, data in build_ros_description(pkg_dir, robot_name,
@@ -613,7 +616,7 @@ def _export_zip(pkg_dir, robot_name, mesh_fmt="dae", ros_version=1,
                                                collision_quality=collision_quality,
                                                merge_fixed=merge_fixed,
                                                mesh_dir=mesh_dir,
-                                               **kwargs):
+                                               ctx_fmt=ctx_fmt):
             # a node under scripts/ must extract executable (0755) so ament's
             # install(PROGRAMS) + `colcon build --symlink-install` leaves a
             # runnable libexec entry that `ros2 launch` can find
@@ -2026,10 +2029,15 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 cls = type(self)
                 if not cls.pkg_dir:
                     return self._send_json({"error": "no package open"}, 400)
-                fmt = (query.get("meshes") or ["dae"])[0]
-                if fmt not in ("dae", "glb"):
+                visuaL_fmt = (query.get("meshes") or ["dae"])[0]
+                if visuaL_fmt not in ("dae", "stl", "glb"):
                     return self._send_json(
-                        {"error": f"unsupported mesh format: {fmt}"}, 400)
+                        {"error": f"unsupported visual mesh format: {fmt}"}, 400)
+                collision_fmt = (query.get("colfmt") or ["stl"])[0]
+                if collision_fmt not in ("stl", "glb"):
+                    return self._send_json(
+                        {"error": f"unsupported collision mesh format: {colfmt}"},
+                        400)
                 ros = (query.get("ros") or ["1"])[0]
                 if ros not in ("1", "2"):
                     return self._send_json(
@@ -2066,7 +2074,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                               if _cad_mode(cls.pkg_dir)
                               else _um_colors(_um["state"]))
                     with _um_materialized(cls.pkg_dir, cls.urdf_rel):
-                        pkg, data = _export_zip(cls.pkg_dir, cls.robot_name, fmt,
+                        pkg, data = _export_zip(cls.pkg_dir, cls.robot_name, visuaL_fmt,
+                                                collision_fmt,
                                                 ros_version=ros_version,
                                                 pkg_name=pkg_name,
                                                 urdf_name=urdf_name,
@@ -2077,7 +2086,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                                                 mesh_dir=mesh_dir)
                 except ValueError as e:
                     return self._send_json({"error": str(e)}, 400)
-                fname = (f"{cls.robot_name}_glb.zip" if fmt == "glb"
+                fname = (f"{cls.robot_name}_glb.zip"
+                         if visuaL_fmt == "glb" and collision_fmt == "glb"
                          else f"{pkg}.zip")
                 self.send_response(200)
                 self.send_header("Content-Type", "application/zip")

--- a/sw2robot/exporter/ros_export.py
+++ b/sw2robot/exporter/ros_export.py
@@ -43,6 +43,10 @@ from .urdf_writer import (
     RVIZ_CONFIG_ROS2,
 )
 
+# fallback <material> colour for an STL <visual> with no per-link override (STL
+# carries no colour, so without this RViz would show the link in its default grey)
+_DEFAULT_VISUAL_RGBA = (191, 191, 191, 255)   # neutral light grey (~0.75)
+
 
 def _loop_closures_yaml(closures):
     """Serialise the loop-closure config (closures + driven/solved joint split)
@@ -732,6 +736,12 @@ def _collada_meshes(mesh):
     return out
 
 
+def _rgba_attr(rgba):
+    """uint8 ``[r,g,b,a]`` -> a URDF ``<color rgba>`` string of 0..1 floats."""
+    vals = [max(0.0, min(1.0, float(c) / 255.0)) for c in rgba]
+    return " ".join(f"{v:.4g}" for v in vals)
+
+
 def _dae_sidecar_images(dae_path):
     """Relative sidecar image paths a COLLADA ``.dae`` references via
     ``<init_from>`` (textures), so a verbatim copy can ship them too.  Best
@@ -1145,6 +1155,18 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
                         job_order.append(key)
                     mesh.set("filename",
                              f"package://{pkg}/{mesh_rel}/{job['name']}")
+                    # STL carries no colour, so a <visual> STL would render grey
+                    # in RViz.  Emit a URDF <material> instead: the per-link colour
+                    # override if set, else a default colour.  dae/glb keep their
+                    # colour in the mesh and get no <material>.
+                    if ctx == "visual" and fmt == "stl" \
+                            and block.find("material") is None:
+                        rgba = _hex_to_rgba(color)
+                        if rgba is None:
+                            rgba = _DEFAULT_VISUAL_RGBA
+                        mat = ET.SubElement(block, "material")
+                        mat.set("name", f"{base}_material")
+                        ET.SubElement(mat, "color").set("rgba", _rgba_attr(rgba))
 
     if errors:
         raise RuntimeError("ROS description export failed: " + "; ".join(errors))

--- a/sw2robot/exporter/ros_export.py
+++ b/sw2robot/exporter/ros_export.py
@@ -1165,7 +1165,14 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
                         if rgba is None:
                             rgba = _DEFAULT_VISUAL_RGBA
                         mat = ET.SubElement(block, "material")
-                        mat.set("name", f"{base}_material")
+                        # name off the UNIQUE mesh output name, not the raw
+                        # basename: two links whose visual meshes come from
+                        # different sources sharing a basename (part.stl vs
+                        # part_2.stl) would otherwise both emit
+                        # <material name="part_material">, and urdfdom/RViz
+                        # treat material names as a global map -- the second
+                        # link would inherit the first's colour.
+                        mat.set("name", f"{job['name'].rsplit('.', 1)[0]}_material")
                         ET.SubElement(mat, "color").set("rgba", _rgba_attr(rgba))
 
     if errors:

--- a/tests/test_ros_export.py
+++ b/tests/test_ros_export.py
@@ -463,6 +463,65 @@ def test_colour_override_repaints_visual_mesh(tmp_path):
     assert (0.07, 0.53, 1.0) not in plain_triples
 
 
+_STL_CTX = (("visual", "stl"), ("collision", "stl"))
+
+
+def test_stl_visual_emits_material_from_override(tmp_path):
+    """An STL <visual> carries no colour, so the per-link override is emitted as a
+    URDF <material><color> (and the collision is stl too)."""
+    import xml.etree.ElementTree as ET
+
+    from sw2robot.exporter.ros_export import build_ros_description
+
+    pkg_dir = _make_pkg(tmp_path, robot="fing")
+    files = dict(build_ros_description(pkg_dir, "fing", ctx_fmt=_STL_CTX,
+                                       colors={"part": "#1188ff"}))
+    # both contexts are stl
+    assert "fing_description/meshes/part.stl" in files
+    assert not any(a.endswith((".dae", ".glb")) for a in files)
+
+    link = ET.fromstring(
+        files["fing_description/urdf/fing_description.urdf"].decode()).find("link")
+    mat = link.find("visual").find("material")
+    assert mat is not None
+    rgba = [round(float(x), 2) for x in mat.find("color").get("rgba").split()]
+    assert rgba[:3] == [0.07, 0.53, 1.0]                  # #1188ff
+    assert link.find("collision").find("material") is None   # collision: no colour
+
+
+def test_stl_visual_material_default_when_no_override(tmp_path):
+    """With no override, the STL <material> uses the default colour (so the link
+    isn't left RViz-default grey)."""
+    import xml.etree.ElementTree as ET
+
+    from sw2robot.exporter.ros_export import (
+        _DEFAULT_VISUAL_RGBA,
+        _rgba_attr,
+        build_ros_description,
+    )
+
+    pkg_dir = _make_pkg(tmp_path, robot="fing")
+    files = dict(build_ros_description(pkg_dir, "fing", ctx_fmt=_STL_CTX))
+    link = ET.fromstring(
+        files["fing_description/urdf/fing_description.urdf"].decode()).find("link")
+    mat = link.find("visual").find("material")
+    assert mat is not None
+    assert mat.find("color").get("rgba") == _rgba_attr(_DEFAULT_VISUAL_RGBA)
+
+
+def test_dae_visual_emits_no_material(tmp_path):
+    """The default dae visual keeps colour in the mesh -> no URDF <material>."""
+    import xml.etree.ElementTree as ET
+
+    from sw2robot.exporter.ros_export import build_ros_description
+
+    pkg_dir = _make_pkg(tmp_path, robot="fing")
+    files = dict(build_ros_description(pkg_dir, "fing"))   # default dae/stl
+    link = ET.fromstring(
+        files["fing_description/urdf/fing_description.urdf"].decode()).find("link")
+    assert link.find("visual").find("material") is None
+
+
 def _two_unit_boxes():
     """Two trivial convex parts (unit cubes), as CoACD returns ``(verts, faces)``
     pairs -- a stand-in for a real decomposition so tests stay fast + CoACD-free."""

--- a/tests/test_ros_export.py
+++ b/tests/test_ros_export.py
@@ -900,3 +900,37 @@ def test_missing_mesh_aborts_instead_of_half_broken_package(tmp_path):
         build_ros_description(str(tmp_path), "r")
     assert (tmp_path / "urdf" / "r.urdf").read_text(encoding="utf-8") == urdf
     assert sorted(os.listdir(tmp_path / "meshes")) == []
+
+
+@pytest.mark.parametrize("vfmt,cfmt", [("glb", "stl"), ("dae", "glb"),
+                                       ("stl", "glb")])
+def test_visual_and_collision_formats_are_independent(tmp_path, vfmt, cfmt):
+    """The visual and collision selectors are orthogonal: each context converts
+    the same source to its OWN format.  The default (dae/stl) and uniform-glb
+    cases are covered elsewhere; this pins the ASYMMETRIC combinations so a
+    regression that couples the two (e.g. collision inheriting the visual fmt)
+    is caught.  _make_pkg's single link references the one mesh from BOTH a
+    <visual> and a <collision>, so the two outputs must be distinct files."""
+    import xml.etree.ElementTree as ET
+
+    from sw2robot.exporter.ros_export import build_ros_description
+
+    pkg_dir = _make_pkg(tmp_path, robot="mix")
+    ctx_fmt = (("visual", vfmt), ("collision", cfmt))
+    files = dict(build_ros_description(pkg_dir, "mix", ctx_fmt=ctx_fmt))
+
+    # each context's <mesh> points at a file with ITS format's extension
+    link = ET.fromstring(
+        files["mix_description/urdf/mix_description.urdf"].decode()).find("link")
+    assert link.find("visual").find(".//mesh").get("filename") \
+        == f"package://mix_description/meshes/part.{vfmt}"
+    assert link.find("collision").find(".//mesh").get("filename") \
+        == f"package://mix_description/meshes/part.{cfmt}"
+
+    # both output files are shipped; if vfmt==cfmt they'd share one, but here
+    # the combos are asymmetric so exactly the two expected files exist
+    assert f"mix_description/meshes/part.{vfmt}" in files
+    assert f"mix_description/meshes/part.{cfmt}" in files
+    mesh_arcs = {a for a in files if a.startswith("mix_description/meshes/")}
+    assert mesh_arcs == {f"mix_description/meshes/part.{vfmt}",
+                         f"mix_description/meshes/part.{cfmt}"}

--- a/tests/test_urdf_mode_webserver.py
+++ b/tests/test_urdf_mode_webserver.py
@@ -835,6 +835,33 @@ def test_export_zip_bakes_colour_and_restores_pristine(server):
     assert "<material" not in disk
 
 
+def test_export_zip_rejects_bad_formats(server):
+    """Invalid visual/collision mesh formats return a clean 400 (not a 500) -- the
+    error message names the offending value."""
+    code, data = _get_status(server, "/api/export/zip?ros=1&meshes=foo")
+    assert code == 400 and b"foo" in data
+    code, data = _get_status(server, "/api/export/zip?ros=1&colfmt=bar")
+    assert code == 400 and b"bar" in data
+
+
+def test_export_zip_stl_visual_emits_material(server):
+    """An STL visual export (via the server) ships .stl visual meshes and carries
+    the per-link colour as a URDF <material> (STL has no colour of its own)."""
+    import io
+    import zipfile
+
+    _post(server, "/api/set_color", {"link": TIP_LINK, "color": "#ff0000"})
+    code, data = _get_status(server,
+                             "/api/export/zip?ros=1&meshes=stl&colfmt=stl")
+    assert code == 200, data[:200]
+    zf = zipfile.ZipFile(io.BytesIO(data))
+    names = zf.namelist()
+    assert any("/meshes/" in n and n.endswith(".stl") for n in names)
+    assert not any(n.endswith((".dae", ".glb")) for n in names)
+    exported = zf.read(next(n for n in names if n.endswith(".urdf"))).decode()
+    assert "<material" in exported and 'rgba="1 0 0 1"' in exported
+
+
 def test_export_materializes_overlay_then_restores(server):
     """The on-disk URDF stays pristine while serving live, but the export window
     temporarily materializes the overlay so the ROS exporter picks edits up."""

--- a/tests/test_urdf_mode_webserver.py
+++ b/tests/test_urdf_mode_webserver.py
@@ -413,7 +413,10 @@ def test_reexport_glb_distinct_meshes_same_basename(tmp_path):
         '</link></robot>', encoding="utf-8")
     base, httpd = _start(pkg)
     try:
-        code, data = _get_status(base, "/api/export/zip?ros=1&meshes=glb")
+        # uniform glb (visual + collision) -- collision format now defaults to
+        # stl, so request glb collision explicitly to keep both meshes glb
+        code, data = _get_status(base,
+                                 "/api/export/zip?ros=1&meshes=glb&colfmt=glb")
         assert code == 200, data[:300]
         zf = zipfile.ZipFile(io.BytesIO(data))
         glbs = [n for n in zf.namelist() if n.endswith(".glb")]


### PR DESCRIPTION
Addresses Issue https://github.com/jsk-ros-pkg/solidworks_urdf_exporter2/issues/104

Adds STL as a visual mesh format alongside DAE and GLB, and — since the format choice turned out to be orthogonal to both the ROS version and the collision mesh, I have split the export panel into two independent selectors: visual (dae/stl/glb) and collision (stl/glb). Because STL carries no colour, an STL visual now emits the per-link colour as a URDF <material> so it still renders correctly in RViz.

# Notes / limitations

- With collision=coacd, collision parts are always STL regardless of colfmt (CoACD emits STL) — UI doesn't disable the glb collision option in that case.
- Multi-colour parts collapse to a single <material> colour on STL.