### PR TITLE
Collision modes: copy / convex-hull / CoACD 

### DIFF
--- a/sw2robot/editor/autoinit.py
+++ b/sw2robot/editor/autoinit.py
@@ -66,7 +66,7 @@ def link_meshes(robot):
     return out
 
 
-def load_coacd_parts(preview_dir, link_names):
+def load_collision_parts(preview_dir, link_names):
     """``{link name -> [convex part trimesh, ...]}`` loaded from the CoACD preview
     GLBs (``<preview_dir>/<safe link>.glb``), each part in the link-local frame
     (the collision ``<origin>`` was baked in at generation).  Links without a

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -4325,6 +4325,10 @@ function updateCollUI() {
 }
 collModeSel?.addEventListener('change', () => {
   updateCollUI();
+  // a generate job still in flight belongs to the PREVIOUS mode -- abandon it,
+  // else its completion would finalize against the old mode and silently revert
+  // this deliberate switch (re-applying the old parts to live + export).
+  if (collPreviewPoll) { collPreviewAbort(); }
   // any generated preview belongs to the PREVIOUS mode, so switching type drops
   // it: nothing is shown until a preview is made for the newly-selected type
   // (copy has none; hull/coacd must be (re)generated).
@@ -4493,6 +4497,19 @@ collPreviewStopBtn?.addEventListener('click', async () => {
   log(t('coacd.stopping'));
   try { await fetch('/api/collision/coacd/cancel'); } catch (_e) { /* ignore */ }
 });
+// Abandon the in-flight generate job (the user switched collision mode mid-run).
+// Stop polling FIRST so the now-cancelled job's completion can't reach the
+// finalize block and revert the selector to the old mode; then tell the server
+// to stop and reset the gen UI.  Unlike Stop, this discards the partial result.
+function collPreviewAbort() {
+  if (collPreviewPoll) { clearInterval(collPreviewPoll); collPreviewPoll = null; }
+  collPreviewSetBlink([]);                         // stop the per-link blink timer
+  try { fetch('/api/collision/coacd/cancel'); } catch (_e) { /* ignore */ }
+  collPreviewStat?.classList.remove('on');         // hide the "computing" banner
+  if (collPreviewProg) { collPreviewProg.textContent = ''; }
+  if (collPreviewGenBtn) { collPreviewGenBtn.disabled = false; }
+  if (collPreviewStopBtn) { collPreviewStopBtn.disabled = false; }
+}
 collPreviewGenBtn?.addEventListener('click', async () => {
   if (collPreviewPoll) { return; }
   collPreviewClearOverlay();

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -697,22 +697,28 @@ mesh layout differs, e.g. 'urdf/mesh'. A '/' makes subdirectories."
                       font-size:11px" placeholder="meshes">
       </div>
       <div style="display:flex;gap:6px;align-items:center;margin-bottom:4px;flex-wrap:wrap">
-        <label style="display:flex;gap:4px;align-items:center;color:#8a93a3;cursor:pointer"
-               data-i18n-title="t.coacd"
-               title="Replace <collision> meshes with CoACD convex parts (what physics
-engines want). Slower: tens of seconds per link, but cached after the first run.
-Applies to the ROS1/ROS2 packages (not glb); needs the 'coacd' package server-side.">
-          <input id="coacd" type="checkbox">
-          <span data-i18n="ui.coacd">CoACD collision</span>
+        <label style="display:flex;gap:4px;align-items:center;color:#8a93a3"
+               data-i18n-title="t.collmode"
+               title="How <collision> geometry is produced for the ROS1/ROS2 packages:
+'visual mesh' reuses the visual mesh; 'convex hull' uses one convex hull per
+link; 'CoACD' decomposes each link into many convex parts.">
+          <span data-i18n="ui.collmode">collision</span>
+          <select id="collmode"
+                  style="background:#15171a;color:#cfe3ff;border:1px solid #2d4a35;
+                         border-radius:3px;padding:2px 4px;font-size:11px">
+            <option value="copy" data-i18n="ui.collcopy">Visual mesh</option>
+            <option value="hull" data-i18n="ui.collhull">Convex hull</option>
+            <option value="coacd" data-i18n="ui.collcoacd">CoACD (convex parts)</option>
+          </select>
         </label>
         <select id="cquality"
                 style="background:#15171a;color:#cfe3ff;border:1px solid #2d4a35;
                        border-radius:3px;padding:2px 4px;font-size:11px">
-          <option value="balanced" data-i18n="ui.cqbalanced">balanced</option>
-          <option value="fine" data-i18n="ui.cqfine">fine</option>
+          <option value="balanced" data-i18n="ui.cqbalanced">Balanced</option>
+          <option value="fine" data-i18n="ui.cqfine">Fine</option>
         </select>
       </div>
-      <div style="display:flex;gap:6px;align-items:center;margin-bottom:4px;flex-wrap:wrap">
+      <div id="collgenrow" style="display:flex;gap:6px;align-items:center;margin-bottom:4px;flex-wrap:wrap">
         <button id="coacdgen" data-i18n="ui.coacdgen" data-i18n-title="t.coacdgen"
                 title="Run CoACD now and preview each link's convex collision parts
 in the viewer as they finish. Caches the result, so a later CoACD export is instant.">
@@ -1373,11 +1379,16 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     'ui.expros2': { en: '⬇ ROS2 package', ja: '⬇ ROS2 パッケージ' },
     't.expglb': { en: 'uniform .glb meshes (colour kept) for three.js / skrobot / native-mesh consumers (not RViz-loadable)',
                   ja: '均一な .glb メッシュ（色は保持）three.js / skrobot / ネイティブメッシュ向け（RVizでは読込不可）' },
+    'ui.collmode': { en: 'collision', ja: '衝突形状' },
+    't.collmode': { en: "How <collision> geometry is produced for the ROS1/ROS2 packages: 'visual mesh' reuses the visual mesh as-is; 'convex hull' uses a single convex hull per link (simple, good for path planning); 'CoACD' decomposes each link into many convex parts (best for physics, slower — server needs the coacd package). Generate previews the hull/CoACD result in the viewer.",
+                    ja: 'ROS1/ROS2 パッケージの <collision> ジオメトリの生成方法: 「ビジュアルメッシュ」はメッシュをそのまま使用、「凸包」はリンクごとに単一の凸包（シンプル、経路計画向け）、「CoACD」は各リンクを多数の凸パーツに分解（物理向け・低速、サーバーに coacd パッケージが必要）。「生成」でビューアにプレビューします。' },
+    'ui.collcopy': { en: 'Visual mesh', ja: 'ビジュアルメッシュ' },
+    'ui.collhull': { en: 'Convex hull', ja: '凸包' },
+    'ui.collcoacd': { en: 'CoACD (convex parts)', ja: 'CoACD（凸パーツ）' },
+    'coll.hullword': { en: 'convex-hull', ja: '凸包' },
     'ui.coacd': { en: 'CoACD collision', ja: 'CoACD 衝突形状' },
-    't.coacd': { en: 'Replace <collision> meshes with CoACD convex parts (what physics engines want). Slower: tens of seconds per link, but cached after the first run. Applies to the ROS1/ROS2 packages (not glb); needs the coacd package server-side.',
-                 ja: '<collision> メッシュを CoACD の凸パーツ群に置き換えます（物理エンジン向け）。1リンクあたり数十秒と遅いですが、初回以降はキャッシュされます。ROS1/ROS2 パッケージのみ（glb は対象外）。サーバー側に coacd パッケージが必要です。' },
-    'ui.cqbalanced': { en: 'balanced', ja: 'バランス' },
-    'ui.cqfine': { en: 'fine', ja: '高精細' },
+    'ui.cqbalanced': { en: 'Balanced', ja: 'バランス' },
+    'ui.cqfine': { en: 'Fine', ja: '高精細' },
     'ui.coacdgen': { en: '⚙ Generate collision', ja: '⚙ 衝突形状を生成' },
     't.coacdgen': { en: "Run CoACD now and preview each link's convex collision parts in the viewer as they finish. Caches the result, so a later CoACD export is instant.",
                     ja: 'いま CoACD を実行し、各リンクの凸collisionパーツを完成した順にビューアでプレビューします。結果はキャッシュされ、後の CoACD エクスポートは瞬時です。' },
@@ -1398,18 +1409,18 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     't.coacdshow': { en: 'Overlay the generated convex collision parts (semi-transparent, colour-coded) on top of the visual meshes.',
                      ja: '生成した凸collisionパーツ（半透明・色分け）を visual メッシュの上に重ねて表示します。' },
     'coacd.start': { en: 'starting …', ja: '開始中 …' },
-    'coacd.started': { en: a => `CoACD collision generation started (${a.q})`,
-                       ja: a => `CoACD 衝突形状の生成を開始しました（${a.q}）` },
-    'coacd.prog': { en: a => `CoACD: ${a.done}/${a.total} links${a.link ? ' · ' + a.link : ''} …`,
-                    ja: a => `CoACD: ${a.done}/${a.total} リンク${a.link ? ' · ' + a.link : ''} …` },
-    'coacd.working': { en: a => `CoACD ${a.done}/${a.total} · decomposing ${a.link} … (tens of seconds)`,
-                       ja: a => `CoACD ${a.done}/${a.total} · ${a.link} を分解中 …（数十秒）` },
-    'coacd.link': { en: a => `CoACD ${a.done}/${a.total} · ${a.link} ✓`,
-                    ja: a => `CoACD ${a.done}/${a.total} · ${a.link} ✓` },
+    'coacd.started': { en: a => `${a.what || 'CoACD'} collision generation started${a.q ? ' (' + a.q + ')' : ''}`,
+                       ja: a => `${a.what || 'CoACD'} 衝突形状の生成を開始しました${a.q ? '（' + a.q + '）' : ''}` },
+    'coacd.prog': { en: a => `${a.what || 'CoACD'}: ${a.done}/${a.total} links${a.link ? ' · ' + a.link : ''} …`,
+                    ja: a => `${a.what || 'CoACD'}: ${a.done}/${a.total} リンク${a.link ? ' · ' + a.link : ''} …` },
+    'coacd.working': { en: a => `${a.what || 'CoACD'} ${a.done}/${a.total} · decomposing ${a.link} … (tens of seconds)`,
+                       ja: a => `${a.what || 'CoACD'} ${a.done}/${a.total} · ${a.link} を分解中 …（数十秒）` },
+    'coacd.link': { en: a => `${a.what || 'CoACD'} ${a.done}/${a.total} · ${a.link} ✓`,
+                    ja: a => `${a.what || 'CoACD'} ${a.done}/${a.total} · ${a.link} ✓` },
     'coacd.done': { en: a => `✓ collision ready (${a.n} links)`,
                     ja: a => `✓ 衝突形状ができました（${a.n} リンク）` },
-    'coacd.applied': { en: '↪ using CoACD parts for live collision + URDF/ROS export',
-                       ja: '↪ ライブ衝突判定とURDF/ROSエクスポートにCoACDパーツを使用します' },
+    'coacd.applied': { en: a => `↪ using ${a.what || 'CoACD'} parts for live collision + URDF/ROS export`,
+                       ja: a => `↪ ライブ衝突判定とURDF/ROSエクスポートに ${a.what || 'CoACD'} パーツを使用します` },
     'ui.coacdstop': { en: '■ stop', ja: '■ 停止' },
     'coacd.stopping': { en: 'stopping after the current link …',
                         ja: '現在のリンクを終えたら停止します …' },
@@ -4299,11 +4310,29 @@ expmeshdir?.addEventListener('input', () => {
 // few seconds, during which a plain <a download> gives NO feedback.  Drive it
 // over fetch instead: show an "exporting ..." loadbar, then hand the finished
 // blob to a throwaway download link.
-// CoACD convex-decomposition of <collision> meshes: opt-in, ROS packages only
-// (the glb export keeps its uniform-mesh layout).
-const collPreviewBox = document.getElementById('coacd');
+// Collision geometry for the ROS packages: 'copy' (visual mesh), 'hull'  or '
+// coacd' (convex decomposition into many parts).
+const collModeSel = document.getElementById('collmode');
+const collGenRow = document.getElementById('collgenrow');
 const cqualitySel = document.getElementById('cquality');
 const mergeFixedBox = document.getElementById('mergefixed');
+
+// quality only applies to CoACD; the Generate/preview row only to hull+coacd
+function updateCollUI() {
+  const mode = collModeSel?.value || 'copy';
+  if (cqualitySel) { cqualitySel.style.display = mode === 'coacd' ? '' : 'none'; }
+  if (collGenRow) { collGenRow.style.display = mode === 'copy' ? 'none' : 'flex'; }
+}
+collModeSel?.addEventListener('change', () => {
+  updateCollUI();
+  // any generated preview belongs to the PREVIOUS mode, so switching type drops
+  // it: nothing is shown until a preview is made for the newly-selected type
+  // (copy has none; hull/coacd must be (re)generated).
+  collPreviewClearOverlay();
+  collPreviewFinalized = false;
+  setCollisionShown(false);
+});
+updateCollUI();
 
 // ---- CoACD collision preview: generate per-link convex parts in the
 // background, popping each link's mesh into the viewer as it lands, and a toggle
@@ -4357,6 +4386,7 @@ function collPreviewClearOverlay() {
 }
 function collPreviewSetShown(on) {
   for (const grp of Object.values(collPreviewGroups)) { grp.visible = on; }
+  viewer.redraw();          // on-demand renderer: toggling must trigger a frame
 }
 // When the overlay is globally HIDDEN, still reveal the collision mesh of any
 // link that is currently self-colliding -- so even with "coll" off you can see
@@ -4367,6 +4397,7 @@ function collPreviewRevealColliding(links) {
   for (const [link, grp] of Object.entries(collPreviewGroups)) {
     grp.visible = !!(links && links.has && links.has(link));
   }
+  viewer.redraw();
 }
 function collPreviewLoadLink(link, url) {
   if (collPreviewGroups[link]) { return; }          // already loaded this link
@@ -4393,12 +4424,13 @@ async function collPreviewTick() {
   let s;
   try { s = await (await fetch('/api/collision/coacd/status')).json(); }
   catch (_e) { return; }
+  const what = s.mode === 'hull' ? t('coll.hullword') : 'CoACD';
   // pop each newly-finished link into the viewer + log it once
   for (const [link, url] of Object.entries(s.parts || {})) {
     collPreviewLoadLink(link, url);
     if (!collPreviewLogged.has(link)) {
       collPreviewLogged.add(link);
-      log(t('coacd.link', { done: collPreviewLogged.size, total: s.total || 0, link }),
+      log(t('coacd.link', { done: collPreviewLogged.size, total: s.total || 0, link, what }),
           'ok');
     }
   }
@@ -4408,7 +4440,7 @@ async function collPreviewTick() {
   if (s.running && s.current && s.current !== collPreviewLastCurrent
       && !collPreviewLogged.has(s.current)) {
     collPreviewLastCurrent = s.current;
-    log(t('coacd.working', { done, total, link: s.current }));
+    log(t('coacd.working', { done, total, link: s.current, what }));
   }
   // links the SERVER produced parts for (authoritative: the overlay GLBs load
   // asynchronously, so collPreviewGroups may still be empty right when the job ends)
@@ -4427,7 +4459,7 @@ async function collPreviewTick() {
       ? inflight.slice(0, 2).join(', ')
         + (inflight.length > 2 ? ` +${inflight.length - 2}` : '')
       : (s.current || '');
-    const msg = t('coacd.prog', { done, total, link: label });
+    const msg = t('coacd.prog', { done, total, link: label, what });
     collPreviewProg.textContent = msg;
     if (collPreviewStatText) { collPreviewStatText.textContent = msg; }   // top banner
     collPreviewStat?.classList.add('on');
@@ -4445,12 +4477,13 @@ async function collPreviewTick() {
     if (collPreviewStopBtn) { collPreviewStopBtn.disabled = false; }
     if (produced > 0 && !collPreviewFinalized) {
       collPreviewFinalized = true;
-      // 1) the URDF/ROS export should now ship these convex parts as <collision>
-      if (collPreviewBox && !collPreviewBox.checked) { collPreviewBox.checked = true; }
+      // 1) the URDF/ROS export should now ship these parts as <collision>:
+      //    point the mode selector at whatever we just generated
+      if (collModeSel && s.mode) { collModeSel.value = s.mode; updateCollUI(); }
       // 2) rebuild the live self-collision model so the red highlight uses the
-      //    CoACD parts (the server dropped the old one when the job finished)
+      //    generated parts (the server dropped the old one when the job finished)
       initCollision();
-      log(t('coacd.applied'), 'ok');
+      log(t('coacd.applied', { what }), 'ok');
     }
   }
 }
@@ -4472,12 +4505,15 @@ collPreviewGenBtn?.addEventListener('click', async () => {
   if (collPreviewStatText) { collPreviewStatText.textContent = t('coacd.start'); }
   if (collPreviewBar) { collPreviewBar.style.width = '0%'; }
   collPreviewStat?.classList.add('on');                // show "computing" banner now
+  const mode = collModeSel?.value || 'coacd';
   const q = cqualitySel?.value || 'balanced';
+  const what = mode === 'hull' ? t('coll.hullword') : 'CoACD';
   try {
     const r = await (await fetch(
-      `/api/collision/coacd/init?quality=${encodeURIComponent(q)}`)).json();
+      `/api/collision/coacd/init?mode=${encodeURIComponent(mode)}`
+      + `&quality=${encodeURIComponent(q)}`)).json();
     if (r.error) { throw new Error(r.error); }
-    log(t('coacd.started', { q }));
+    log(t('coacd.started', { q: mode === 'coacd' ? q : '', what }));
     collPreviewPoll = setInterval(collPreviewTick, 1000);
     collPreviewTick();
   } catch (e) {
@@ -4518,14 +4554,16 @@ expLinks.forEach(a => a.addEventListener('click', async ev => {
   const name = (exppkg?.value || '').trim();
   const urdf = (expurdf?.value || '').trim();
   const meshdir = (expmeshdir?.value || '').trim().replace(/^\/+|\/+$/g, '');
-  // coacd + merge-fixed apply to the ROS (.dae) packages, not the uniform glb
-  const coacd = a.id !== 'expglb' && !!collPreviewBox?.checked;
+  // collision mode + merge-fixed apply to the ROS (.dae) packages, not the
+  // uniform glb (which keeps copy-style collision)
+  const collMode = a.id !== 'expglb' ? (collModeSel?.value || 'copy') : 'copy';
   const mergeFixed = a.id !== 'expglb' && !!mergeFixedBox?.checked;
   const url = base
     + (name ? `&name=${encodeURIComponent(name)}` : '')
     + (urdf ? `&urdf=${encodeURIComponent(urdf)}` : '')
     + (meshdir ? `&meshdir=${encodeURIComponent(meshdir)}` : '')
-    + (coacd ? `&collision=coacd&cquality=${cqualitySel?.value || 'balanced'}` : '')
+    + (collMode !== 'copy' ? `&collision=${collMode}` : '')
+    + (collMode === 'coacd' ? `&cquality=${cqualitySel?.value || 'balanced'}` : '')
     + (mergeFixed ? '&mergefixed=1' : '');
   const what = a.id === 'expglb' ? 'glb'
     : a.id === 'expros2' ? 'ROS 2' : 'ROS 1';

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -4428,6 +4428,10 @@ async function collPreviewTick() {
   let s;
   try { s = await (await fetch('/api/collision/preview/status')).json(); }
   catch (_e) { return; }
+  // If the user switched collision mode while THIS status fetch was in flight,
+  // collPreviewAbort() already nulled the poll -- bail before the finalize
+  // block below can revert the selector to the old mode and re-apply its parts.
+  if (!collPreviewPoll) { return; }
   const what = s.mode === 'hull' ? t('coll.hullword') : 'CoACD';
   // pop each newly-finished link into the viewer + log it once
   for (const [link, url] of Object.entries(s.parts || {})) {

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -3106,7 +3106,7 @@ function applyCollision(links, pairs) {
     if (!collisionLinks.has(n)) { _tintLink(n, 'col'); }
   }
   collisionLinks = links;
-  coacdRevealColliding(links);   // show colliding links' collision mesh even
+  collPreviewRevealColliding(links);   // show colliding links' collision mesh even
                                  // when the CoACD overlay is globally hidden
   if (pairs.length) {
     // "this angle collides": name the joint being moved + its angle
@@ -4301,75 +4301,75 @@ expmeshdir?.addEventListener('input', () => {
 // blob to a throwaway download link.
 // CoACD convex-decomposition of <collision> meshes: opt-in, ROS packages only
 // (the glb export keeps its uniform-mesh layout).
-const coacdBox = document.getElementById('coacd');
+const collPreviewBox = document.getElementById('coacd');
 const cqualitySel = document.getElementById('cquality');
 const mergeFixedBox = document.getElementById('mergefixed');
 
 // ---- CoACD collision preview: generate per-link convex parts in the
 // background, popping each link's mesh into the viewer as it lands, and a toggle
 // to overlay them (semi-transparent) on the visual meshes.
-const coacdGenBtn = document.getElementById('coacdgen');
-const coacdShow = document.getElementById('coacdshow');
-const coacdProg = document.getElementById('coacdprog');
-const coacdStat = document.getElementById('coacdstat');       // top banner
-const coacdStatText = document.getElementById('coacdstattext');
-const coacdStopBtn = document.getElementById('coacdstop');
-const coacdBar = document.getElementById('coacdbar');         // determinate fill
+const collPreviewGenBtn = document.getElementById('coacdgen');
+const collPreviewShow = document.getElementById('coacdshow');
+const collPreviewProg = document.getElementById('coacdprog');
+const collPreviewStat = document.getElementById('coacdstat');       // top banner
+const collPreviewStatText = document.getElementById('coacdstattext');
+const collPreviewStopBtn = document.getElementById('coacdstop');
+const collPreviewBar = document.getElementById('coacdbar');         // determinate fill
 
 // blink the links currently being decomposed (several run in parallel), so it
 // is obvious which parts are still computing -- toggle their hover tint on one
 // shared timer
-let coacdBlinkSet = new Set(), coacdBlinkTimer = null, coacdBlinkOn = false;
-function coacdSetBlink(links) {
+let collPreviewBlinkSet = new Set(), collPreviewBlinkTimer = null, collPreviewBlinkOn = false;
+function collPreviewSetBlink(links) {
   const next = new Set(links || []);
-  for (const l of coacdBlinkSet) {            // restore links no longer running
+  for (const l of collPreviewBlinkSet) {            // restore links no longer running
     if (!next.has(l)) { try { highlightLink(l, false); } catch (_e) { /* gone */ } }
   }
-  coacdBlinkSet = next;
+  collPreviewBlinkSet = next;
   if (next.size === 0) {
-    if (coacdBlinkTimer) { clearInterval(coacdBlinkTimer); coacdBlinkTimer = null; }
-    coacdBlinkOn = false;
+    if (collPreviewBlinkTimer) { clearInterval(collPreviewBlinkTimer); collPreviewBlinkTimer = null; }
+    collPreviewBlinkOn = false;
     return;
   }
-  if (!coacdBlinkTimer) {
-    coacdBlinkTimer = setInterval(() => {
-      coacdBlinkOn = !coacdBlinkOn;
-      for (const l of coacdBlinkSet) {
+  if (!collPreviewBlinkTimer) {
+    collPreviewBlinkTimer = setInterval(() => {
+      collPreviewBlinkOn = !collPreviewBlinkOn;
+      for (const l of collPreviewBlinkSet) {
         if (viewer.robot?.links?.[l]) {
-          try { highlightLink(l, coacdBlinkOn); } catch (_e) { /* gone */ }
+          try { highlightLink(l, collPreviewBlinkOn); } catch (_e) { /* gone */ }
         }
       }
     }, 500);
   }
 }
-const coacdGroups = {};        // link name -> THREE.Object3D attached to the link
-let coacdPoll = null;
-let coacdFinalized = false;    // ran the post-generation hookup (export + collision)
-let coacdLastCurrent = null;   // last link the server reported as in-progress
-const coacdLogged = new Set(); // links already logged as ready (avoid repeats)
+const collPreviewGroups = {};        // link name -> THREE.Object3D attached to the link
+let collPreviewPoll = null;
+let collPreviewFinalized = false;    // ran the post-generation hookup (export + collision)
+let collPreviewLastCurrent = null;   // last link the server reported as in-progress
+const collPreviewLogged = new Set(); // links already logged as ready (avoid repeats)
 
-function coacdClearOverlay() {
-  for (const [link, grp] of Object.entries(coacdGroups)) {
+function collPreviewClearOverlay() {
+  for (const [link, grp] of Object.entries(collPreviewGroups)) {
     grp.parent?.remove(grp);
     grp.traverse(o => { o.geometry?.dispose?.(); o.material?.dispose?.(); });
-    delete coacdGroups[link];
+    delete collPreviewGroups[link];
   }
 }
-function coacdSetShown(on) {
-  for (const grp of Object.values(coacdGroups)) { grp.visible = on; }
+function collPreviewSetShown(on) {
+  for (const grp of Object.values(collPreviewGroups)) { grp.visible = on; }
 }
 // When the overlay is globally HIDDEN, still reveal the collision mesh of any
 // link that is currently self-colliding -- so even with "coll" off you can see
 // WHICH part hit and where.  When the overlay is shown globally, the toggle
 // owns visibility and this is a no-op.
-function coacdRevealColliding(links) {
+function collPreviewRevealColliding(links) {
   if (!collViewBtn || collViewBtn.classList.contains('active')) { return; }
-  for (const [link, grp] of Object.entries(coacdGroups)) {
+  for (const [link, grp] of Object.entries(collPreviewGroups)) {
     grp.visible = !!(links && links.has && links.has(link));
   }
 }
-function coacdLoadLink(link, url) {
-  if (coacdGroups[link]) { return; }          // already loaded this link
+function collPreviewLoadLink(link, url) {
+  if (collPreviewGroups[link]) { return; }          // already loaded this link
   const target = viewer.robot?.links?.[link];
   if (!target || !GLTFLoader) { return; }
   new GLTFLoader().load(url, g => {
@@ -4384,43 +4384,43 @@ function coacdLoadLink(link, url) {
         m.depthWrite = false; m.vertexColors = true;
       }
     });
-    grp.visible = !!coacdShow?.checked;
-    coacdGroups[link] = grp;
+    grp.visible = !!collPreviewShow?.checked;
+    collPreviewGroups[link] = grp;
     target.add(grp);
   }, null, () => { /* a link mesh failing to load is non-fatal */ });
 }
-async function coacdTick() {
+async function collPreviewTick() {
   let s;
   try { s = await (await fetch('/api/collision/coacd/status')).json(); }
   catch (_e) { return; }
   // pop each newly-finished link into the viewer + log it once
   for (const [link, url] of Object.entries(s.parts || {})) {
-    coacdLoadLink(link, url);
-    if (!coacdLogged.has(link)) {
-      coacdLogged.add(link);
-      log(t('coacd.link', { done: coacdLogged.size, total: s.total || 0, link }),
+    collPreviewLoadLink(link, url);
+    if (!collPreviewLogged.has(link)) {
+      collPreviewLogged.add(link);
+      log(t('coacd.link', { done: collPreviewLogged.size, total: s.total || 0, link }),
           'ok');
     }
   }
   const total = s.total || 0, done = s.done || 0;
   // also surface the link currently being decomposed (the slow step), so a
   // multi-minute link does not look frozen
-  if (s.running && s.current && s.current !== coacdLastCurrent
-      && !coacdLogged.has(s.current)) {
-    coacdLastCurrent = s.current;
+  if (s.running && s.current && s.current !== collPreviewLastCurrent
+      && !collPreviewLogged.has(s.current)) {
+    collPreviewLastCurrent = s.current;
     log(t('coacd.working', { done, total, link: s.current }));
   }
   // links the SERVER produced parts for (authoritative: the overlay GLBs load
-  // asynchronously, so coacdGroups may still be empty right when the job ends)
+  // asynchronously, so collPreviewGroups may still be empty right when the job ends)
   const produced = Object.keys(s.parts || {}).length;
-  if (coacdBar) {                              // determinate progress fill
-    coacdBar.style.width = total ? Math.round(done / total * 100) + '%' : '0%';
+  if (collPreviewBar) {                              // determinate progress fill
+    collPreviewBar.style.width = total ? Math.round(done / total * 100) + '%' : '0%';
   }
   // blink ALL links currently being decomposed (they run in parallel)
   const inflight = s.running ? (s.inflight || []) : [];
-  coacdSetBlink(inflight);
+  collPreviewSetBlink(inflight);
   if (s.error) {
-    coacdProg.textContent = '';
+    collPreviewProg.textContent = '';
     log(t('coacd.fail', { e: s.error }), 'err');
   } else if (s.running) {
     const label = inflight.length
@@ -4428,25 +4428,25 @@ async function coacdTick() {
         + (inflight.length > 2 ? ` +${inflight.length - 2}` : '')
       : (s.current || '');
     const msg = t('coacd.prog', { done, total, link: label });
-    coacdProg.textContent = msg;
-    if (coacdStatText) { coacdStatText.textContent = msg; }   // top banner
-    coacdStat?.classList.add('on');
+    collPreviewProg.textContent = msg;
+    if (collPreviewStatText) { collPreviewStatText.textContent = msg; }   // top banner
+    collPreviewStat?.classList.add('on');
   } else if (s.cancelled) {
-    coacdProg.textContent = t('coacd.cancelled', { n: produced });
+    collPreviewProg.textContent = t('coacd.cancelled', { n: produced });
     log(t('coacd.cancelled', { n: produced }), 'warn');
   } else {
-    coacdProg.textContent = t('coacd.done', { n: produced });
+    collPreviewProg.textContent = t('coacd.done', { n: produced });
     log(t('coacd.done', { n: produced }), 'ok');
   }
   if (!s.running) {
-    coacdStat?.classList.remove('on');
-    clearInterval(coacdPoll); coacdPoll = null;
-    if (coacdGenBtn) { coacdGenBtn.disabled = false; }
-    if (coacdStopBtn) { coacdStopBtn.disabled = false; }
-    if (produced > 0 && !coacdFinalized) {
-      coacdFinalized = true;
+    collPreviewStat?.classList.remove('on');
+    clearInterval(collPreviewPoll); collPreviewPoll = null;
+    if (collPreviewGenBtn) { collPreviewGenBtn.disabled = false; }
+    if (collPreviewStopBtn) { collPreviewStopBtn.disabled = false; }
+    if (produced > 0 && !collPreviewFinalized) {
+      collPreviewFinalized = true;
       // 1) the URDF/ROS export should now ship these convex parts as <collision>
-      if (coacdBox && !coacdBox.checked) { coacdBox.checked = true; }
+      if (collPreviewBox && !collPreviewBox.checked) { collPreviewBox.checked = true; }
       // 2) rebuild the live self-collision model so the red highlight uses the
       //    CoACD parts (the server dropped the old one when the job finished)
       initCollision();
@@ -4454,36 +4454,36 @@ async function coacdTick() {
     }
   }
 }
-coacdStopBtn?.addEventListener('click', async () => {
-  coacdStopBtn.disabled = true;
-  if (coacdStatText) { coacdStatText.textContent = t('coacd.stopping'); }
+collPreviewStopBtn?.addEventListener('click', async () => {
+  collPreviewStopBtn.disabled = true;
+  if (collPreviewStatText) { collPreviewStatText.textContent = t('coacd.stopping'); }
   log(t('coacd.stopping'));
   try { await fetch('/api/collision/coacd/cancel'); } catch (_e) { /* ignore */ }
 });
-coacdGenBtn?.addEventListener('click', async () => {
-  if (coacdPoll) { return; }
-  coacdClearOverlay();
-  coacdLogged.clear(); coacdLastCurrent = null;
-  coacdFinalized = false;
+collPreviewGenBtn?.addEventListener('click', async () => {
+  if (collPreviewPoll) { return; }
+  collPreviewClearOverlay();
+  collPreviewLogged.clear(); collPreviewLastCurrent = null;
+  collPreviewFinalized = false;
   setCollisionShown(true);                       // watch it build by default
-  coacdGenBtn.disabled = true;
-  if (coacdStopBtn) { coacdStopBtn.disabled = false; }
-  coacdProg.textContent = t('coacd.start');
-  if (coacdStatText) { coacdStatText.textContent = t('coacd.start'); }
-  if (coacdBar) { coacdBar.style.width = '0%'; }
-  coacdStat?.classList.add('on');                // show "computing" banner now
+  collPreviewGenBtn.disabled = true;
+  if (collPreviewStopBtn) { collPreviewStopBtn.disabled = false; }
+  collPreviewProg.textContent = t('coacd.start');
+  if (collPreviewStatText) { collPreviewStatText.textContent = t('coacd.start'); }
+  if (collPreviewBar) { collPreviewBar.style.width = '0%'; }
+  collPreviewStat?.classList.add('on');                // show "computing" banner now
   const q = cqualitySel?.value || 'balanced';
   try {
     const r = await (await fetch(
       `/api/collision/coacd/init?quality=${encodeURIComponent(q)}`)).json();
     if (r.error) { throw new Error(r.error); }
     log(t('coacd.started', { q }));
-    coacdPoll = setInterval(coacdTick, 1000);
-    coacdTick();
+    collPreviewPoll = setInterval(collPreviewTick, 1000);
+    collPreviewTick();
   } catch (e) {
-    coacdGenBtn.disabled = false;
-    coacdProg.textContent = '';
-    coacdStat?.classList.remove('on');
+    collPreviewGenBtn.disabled = false;
+    collPreviewProg.textContent = '';
+    collPreviewStat?.classList.remove('on');
     log(t('coacd.fail', { e: e.message ?? e }), 'err');
   }
 });
@@ -4491,14 +4491,14 @@ coacdGenBtn?.addEventListener('click', async () => {
 // the top-toolbar toggle or the export-panel checkbox (kept in sync)
 const collViewBtn = document.getElementById('collview');
 function setCollisionShown(on) {
-  if (coacdShow) { coacdShow.checked = on; }
+  if (collPreviewShow) { collPreviewShow.checked = on; }
   collViewBtn?.classList.toggle('active', on);
-  coacdSetShown(on);
+  collPreviewSetShown(on);
   // hiding the overlay shouldn't hide a CURRENT collision -- keep colliding
   // links' meshes visible
-  if (!on) { coacdRevealColliding(collisionLinks); }
+  if (!on) { collPreviewRevealColliding(collisionLinks); }
 }
-coacdShow?.addEventListener('change', () => setCollisionShown(coacdShow.checked));
+collPreviewShow?.addEventListener('change', () => setCollisionShown(collPreviewShow.checked));
 collViewBtn?.addEventListener('click',
   () => setCollisionShown(!collViewBtn.classList.contains('active')));
 
@@ -4519,7 +4519,7 @@ expLinks.forEach(a => a.addEventListener('click', async ev => {
   const urdf = (expurdf?.value || '').trim();
   const meshdir = (expmeshdir?.value || '').trim().replace(/^\/+|\/+$/g, '');
   // coacd + merge-fixed apply to the ROS (.dae) packages, not the uniform glb
-  const coacd = a.id !== 'expglb' && !!coacdBox?.checked;
+  const coacd = a.id !== 'expglb' && !!collPreviewBox?.checked;
   const mergeFixed = a.id !== 'expglb' && !!mergeFixedBox?.checked;
   const url = base
     + (name ? `&name=${encodeURIComponent(name)}` : '')

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -4426,7 +4426,7 @@ function collPreviewLoadLink(link, url) {
 }
 async function collPreviewTick() {
   let s;
-  try { s = await (await fetch('/api/collision/coacd/status')).json(); }
+  try { s = await (await fetch('/api/collision/preview/status')).json(); }
   catch (_e) { return; }
   const what = s.mode === 'hull' ? t('coll.hullword') : 'CoACD';
   // pop each newly-finished link into the viewer + log it once
@@ -4495,7 +4495,7 @@ collPreviewStopBtn?.addEventListener('click', async () => {
   collPreviewStopBtn.disabled = true;
   if (collPreviewStatText) { collPreviewStatText.textContent = t('coacd.stopping'); }
   log(t('coacd.stopping'));
-  try { await fetch('/api/collision/coacd/cancel'); } catch (_e) { /* ignore */ }
+  try { await fetch('/api/collision/preview/cancel'); } catch (_e) { /* ignore */ }
 });
 // Abandon the in-flight generate job (the user switched collision mode mid-run).
 // Stop polling FIRST so the now-cancelled job's completion can't reach the
@@ -4504,7 +4504,7 @@ collPreviewStopBtn?.addEventListener('click', async () => {
 function collPreviewAbort() {
   if (collPreviewPoll) { clearInterval(collPreviewPoll); collPreviewPoll = null; }
   collPreviewSetBlink([]);                         // stop the per-link blink timer
-  try { fetch('/api/collision/coacd/cancel'); } catch (_e) { /* ignore */ }
+  try { fetch('/api/collision/preview/cancel'); } catch (_e) { /* ignore */ }
   collPreviewStat?.classList.remove('on');         // hide the "computing" banner
   if (collPreviewProg) { collPreviewProg.textContent = ''; }
   if (collPreviewGenBtn) { collPreviewGenBtn.disabled = false; }
@@ -4527,7 +4527,7 @@ collPreviewGenBtn?.addEventListener('click', async () => {
   const what = mode === 'hull' ? t('coll.hullword') : 'CoACD';
   try {
     const r = await (await fetch(
-      `/api/collision/coacd/init?mode=${encodeURIComponent(mode)}`
+      `/api/collision/preview/init?mode=${encodeURIComponent(mode)}`
       + `&quality=${encodeURIComponent(q)}`)).json();
     if (r.error) { throw new Error(r.error); }
     log(t('coacd.started', { q: mode === 'coacd' ? q : '', what }));

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1487,7 +1487,7 @@ def _build_collision(urdf_path, key, pkg_dir=None):
 # instant.  One job at a time.
 _coll_preview_job = {"running": False, "done": 0, "total": 0, "current": None,
               "inflight": [], "parts": {}, "error": None, "quality": None,
-              "cancel": False, "cancelled": False}
+              "mode": None, "cancel": False, "cancelled": False}
 _coll_preview_lock = threading.Lock()
 
 
@@ -1495,10 +1495,10 @@ def _reset_coll_preview_job():
     with _coll_preview_lock:
         _coll_preview_job.update(running=False, done=0, total=0, current=None,
                           inflight=[], parts={}, error=None, quality=None,
-                          cancel=False, cancelled=False)
+                          mode=None, cancel=False, cancelled=False)
 
 
-def _run_coll_preview_job(pkg_dir, robot_name, urdf_rel, quality):
+def _run_coll_preview_job(pkg_dir, robot_name, urdf_rel, quality, mode="coacd"):
     from sw2robot.exporter.ros_export import collision_preview_glbs
 
     def _on_start(link):                  # a link's decomposition began
@@ -1523,7 +1523,7 @@ def _run_coll_preview_job(pkg_dir, robot_name, urdf_rel, quality):
         # materialise URDF-mode edits to disk for the job (no-op in CAD mode),
         # restoring the pristine base when it ends
         with _um_materialized(pkg_dir, urdf_rel):
-            collision_preview_glbs(pkg_dir, robot_name, quality=quality,
+            collision_preview_glbs(pkg_dir, robot_name, quality=quality, mode=mode,
                                progress=_progress, on_start=_on_start,
                                should_cancel=_should_cancel)
         with _coll_preview_lock:
@@ -2036,7 +2036,7 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                         {"error": f"unsupported ros version: {ros}"}, 400)
                 ros_version = int(ros)
                 collision = (query.get("collision") or ["copy"])[0]
-                if collision not in ("copy", "coacd"):
+                if collision not in ("copy", "hull", "coacd"):
                     return self._send_json(
                         {"error": f"unsupported collision mode: {collision}"}, 400)
                 cquality = (query.get("cquality") or ["balanced"])[0]
@@ -2115,8 +2115,12 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 cls = type(self)
                 if not cls.pkg_dir:
                     return self._send_json({"error": "no package open"}, 400)
+                mode = (query.get("mode") or ["coacd"])[0]
+                if mode not in ("coacd", "hull"):
+                    return self._send_json(
+                        {"error": f"unsupported collision mode: {mode}"}, 400)
                 quality = (query.get("quality") or ["balanced"])[0]
-                if quality not in ("balanced", "fine"):
+                if mode == "coacd" and quality not in ("balanced", "fine"):
                     return self._send_json(
                         {"error": f"unsupported collision quality: {quality}"},
                         400)
@@ -2134,12 +2138,14 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                         return self._send_json({"error": "already running"}, 409)
                 _reset_coll_preview_job()
                 with _coll_preview_lock:
-                    _coll_preview_job.update(running=True, quality=quality)
+                    _coll_preview_job.update(running=True, quality=quality, mode=mode)
                 threading.Thread(
                     target=_run_coll_preview_job,
-                    args=(cls.pkg_dir, cls.robot_name, cls.urdf_rel, quality),
+                    args=(cls.pkg_dir, cls.robot_name, cls.urdf_rel, quality,
+                          mode),
                     daemon=True).start()
-                return self._send_json({"running": True, "quality": quality})
+                return self._send_json(
+                    {"running": True, "quality": quality, "mode": mode})
             if path == "/api/collision/coacd/cancel":
                 # request stop; the job ends at the next link boundary (CoACD
                 # itself is not interruptible mid-link)

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -575,7 +575,7 @@ exec ros2 launch "$PKG" display.launch.py
 
 def _export_zip(pkg_dir, robot_name, mesh_fmt="dae", ros_version=1,
                 pkg_name=None, urdf_name=None, colors=None,
-                collision="copy", collision_quality="balanced",
+                collision="copy", coacd_quality="balanced",
                 merge_fixed=False, mesh_dir=None):
     """ZIP a portable ROS package (package:// URLs), named ``pkg_name`` if given
     else ``<robot_name>_description``; the URDF inside is named ``urdf_name`` if
@@ -610,7 +610,7 @@ def _export_zip(pkg_dir, robot_name, mesh_fmt="dae", ros_version=1,
                                                urdf_name=urdf_name,
                                                colors=colors,
                                                collision=collision,
-                                               collision_quality=collision_quality,
+                                               coacd_quality=coacd_quality,
                                                merge_fixed=merge_fixed,
                                                mesh_dir=mesh_dir,
                                                **kwargs):
@@ -2072,7 +2072,7 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                                                 urdf_name=urdf_name,
                                                 colors=colors,
                                                 collision=collision,
-                                                collision_quality=cquality,
+                                                coacd_quality=cquality,
                                                 merge_fixed=merge_fixed,
                                                 mesh_dir=mesh_dir)
                 except ValueError as e:

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1534,13 +1534,13 @@ def _run_coll_preview_job(pkg_dir, robot_name, urdf_rel, quality, mode="coacd"):
         # the current one so the next /api/collision/init rebuilds with them
         with _coll_lock:
             _coll.update(key=None, ctx=None)
-        print(f"[sw2robot.web] coacd preview "
+        print(f"[sw2robot.web] collision preview "
               f"{'cancelled' if stopped else 'ready'}: "
               f"{len(_coll_preview_job['parts'])} links")
     except Exception as e:
         with _coll_preview_lock:
             _coll_preview_job.update(running=False, error=repr(e))
-        print(f"[sw2robot.web] coacd preview FAILED: {e!r}")
+        print(f"[sw2robot.web] collision preview FAILED: {e!r}")
 
 
 # ---- auto joint limits: self-collision sweep over the live collision model.
@@ -2111,7 +2111,7 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 self.end_headers()
                 self.wfile.write(body)
                 return None
-            if path == "/api/collision/coacd/init":
+            if path == "/api/collision/preview/init":
                 cls = type(self)
                 if not cls.pkg_dir:
                     return self._send_json({"error": "no package open"}, 400)
@@ -2119,8 +2119,11 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 if mode not in ("coacd", "hull"):
                     return self._send_json(
                         {"error": f"unsupported collision mode: {mode}"}, 400)
+                # quality only affects CoACD, but validate it regardless so a
+                # malformed value is never silently accepted (and echoed back)
+                # for hull
                 quality = (query.get("quality") or ["balanced"])[0]
-                if mode == "coacd" and quality not in ("balanced", "fine"):
+                if quality not in ("balanced", "fine"):
                     return self._send_json(
                         {"error": f"unsupported collision quality: {quality}"},
                         400)
@@ -2146,14 +2149,14 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                     daemon=True).start()
                 return self._send_json(
                     {"running": True, "quality": quality, "mode": mode})
-            if path == "/api/collision/coacd/cancel":
+            if path == "/api/collision/preview/cancel":
                 # request stop; the job ends at the next link boundary (CoACD
                 # itself is not interruptible mid-link)
                 with _coll_preview_lock:
                     if _coll_preview_job["running"]:
                         _coll_preview_job["cancel"] = True
                 return self._send_json({"cancelling": True})
-            if path == "/api/collision/coacd/status":
+            if path == "/api/collision/preview/status":
                 with _coll_preview_lock:
                     return self._send_json(dict(_coll_preview_job))
             if path.startswith("/pkg/"):

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1451,7 +1451,7 @@ def _build_collision(urdf_path, key, pkg_dir=None):
         parts = {}
         if pkg_dir:
             preview = os.path.join(pkg_dir, "meshes", ".coacd_cache", "preview")
-            parts = autoinit.load_coacd_parts(preview, list(meshes))
+            parts = autoinit.load_collision_parts(preview, list(meshes))
         if parts:
             sc = autoinit.SelfCollision(robot, meshes, parts=parts)
         else:
@@ -1485,50 +1485,50 @@ def _build_collision(urdf_path, key, pkg_dir=None):
 # the client polls progress and pops each link's collision mesh into the viewer
 # as it lands.  Parts are cached on disk, so a later collision='coacd' export is
 # instant.  One job at a time.
-_coacd_job = {"running": False, "done": 0, "total": 0, "current": None,
+_coll_preview_job = {"running": False, "done": 0, "total": 0, "current": None,
               "inflight": [], "parts": {}, "error": None, "quality": None,
               "cancel": False, "cancelled": False}
-_coacd_lock = threading.Lock()
+_coll_preview_lock = threading.Lock()
 
 
-def _reset_coacd_job():
-    with _coacd_lock:
-        _coacd_job.update(running=False, done=0, total=0, current=None,
+def _reset_coll_preview_job():
+    with _coll_preview_lock:
+        _coll_preview_job.update(running=False, done=0, total=0, current=None,
                           inflight=[], parts={}, error=None, quality=None,
                           cancel=False, cancelled=False)
 
 
-def _run_coacd_job(pkg_dir, robot_name, urdf_rel, quality):
-    from sw2robot.exporter.ros_export import coacd_preview_glbs
+def _run_coll_preview_job(pkg_dir, robot_name, urdf_rel, quality):
+    from sw2robot.exporter.ros_export import collision_preview_glbs
 
     def _on_start(link):                  # a link's decomposition began
-        with _coacd_lock:
-            if link not in _coacd_job["inflight"]:
-                _coacd_job["inflight"].append(link)
-            _coacd_job["current"] = link
+        with _coll_preview_lock:
+            if link not in _coll_preview_job["inflight"]:
+                _coll_preview_job["inflight"].append(link)
+            _coll_preview_job["current"] = link
 
     def _progress(done, total, link, rel):    # a link finished
-        with _coacd_lock:
-            _coacd_job["done"] = done
-            _coacd_job["total"] = total
-            if link in _coacd_job["inflight"]:
-                _coacd_job["inflight"].remove(link)
+        with _coll_preview_lock:
+            _coll_preview_job["done"] = done
+            _coll_preview_job["total"] = total
+            if link in _coll_preview_job["inflight"]:
+                _coll_preview_job["inflight"].remove(link)
             if rel:
-                _coacd_job["parts"][link] = "/pkg/" + rel
+                _coll_preview_job["parts"][link] = "/pkg/" + rel
 
     def _should_cancel():
-        with _coacd_lock:
-            return _coacd_job["cancel"]
+        with _coll_preview_lock:
+            return _coll_preview_job["cancel"]
     try:
         # materialise URDF-mode edits to disk for the job (no-op in CAD mode),
         # restoring the pristine base when it ends
         with _um_materialized(pkg_dir, urdf_rel):
-            coacd_preview_glbs(pkg_dir, robot_name, quality=quality,
+            collision_preview_glbs(pkg_dir, robot_name, quality=quality,
                                progress=_progress, on_start=_on_start,
                                should_cancel=_should_cancel)
-        with _coacd_lock:
-            stopped = _coacd_job["cancel"]
-            _coacd_job.update(running=False, current=None, inflight=[],
+        with _coll_preview_lock:
+            stopped = _coll_preview_job["cancel"]
+            _coll_preview_job.update(running=False, current=None, inflight=[],
                               cancelled=stopped)
         # the live self-collision model can now use these convex parts -- drop
         # the current one so the next /api/collision/init rebuilds with them
@@ -1536,10 +1536,10 @@ def _run_coacd_job(pkg_dir, robot_name, urdf_rel, quality):
             _coll.update(key=None, ctx=None)
         print(f"[sw2robot.web] coacd preview "
               f"{'cancelled' if stopped else 'ready'}: "
-              f"{len(_coacd_job['parts'])} links")
+              f"{len(_coll_preview_job['parts'])} links")
     except Exception as e:
-        with _coacd_lock:
-            _coacd_job.update(running=False, error=repr(e))
+        with _coll_preview_lock:
+            _coll_preview_job.update(running=False, error=repr(e))
         print(f"[sw2robot.web] coacd preview FAILED: {e!r}")
 
 
@@ -2015,7 +2015,7 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 # load the new one (plain URDF -> in-memory overlay; a CAD package
                 # uses the joints.yaml + build() path, no overlay)
                 _um_close()
-                _reset_coacd_job()        # drop the previous package's preview
+                _reset_coll_preview_job()        # drop the previous package's preview
                 if not _cad_mode(pkg):
                     _um_load(pkg, rel)
                 print(f"[sw2robot.web] open: {cls.robot_name} ({pkg})"
@@ -2129,27 +2129,27 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                     return self._send_json(
                         {"error": "collision generation needs the standard "
                          "<pkg>/urdf/<name>.urdf + <pkg>/meshes/ layout"}, 400)
-                with _coacd_lock:
-                    if _coacd_job["running"]:
+                with _coll_preview_lock:
+                    if _coll_preview_job["running"]:
                         return self._send_json({"error": "already running"}, 409)
-                _reset_coacd_job()
-                with _coacd_lock:
-                    _coacd_job.update(running=True, quality=quality)
+                _reset_coll_preview_job()
+                with _coll_preview_lock:
+                    _coll_preview_job.update(running=True, quality=quality)
                 threading.Thread(
-                    target=_run_coacd_job,
+                    target=_run_coll_preview_job,
                     args=(cls.pkg_dir, cls.robot_name, cls.urdf_rel, quality),
                     daemon=True).start()
                 return self._send_json({"running": True, "quality": quality})
             if path == "/api/collision/coacd/cancel":
                 # request stop; the job ends at the next link boundary (CoACD
                 # itself is not interruptible mid-link)
-                with _coacd_lock:
-                    if _coacd_job["running"]:
-                        _coacd_job["cancel"] = True
+                with _coll_preview_lock:
+                    if _coll_preview_job["running"]:
+                        _coll_preview_job["cancel"] = True
                 return self._send_json({"cancelling": True})
             if path == "/api/collision/coacd/status":
-                with _coacd_lock:
-                    return self._send_json(dict(_coacd_job))
+                with _coll_preview_lock:
+                    return self._send_json(dict(_coll_preview_job))
             if path.startswith("/pkg/"):
                 if not cls.pkg_dir:
                     return self.send_error(404, "no package open")

--- a/sw2robot/exporter/export.py
+++ b/sw2robot/exporter/export.py
@@ -319,11 +319,14 @@ def main():
                     help="package-relative directory the --ros-pkg meshes go in "
                          "and that the URDF's package:// refs point at (default: "
                          "'meshes'); e.g. 'urdf/mesh' for a different layout")
-    ap.add_argument("--collision", choices=("copy", "coacd"), default="copy",
+    ap.add_argument("--collision", choices=("copy", "hull", "coacd"),
+                    default="copy",
                     help="--ros-pkg <collision> geometry: 'copy' (default) "
-                         "reuses the visual mesh as one STL; 'coacd' runs "
-                         "approximate convex decomposition into convex part "
-                         "STLs (needs: pip install coacd)")
+                         "reuses the visual mesh as one STL; 'hull' replaces it "
+                         "with a single convex hull STL (simple collision, good "
+                         "for path planning); 'coacd' runs approximate convex "
+                         "decomposition into convex part STLs (needs: pip "
+                         "install coacd)")
     ap.add_argument("--collision-quality", choices=("balanced", "fine"),
                     default="balanced",
                     help="CoACD preset for --collision coacd: 'balanced' "

--- a/sw2robot/exporter/export.py
+++ b/sw2robot/exporter/export.py
@@ -198,7 +198,7 @@ def _loop_closures_cfg(model, joint_overrides):
 # ---------------------------------------------------------------- build
 def build(pkg_dir, config_path=None, base_hint=None, exclude=None,
           ros_pkg=False, density=None, ros_version=1, ros_pkg_name=None,
-          ros_urdf_name=None, collision="copy", collision_quality="balanced",
+          ros_urdf_name=None, collision="copy", coacd_quality="balanced",
           merge_fixed=False, ros_mesh_dir=None):
     _tolerant_console()
     graph = GraphState.load(os.path.join(pkg_dir, GRAPH_FILE))
@@ -258,7 +258,7 @@ def build(pkg_dir, config_path=None, base_hint=None, exclude=None,
             pkg_dir, robot_name, os.path.dirname(os.path.abspath(pkg_dir)),
             ros_version=ros_version, pkg_name=ros_pkg_name,
             urdf_name=ros_urdf_name, colors=colors,
-            collision=collision, collision_quality=collision_quality,
+            collision=collision, coacd_quality=coacd_quality,
             merge_fixed=merge_fixed, mesh_dir=ros_mesh_dir,
             loop_closures=closures)
 
@@ -277,13 +277,13 @@ def build(pkg_dir, config_path=None, base_hint=None, exclude=None,
 def export(assembly_path, out_dir=None, robot_name=None, visible=False,
            config_path=None, base_hint=None, exclude=None, ros_pkg=False,
            ros_version=1, ros_pkg_name=None, ros_urdf_name=None,
-           collision="copy", collision_quality="balanced", merge_fixed=False,
+           collision="copy", coacd_quality="balanced", merge_fixed=False,
            ros_mesh_dir=None):
     pkg_dir = extract(assembly_path, out_dir, robot_name, visible)
     return build(pkg_dir, config_path=config_path, base_hint=base_hint,
                  exclude=exclude, ros_pkg=ros_pkg, ros_version=ros_version,
                  ros_pkg_name=ros_pkg_name, ros_urdf_name=ros_urdf_name,
-                 collision=collision, collision_quality=collision_quality,
+                 collision=collision, coacd_quality=coacd_quality,
                  merge_fixed=merge_fixed, ros_mesh_dir=ros_mesh_dir)
 
 
@@ -323,11 +323,10 @@ def main():
                     default="copy",
                     help="--ros-pkg <collision> geometry: 'copy' (default) "
                          "reuses the visual mesh as one STL; 'hull' replaces it "
-                         "with a single convex hull STL (simple collision, good "
-                         "for path planning); 'coacd' runs approximate convex "
-                         "decomposition into convex part STLs (needs: pip "
+                         "with a single convex hull STL; 'coacd' runs approximate "
+                         "convex decomposition into convex part STLs (needs: pip "
                          "install coacd)")
-    ap.add_argument("--collision-quality", choices=("balanced", "fine"),
+    ap.add_argument("--coacd-quality", choices=("balanced", "fine"),
                     default="balanced",
                     help="CoACD preset for --collision coacd: 'balanced' "
                          "(default, ~5-6 parts/link, ~8-60s) or 'fine' "
@@ -343,7 +342,7 @@ def main():
            ros_pkg=args.ros_pkg or args.ros2,
            ros_version=2 if args.ros2 else 1,
            ros_pkg_name=args.ros_pkg_name, ros_urdf_name=args.ros_urdf_name,
-           collision=args.collision, collision_quality=args.collision_quality,
+           collision=args.collision, coacd_quality=args.coacd_quality,
            merge_fixed=args.merge_fixed, ros_mesh_dir=args.ros_mesh_dir)
 
 

--- a/sw2robot/exporter/ros_export.py
+++ b/sw2robot/exporter/ros_export.py
@@ -423,11 +423,32 @@ def _coacd_part_stls(src, quality, cache_dir):
         return out
 
 
-# a fixed high-contrast palette so adjacent convex parts read apart in the viewer
+def _hull_part_stls(src):
+    """``[stl_bytes]`` -- the source mesh ``src`` reduced to a SINGLE watertight
+    convex hull (one STL in metres). """
+    hull = _load_mesh_metres(src).convex_hull
+    hull.units = "meter"
+    return [hull.export(file_type="stl")]
+
+
+def _collision_part_stls(src, mode, quality, cache_dir):
+    """``[stl_bytes, ...]`` -- the convex collision part(s) for ``src`` per the
+    selected ``mode``: ``"coacd"`` runs CoACD approximate convex decomposition
+    (many parts, slow, disk-cached under ``cache_dir``); ``"hull"`` returns a
+    single convex hull (fast, no optional dep).  The single-vs-many distinction
+    is the only difference downstream consumers see."""
+    if mode == "hull":
+        return _hull_part_stls(src)
+    return _coacd_part_stls(src, quality, cache_dir)
+
+
+# a fixed high-contrast palette so adjacent convex parts read apart in the viewer.
+# NO red/salmon: red is the self-collision highlight colour, so a red preview part
+# (a single-part hull is always palette[0]) would read as a collision.
 _COLLISION_PALETTE = (
-    (228, 26, 28), (55, 126, 184), (77, 175, 74), (152, 78, 163),
-    (255, 127, 0), (210, 210, 40), (166, 86, 40), (247, 129, 191),
-    (102, 194, 165), (252, 141, 98), (141, 160, 203), (153, 153, 153),
+    (55, 126, 184), (77, 175, 74), (152, 78, 163), (255, 127, 0),
+    (210, 210, 40), (166, 86, 40), (247, 129, 191), (102, 194, 165),
+    (141, 160, 203), (153, 153, 153),
 )
 
 
@@ -574,15 +595,18 @@ def _bake_origins(root, pkg_dir, own_pkgs, cache):
 
 def collision_preview_glbs(pkg_dir, robot_name, quality="balanced", progress=None,
                        urdf_path=None, should_cancel=None, on_start=None,
-                       max_workers=None):
-    """Decompose every link's ``<collision>`` mesh with CoACD and write one
-    colour-coded preview GLB per link under ``meshes/.coacd_cache/preview/`` (the
-    convex parts, each part a distinct colour, the collision ``<origin>`` baked
-    in so the GLB sits at the link frame).  Shares the on-disk part cache with
-    the ROS export, so generating the preview also warms a later ``collision=
-    'coacd'`` export.
+                       max_workers=None, mode="coacd"):
+    """Build a colour-coded convex-collision preview GLB per link under
+    ``meshes/.coacd_cache/preview/`` (the convex part(s), each a distinct colour,
+    the collision ``<origin>`` baked in so the GLB sits at the link frame).
 
-    Links are decomposed CONCURRENTLY in a thread pool -- CoACD releases the GIL,
+    ``mode`` selects the geometry: ``"coacd"`` (default) runs CoACD approximate
+    convex decomposition into many parts -- shares the on-disk part cache with
+    the ROS export, so generating the preview also warms a later ``collision=
+    'coacd'`` export; ``"hull"`` produces a single convex hull per link (fast,
+    no optional dependency).
+
+    Links are processed CONCURRENTLY in a thread pool -- CoACD releases the GIL,
     so this scales with cores (measured ~4x on a 12-core box).  ``max_workers``
     defaults to ``cpu_count - 2`` (capped at 8).
 
@@ -603,12 +627,17 @@ def collision_preview_glbs(pkg_dir, robot_name, quality="balanced", progress=Non
     import numpy as np
     import trimesh
 
-    if quality not in _COACD_PRESETS:
-        raise ValueError(f"unsupported collision_quality: {quality!r} "
-                         f"(use one of {sorted(_COACD_PRESETS)})")
-    if not coacd_available():
-        raise ValueError("CoACD collision decomposition needs the optional "
-                         "'coacd' package -- install it with: pip install coacd")
+    if mode == "coacd":
+        if quality not in _COACD_PRESETS:
+            raise ValueError(f"unsupported collision_quality: {quality!r} "
+                             f"(use one of {sorted(_COACD_PRESETS)})")
+        if not coacd_available():
+            raise ValueError(
+                "CoACD collision decomposition needs the optional 'coacd' "
+                "package -- install it with: pip install coacd")
+    elif mode != "hull":
+        raise ValueError(f"unsupported collision mode: {mode!r} "
+                         "(use 'coacd' or 'hull')")
     cache_dir = os.path.join(pkg_dir, "meshes", ".coacd_cache")
     preview_dir = os.path.join(cache_dir, "preview")
     os.makedirs(preview_dir, exist_ok=True)
@@ -658,7 +687,7 @@ def collision_preview_glbs(pkg_dir, robot_name, quality="balanced", progress=Non
         scene = trimesh.Scene()
         part_i = 0
         for src, mat in blocks:
-            for data in _coacd_part_stls(src, quality, cache_dir):
+            for data in _collision_part_stls(src, mode, quality, cache_dir):
                 part = trimesh.load(io.BytesIO(data), file_type="stl")
                 part.apply_transform(mat)
                 rgb = _COLLISION_PALETTE[part_i % len(_COLLISION_PALETTE)]
@@ -941,11 +970,15 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
 
     ``collision`` chooses how ``<collision>`` geometry is produced: ``'copy'``
     (default) reuses the visual mesh as one STL (the current behaviour);
-    ``'coacd'`` runs CoACD approximate convex decomposition, replacing each
-    ``<collision>``'s mesh with a set of convex part STLs (better for physics
-    engines).  ``collision_quality`` (``'balanced'`` | ``'fine'``) picks the
-    CoACD preset.  ``'coacd'`` needs the optional ``coacd`` package; its absence
-    raises a clear error.  Decomposition is cached under ``meshes/.coacd_cache``.
+    ``'hull'`` replaces each ``<collision>``'s mesh with a single convex hull
+    STL (the "simple collision" alternative -- one convex shape per link, what
+    path planning usually wants); ``'coacd'`` runs CoACD approximate convex
+    decomposition, replacing each ``<collision>``'s mesh with a *set* of convex
+    part STLs (better for high-fidelity physics).  ``collision_quality``
+    (``'balanced'`` | ``'fine'``) picks the CoACD preset and is ignored for the
+    other modes.  ``'coacd'`` needs the optional ``coacd`` package; its absence
+    raises a clear error.  ``'hull'`` has no extra dependency.  CoACD
+    decomposition is cached under ``meshes/.coacd_cache``.
 
     ``ros_version`` picks the build system: ``1`` (default) writes a catkin
     ``package.xml`` (format 2) + ``CMakeLists.txt``; ``2`` writes an ament_cmake
@@ -965,9 +998,9 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
     before any entries are emitted, so a half-rewritten package never ships."""
     if ros_version not in (1, 2):
         raise ValueError(f"unsupported ros_version: {ros_version}")
-    if collision not in ("copy", "coacd"):
+    if collision not in ("copy", "hull", "coacd"):
         raise ValueError(f"unsupported collision mode: {collision!r} "
-                         "(use 'copy' or 'coacd')")
+                         "(use 'copy', 'hull' or 'coacd')")
     if collision == "coacd":
         if collision_quality not in _COACD_PRESETS:
             raise ValueError(
@@ -1026,38 +1059,46 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
     files = []
     used_names = set()
     errors = []
-    # CoACD parts: keyed by source + quality so a source shared by several links
-    # decomposes once (CoACD itself is also disk-cached under .coacd_cache)
-    coacd_done = {}
+    # convex collision parts ('coacd' = many, 'hull' = one): keyed by source +
+    # mode + quality so a source shared by several links is built once (CoACD is
+    # also disk-cached under .coacd_cache)
+    coll_done = {}
 
-    def _emit_coacd(base, src):
-        # CoACD-decompose a source mesh into convex collision part STLs; returns
-        # the list of emitted mesh names (one per convex part), or None on error.
-        key = (os.path.abspath(src), collision_quality)
-        if key in coacd_done:
-            return coacd_done[key]
+    def _emit_collision(base, src):
+        # build the convex collision part STL(s) for a source mesh per the
+        # selected `collision` mode; returns the emitted mesh names (one per
+        # part -- a single hull, or N CoACD parts), or None on error.
+        key = (os.path.abspath(src), collision, collision_quality)
+        if key in coll_done:
+            return coll_done[key]
         try:
-            blobs = _coacd_part_stls(src, collision_quality, coacd_cache_dir)
+            blobs = _collision_part_stls(src, collision, collision_quality,
+                                         coacd_cache_dir)
         except Exception as e:
-            errors.append(f"{base}: coacd decompose failed ({e!r})")
+            errors.append(f"{base}: {collision} collision failed ({e!r})")
             return None
         names = []
         for i, data in enumerate(blobs):
-            name, j = f"{base}_collision_{i}.stl", 1
+            # hull is one part per link, so name it for what it is; CoACD parts
+            # keep their indexed names
+            stem = f"{base}_collision_hull" if collision == "hull" \
+                else f"{base}_collision_{i}"
+            name, j = f"{stem}.stl", 1
             while name in used_names:
                 j += 1
-                name = f"{base}_collision_{i}_{j}.stl"
+                name = f"{stem}_{j}.stl"
             used_names.add(name)
             files.append((f"{pkg}/{mesh_rel}/{name}", data))
             names.append(name)
-        coacd_done[key] = names
+        coll_done[key] = names
         return names
 
-    def _expand_collision_coacd(link):
+    def _expand_collision(link):
         # replace each <collision> whose single mesh is a convertible source with
-        # N <collision> blocks (one per convex part), preserving its <origin>.
-        # Blocks we can't decompose (primitive geometry, external/missing mesh,
-        # multi-mesh) are left to the normal per-mesh path below.
+        # the convex collision part(s) (one block per part -- a single hull, or N
+        # CoACD parts), preserving its <origin>.  Blocks we can't convert
+        # (primitive geometry, external/missing mesh, multi-mesh) are left to the
+        # normal per-mesh path below.
         for block in list(link.findall("collision")):
             meshes = list(block.iter("mesh"))
             if len(meshes) != 1:
@@ -1069,7 +1110,7 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
             if src is None:
                 errors.append(f"no source mesh for '{base}'")
                 continue
-            names = _emit_coacd(base, src)
+            names = _emit_collision(base, src)
             if not names:
                 continue
             m_bake = bake.get(id(meshes[0]))
@@ -1078,7 +1119,7 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
             # deep-copy the original block per part so <origin> + formatting carry
             for k, name in enumerate(names):
                 nb = copy.deepcopy(block)
-                if m_bake is not None:         # CoACD parts are in source frame:
+                if m_bake is not None:         # parts are in the source frame:
                     _set_origin_el(nb, m_bake)  # carry the bake transform here
                 next(nb.iter("mesh")).set(
                     "filename", f"package://{pkg}/{mesh_rel}/{name}")
@@ -1087,12 +1128,13 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
     if collision == "coacd":
         # CoACD is the heaviest per-mesh op; warm its disk cache for every unique
         # collision source IN PARALLEL (CoACD releases the GIL) so the serial
-        # expansion below is all cache hits
+        # expansion below is all cache hits.  'hull' is fast and not disk-cached,
+        # so it needs no warming -- _emit_collision builds it inline.
         def _warm_coacd(src):
             try:
                 _coacd_part_stls(src, collision_quality, coacd_cache_dir)
             except Exception:
-                pass                        # the real error resurfaces in _emit_coacd
+                pass                        # the real error resurfaces in _emit_collision
         _parallel(_warm_coacd,
                   set(_iter_sources(root, pkg_dir, own_pkgs, ("collision",))))
 
@@ -1113,11 +1155,11 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
         # colour overrides are keyed by LINK name in URDF-input mode and by the
         # component/mesh basename in the CAD path -- accept either
         link_color = colors.get(link.get("name"))
-        if collision == "coacd":
-            _expand_collision_coacd(link)
+        if collision in ("coacd", "hull"):
+            _expand_collision(link)
         for ctx, fmt in ctx_fmt:
-            if ctx == "collision" and collision == "coacd":
-                continue                   # handled by _expand_collision_coacd
+            if ctx == "collision" and collision in ("coacd", "hull"):
+                continue                   # handled by _expand_collision
             for block in link.findall(ctx):
                 for mesh in block.iter("mesh"):
                     base, src, _ext = _resolve_mesh(pkg_dir, mesh.get("filename"),

--- a/sw2robot/exporter/ros_export.py
+++ b/sw2robot/exporter/ros_export.py
@@ -629,7 +629,7 @@ def collision_preview_glbs(pkg_dir, robot_name, quality="balanced", progress=Non
 
     if mode == "coacd":
         if quality not in _COACD_PRESETS:
-            raise ValueError(f"unsupported collision_quality: {quality!r} "
+            raise ValueError(f"unsupported coacd_quality: {quality!r} "
                              f"(use one of {sorted(_COACD_PRESETS)})")
         if not coacd_available():
             raise ValueError(
@@ -945,7 +945,7 @@ def _iter_sources(root, pkg_dir, own_pkgs, contexts):
 def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
                           ctx_fmt=_CTX_FMT, ros_version=1, pkg_name=None,
                           urdf_name=None, colors=None, collision="copy",
-                          collision_quality="balanced", merge_fixed=False,
+                          coacd_quality="balanced", merge_fixed=False,
                           mesh_dir=None, loop_closures=None,
                           zero_origins=True):
     """``pkg_dir`` (a built package) -> ``[(arcname, bytes), ...]`` for a portable
@@ -974,7 +974,7 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
     STL (the "simple collision" alternative -- one convex shape per link, what
     path planning usually wants); ``'coacd'`` runs CoACD approximate convex
     decomposition, replacing each ``<collision>``'s mesh with a *set* of convex
-    part STLs (better for high-fidelity physics).  ``collision_quality``
+    part STLs (better for high-fidelity physics).  ``coacd_quality``
     (``'balanced'`` | ``'fine'``) picks the CoACD preset and is ignored for the
     other modes.  ``'coacd'`` needs the optional ``coacd`` package; its absence
     raises a clear error.  ``'hull'`` has no extra dependency.  CoACD
@@ -1002,9 +1002,9 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
         raise ValueError(f"unsupported collision mode: {collision!r} "
                          "(use 'copy', 'hull' or 'coacd')")
     if collision == "coacd":
-        if collision_quality not in _COACD_PRESETS:
+        if coacd_quality not in _COACD_PRESETS:
             raise ValueError(
-                f"unsupported collision_quality: {collision_quality!r} "
+                f"unsupported coacd_quality: {coacd_quality!r} "
                 f"(use one of {sorted(_COACD_PRESETS)})")
         if not coacd_available():
             raise ValueError(
@@ -1068,11 +1068,11 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
         # build the convex collision part STL(s) for a source mesh per the
         # selected `collision` mode; returns the emitted mesh names (one per
         # part -- a single hull, or N CoACD parts), or None on error.
-        key = (os.path.abspath(src), collision, collision_quality)
+        key = (os.path.abspath(src), collision, coacd_quality)
         if key in coll_done:
             return coll_done[key]
         try:
-            blobs = _collision_part_stls(src, collision, collision_quality,
+            blobs = _collision_part_stls(src, collision, coacd_quality,
                                          coacd_cache_dir)
         except Exception as e:
             errors.append(f"{base}: {collision} collision failed ({e!r})")
@@ -1132,7 +1132,7 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
         # so it needs no warming -- _emit_collision builds it inline.
         def _warm_coacd(src):
             try:
-                _coacd_part_stls(src, collision_quality, coacd_cache_dir)
+                _coacd_part_stls(src, coacd_quality, coacd_cache_dir)
             except Exception:
                 pass                        # the real error resurfaces in _emit_collision
         _parallel(_warm_coacd,
@@ -1266,14 +1266,14 @@ def write_ros_description_package(pkg_dir, robot_name, dest_dir,
                                   email="auto@example.com", ros_version=1,
                                   pkg_name=None, urdf_name=None, colors=None,
                                   collision="copy",
-                                  collision_quality="balanced",
+                                  coacd_quality="balanced",
                                   merge_fixed=False, mesh_dir=None,
                                   loop_closures=None, zero_origins=True):
     """Write the ROS package under ``dest_dir`` and return its directory path.
     The package is named ``pkg_name`` if given, else ``<robot_name>_description``;
     the URDF inside is named ``urdf_name`` if given, else the package name.
     ``ros_version`` (1 = catkin, 2 = ament_cmake), ``colors`` (per-link colour
-    overrides), ``collision`` / ``collision_quality`` (CoACD collision-mesh
+    overrides), ``collision`` / ``coacd_quality`` (CoACD collision-mesh
     decomposition), ``merge_fixed`` (lump fixed-joint children into parents),
     ``mesh_dir`` (package-relative mesh directory, default ``meshes``) and
     ``loop_couplings`` (ROS 2 closed-loop relay node + config) are passed
@@ -1283,7 +1283,7 @@ def write_ros_description_package(pkg_dir, robot_name, dest_dir,
                                   ros_version=ros_version, pkg_name=pkg,
                                   urdf_name=urdf_name, colors=colors,
                                   collision=collision,
-                                  collision_quality=collision_quality,
+                                  coacd_quality=coacd_quality,
                                   merge_fixed=merge_fixed, mesh_dir=mesh_dir,
                                   loop_closures=loop_closures,
                                   zero_origins=zero_origins)

--- a/sw2robot/exporter/ros_export.py
+++ b/sw2robot/exporter/ros_export.py
@@ -424,7 +424,7 @@ def _coacd_part_stls(src, quality, cache_dir):
 
 
 # a fixed high-contrast palette so adjacent convex parts read apart in the viewer
-_COACD_PALETTE = (
+_COLLISION_PALETTE = (
     (228, 26, 28), (55, 126, 184), (77, 175, 74), (152, 78, 163),
     (255, 127, 0), (210, 210, 40), (166, 86, 40), (247, 129, 191),
     (102, 194, 165), (252, 141, 98), (141, 160, 203), (153, 153, 153),
@@ -572,7 +572,7 @@ def _bake_origins(root, pkg_dir, own_pkgs, cache):
     return bake, tf_scale
 
 
-def coacd_preview_glbs(pkg_dir, robot_name, quality="balanced", progress=None,
+def collision_preview_glbs(pkg_dir, robot_name, quality="balanced", progress=None,
                        urdf_path=None, should_cancel=None, on_start=None,
                        max_workers=None):
     """Decompose every link's ``<collision>`` mesh with CoACD and write one
@@ -661,7 +661,7 @@ def coacd_preview_glbs(pkg_dir, robot_name, quality="balanced", progress=None,
             for data in _coacd_part_stls(src, quality, cache_dir):
                 part = trimesh.load(io.BytesIO(data), file_type="stl")
                 part.apply_transform(mat)
-                rgb = _COACD_PALETTE[part_i % len(_COACD_PALETTE)]
+                rgb = _COLLISION_PALETTE[part_i % len(_COLLISION_PALETTE)]
                 part.visual = trimesh.visual.ColorVisuals(
                     mesh=part,
                     face_colors=np.tile([*rgb, 255], (len(part.faces), 1)))

--- a/tests/test_coacd_collision.py
+++ b/tests/test_coacd_collision.py
@@ -5,7 +5,7 @@ box meshes (trimesh + python-fcl only, no skrobot)."""
 import numpy as np
 import trimesh
 
-from sw2robot.editor.autoinit import SelfCollision, load_coacd_parts
+from sw2robot.editor.autoinit import SelfCollision, load_collision_parts
 
 
 def _box(center):
@@ -41,7 +41,7 @@ class _Robot:
         self.joint_list = []          # no joints -> no adjacency baseline
 
 
-def test_load_coacd_parts_roundtrip(tmp_path):
+def test_load_collision_parts_roundtrip(tmp_path):
     """A preview GLB of N parts loads back as N meshes in the same frame."""
     preview = tmp_path / "preview"
     preview.mkdir()
@@ -50,7 +50,7 @@ def test_load_coacd_parts_roundtrip(tmp_path):
     scene.add_geometry(_box((3, 0, 0)))
     (preview / "my_link.glb").write_bytes(scene.export(file_type="glb"))
 
-    parts = load_coacd_parts(str(preview), ["my_link", "absent_link"])
+    parts = load_collision_parts(str(preview), ["my_link", "absent_link"])
     assert set(parts) == {"my_link"}            # absent link omitted
     assert len(parts["my_link"]) == 2
     # frame preserved: the two boxes still span x in [-0.5, 3.5]

--- a/tests/test_ros_export.py
+++ b/tests/test_ros_export.py
@@ -122,6 +122,40 @@ def test_merge_fixed_plus_coacd_compose(tmp_path, monkeypatch):
     assert len(a.findall("visual")) == 2                 # both visuals lumped in
 
 
+def test_collision_hull_single_convex_part(tmp_path):
+    """collision='hull' replaces the link's collision mesh with ONE convex-hull
+    STL (no optional dep, no CoACD), leaving the visual mesh untouched."""
+    import xml.etree.ElementTree as ET
+
+    import trimesh
+
+    from sw2robot.exporter.ros_export import build_ros_description
+
+    pkg_dir = _make_pkg(tmp_path, robot="fing")
+    files = dict(build_ros_description(pkg_dir, "fing", collision="hull"))
+    arcs = set(files)
+
+    # the single hull STL ships; the per-link copy STL does NOT
+    hull_arc = "fing_description/meshes/part_collision_hull.stl"
+    assert hull_arc in arcs
+    assert "fing_description/meshes/part.stl" not in arcs
+    assert "fing_description/meshes/part.dae" in arcs            # visual untouched
+
+    root = ET.fromstring(files["fing_description/urdf/fing_description.urdf"].decode())
+    link = root.find("link")
+    cols = link.findall("collision")
+    assert len(cols) == 1                                        # one hull, not N
+    assert (cols[0].find(".//mesh").get("filename")
+            == "package://fing_description/meshes/part_collision_hull.stl")
+    assert (link.find("visual").find(".//mesh").get("filename")
+            == "package://fing_description/meshes/part.dae")
+
+    # the emitted STL is genuinely a convex hull
+    hull = trimesh.load(io.BytesIO(files[hull_arc]), file_type="stl")
+    assert hull.is_convex
+    assert len(hull.vertices) > 0
+
+
 def test_mesh_to_dae_scale_and_loadable():
     if not os.path.exists(_SAMPLE_MESH):
         pytest.skip("sample .3dxml mesh not present")

--- a/tests/test_ros_export.py
+++ b/tests/test_ros_export.py
@@ -573,7 +573,7 @@ def test_preview_warms_export_cache(tmp_path, monkeypatch):
 
     pkg_dir = _make_pkg(tmp_path, robot="c")
     # 1) generate the preview (decomposes the one mesh -> 1 CoACD run)
-    ros_export.coacd_preview_glbs(pkg_dir, "c", quality="balanced")
+    ros_export.collision_preview_glbs(pkg_dir, "c", quality="balanced")
     assert calls["n"] == 1
     # 2) export with collision='coacd' -- reuses the cache, no second CoACD run
     files = dict(ros_export.build_ros_description(pkg_dir, "c",
@@ -588,8 +588,8 @@ def test_preview_warms_export_cache(tmp_path, monkeypatch):
     assert len(link.findall("collision")) == 2
 
 
-def test_coacd_preview_glbs_per_link(tmp_path, monkeypatch):
-    """coacd_preview_glbs writes one colour-coded GLB per link with a collision
+def test_collision_preview_glbs_per_link(tmp_path, monkeypatch):
+    """collision_preview_glbs writes one colour-coded GLB per link with a collision
     mesh, reports progress per link, and shares the export's part cache."""
     import trimesh
 
@@ -601,7 +601,7 @@ def test_coacd_preview_glbs_per_link(tmp_path, monkeypatch):
 
     pkg_dir = _make_pkg(tmp_path, robot="c")
     seen = []
-    out = ros_export.coacd_preview_glbs(
+    out = ros_export.collision_preview_glbs(
         pkg_dir, "c", quality="balanced",
         progress=lambda d, t, link, rel: seen.append((d, t, link, rel)))
 

--- a/tests/test_ros_export.py
+++ b/tests/test_ros_export.py
@@ -156,6 +156,60 @@ def test_collision_hull_single_convex_part(tmp_path):
     assert len(hull.vertices) > 0
 
 
+def test_collision_hull_preserves_nonidentity_origin(tmp_path):
+    """A <collision> with a non-identity <origin> keeps that transform on the
+    hull block: the hull STL is emitted in the SOURCE frame, so dropping the
+    origin would misplace the collision volume (the same <origin> guarantee the
+    CoACD path gives, but hull was never exercised with a moved origin)."""
+    import xml.etree.ElementTree as ET
+
+    from sw2robot.exporter.ros_export import build_ros_description
+
+    if not os.path.exists(_SAMPLE_MESH):
+        pytest.skip("sample .3dxml mesh not present")
+    (tmp_path / "meshes").mkdir()
+    (tmp_path / "urdf").mkdir()
+    shutil.copy(_SAMPLE_MESH, tmp_path / "meshes" / "part.3dxml")
+    urdf = (
+        '<?xml version="1.0"?>\n<robot name="o">\n'
+        '  <link name="base_link">\n'
+        '    <visual><geometry>'
+        '<mesh filename="../meshes/part.3dxml"/></geometry></visual>\n'
+        '    <collision><origin xyz="0.05 0 0" rpy="0 0 0"/><geometry>'
+        '<mesh filename="../meshes/part.3dxml"/></geometry></collision>\n'
+        '  </link>\n</robot>\n')
+    (tmp_path / "urdf" / "o.urdf").write_text(urdf, encoding="utf-8")
+
+    files = dict(build_ros_description(str(tmp_path), "o", collision="hull"))
+    link = ET.fromstring(
+        files["o_description/urdf/o_description.urdf"].decode()).find("link")
+    cols = link.findall("collision")
+    assert len(cols) == 1
+    assert "part_collision_hull.stl" in cols[0].find(".//mesh").get("filename")
+    # the moved origin survives onto the hull block (not zeroed / not dropped)
+    xyz = [float(x) for x in cols[0].find("origin").get("xyz").split()]
+    assert abs(xyz[0] - 0.05) < 1e-6
+    assert abs(xyz[1]) < 1e-6 and abs(xyz[2]) < 1e-6
+
+
+def test_collision_hull_needs_no_coacd(tmp_path, monkeypatch):
+    """hull mode is trimesh-only: it must still emit its convex hull when CoACD
+    is unavailable -- this pins the PR's "no optional dependency" claim, which
+    the plain hull test can't (it would pass with CoACD installed too)."""
+    import trimesh
+
+    from sw2robot.exporter import ros_export
+
+    monkeypatch.setattr(ros_export, "coacd_available", lambda: False)
+    pkg_dir = _make_pkg(tmp_path, robot="fing")
+    files = dict(ros_export.build_ros_description(
+        pkg_dir, "fing", collision="hull"))
+    hull_arc = "fing_description/meshes/part_collision_hull.stl"
+    assert hull_arc in files
+    hull = trimesh.load(io.BytesIO(files[hull_arc]), file_type="stl")
+    assert hull.is_convex and len(hull.vertices) > 0
+
+
 def test_mesh_to_dae_scale_and_loadable():
     if not os.path.exists(_SAMPLE_MESH):
         pytest.skip("sample .3dxml mesh not present")

--- a/tests/test_ros_export.py
+++ b/tests/test_ros_export.py
@@ -583,9 +583,9 @@ def test_coacd_invalid_quality_rejected(tmp_path, monkeypatch):
 
     monkeypatch.setattr(ros_export, "coacd_available", lambda: True)
     pkg_dir = _make_pkg(tmp_path, robot="c")
-    with pytest.raises(ValueError, match="collision_quality"):
+    with pytest.raises(ValueError, match="coacd_quality"):
         ros_export.build_ros_description(pkg_dir, "c", collision="coacd",
-                                         collision_quality="ultra")
+                                         coacd_quality="ultra")
 
 
 def test_preview_warms_export_cache(tmp_path, monkeypatch):

--- a/tests/test_urdf_mode_webserver.py
+++ b/tests/test_urdf_mode_webserver.py
@@ -866,7 +866,7 @@ def test_coacd_preview_endpoints(server, monkeypatch):
 
     def fake_preview(pkg_dir, robot_name, quality="balanced", progress=None,
                      urdf_path=None, should_cancel=None, on_start=None,
-                     max_workers=None):
+                     max_workers=None, mode="coacd"):
         pdir = os.path.join(pkg_dir, "meshes", ".coacd_cache", "preview")
         os.makedirs(pdir, exist_ok=True)
         out = {}
@@ -905,6 +905,49 @@ def test_coacd_preview_endpoints(server, monkeypatch):
     assert code == 200 and body.startswith(b"glTF-fake-")
 
 
+def test_collision_preview_hull_mode(server, monkeypatch):
+    """/init?mode=hull starts the same observable job but threads mode='hull'
+    through to the preview generator (no quality needed); a bad mode is 400."""
+    import os
+    import time
+
+    from sw2robot.exporter import ros_export
+
+    seen = {}
+
+    def fake_preview(pkg_dir, robot_name, quality="balanced", progress=None,
+                     urdf_path=None, should_cancel=None, on_start=None,
+                     max_workers=None, mode="coacd"):
+        seen["mode"] = mode
+        pdir = os.path.join(pkg_dir, "meshes", ".coacd_cache", "preview")
+        os.makedirs(pdir, exist_ok=True)
+        link = TIP_LINK
+        with open(os.path.join(pdir, link + ".glb"), "wb") as f:
+            f.write(b"glTF-fake-" + link.encode())
+        if progress:
+            progress(1, 1, link, f"meshes/.coacd_cache/preview/{link}.glb")
+        return {link: f"meshes/.coacd_cache/preview/{link}.glb"}
+
+    monkeypatch.setattr(ros_export, "collision_preview_glbs", fake_preview)
+
+    # bad mode -> 400, no job started
+    code, _ = _get_status(server, "/api/collision/coacd/init?mode=bogus")
+    assert code == 400
+
+    r = _get_json(server, "/api/collision/coacd/init?mode=hull")
+    assert r.get("running") is True and r.get("mode") == "hull"
+
+    deadline, s = time.time() + 10, {}
+    while time.time() < deadline:
+        s = _get_json(server, "/api/collision/coacd/status")
+        if not s.get("running"):
+            break
+        time.sleep(0.05)
+    assert s.get("running") is False and s.get("error") is None
+    assert s.get("mode") == "hull"           # echoed in the job status
+    assert seen.get("mode") == "hull"        # and threaded to the generator
+
+
 def test_coacd_cancel_stops_at_link_boundary(server, monkeypatch):
     """/cancel stops the job at the next link boundary, leaving it not-running,
     flagged cancelled, with fewer than all links done."""
@@ -917,7 +960,7 @@ def test_coacd_cancel_stops_at_link_boundary(server, monkeypatch):
 
     def slow_preview(pkg_dir, robot_name, quality="balanced", progress=None,
                      urdf_path=None, should_cancel=None, on_start=None,
-                     max_workers=None):
+                     max_workers=None, mode="coacd"):
         pdir = os.path.join(pkg_dir, "meshes", ".coacd_cache", "preview")
         os.makedirs(pdir, exist_ok=True)
         out = {}

--- a/tests/test_urdf_mode_webserver.py
+++ b/tests/test_urdf_mode_webserver.py
@@ -879,7 +879,7 @@ def test_coacd_preview_endpoints(server, monkeypatch):
                 progress(i, len(links), link, rel)
         return out
 
-    monkeypatch.setattr(ros_export, "coacd_preview_glbs", fake_preview)
+    monkeypatch.setattr(ros_export, "collision_preview_glbs", fake_preview)
 
     # bad quality -> 400, no job started
     code, _ = _get_status(server, "/api/collision/coacd/init?quality=ultra")
@@ -936,7 +936,7 @@ def test_coacd_cancel_stops_at_link_boundary(server, monkeypatch):
                 progress(i + 1, total, link, rel)
         return out
 
-    monkeypatch.setattr(ros_export, "coacd_preview_glbs", slow_preview)
+    monkeypatch.setattr(ros_export, "collision_preview_glbs", slow_preview)
 
     assert _get_json(
         server, "/api/collision/coacd/init?quality=balanced")["running"] is True

--- a/tests/test_urdf_mode_webserver.py
+++ b/tests/test_urdf_mode_webserver.py
@@ -882,15 +882,15 @@ def test_coacd_preview_endpoints(server, monkeypatch):
     monkeypatch.setattr(ros_export, "collision_preview_glbs", fake_preview)
 
     # bad quality -> 400, no job started
-    code, _ = _get_status(server, "/api/collision/coacd/init?quality=ultra")
+    code, _ = _get_status(server, "/api/collision/preview/init?quality=ultra")
     assert code == 400
 
-    r = _get_json(server, "/api/collision/coacd/init?quality=balanced")
+    r = _get_json(server, "/api/collision/preview/init?quality=balanced")
     assert r.get("running") is True and r.get("quality") == "balanced"
 
     deadline, s = time.time() + 10, {}
     while time.time() < deadline:
-        s = _get_json(server, "/api/collision/coacd/status")
+        s = _get_json(server, "/api/collision/preview/status")
         if not s.get("running"):
             break
         time.sleep(0.05)
@@ -931,15 +931,15 @@ def test_collision_preview_hull_mode(server, monkeypatch):
     monkeypatch.setattr(ros_export, "collision_preview_glbs", fake_preview)
 
     # bad mode -> 400, no job started
-    code, _ = _get_status(server, "/api/collision/coacd/init?mode=bogus")
+    code, _ = _get_status(server, "/api/collision/preview/init?mode=bogus")
     assert code == 400
 
-    r = _get_json(server, "/api/collision/coacd/init?mode=hull")
+    r = _get_json(server, "/api/collision/preview/init?mode=hull")
     assert r.get("running") is True and r.get("mode") == "hull"
 
     deadline, s = time.time() + 10, {}
     while time.time() < deadline:
-        s = _get_json(server, "/api/collision/coacd/status")
+        s = _get_json(server, "/api/collision/preview/status")
         if not s.get("running"):
             break
         time.sleep(0.05)
@@ -982,13 +982,13 @@ def test_coacd_cancel_stops_at_link_boundary(server, monkeypatch):
     monkeypatch.setattr(ros_export, "collision_preview_glbs", slow_preview)
 
     assert _get_json(
-        server, "/api/collision/coacd/init?quality=balanced")["running"] is True
+        server, "/api/collision/preview/init?quality=balanced")["running"] is True
     time.sleep(0.4)                          # let a couple links finish
-    assert _get_json(server, "/api/collision/coacd/cancel")["cancelling"] is True
+    assert _get_json(server, "/api/collision/preview/cancel")["cancelling"] is True
 
     deadline, s = time.time() + 10, {}
     while time.time() < deadline:
-        s = _get_json(server, "/api/collision/coacd/status")
+        s = _get_json(server, "/api/collision/preview/status")
         if not s.get("running"):
             break
         time.sleep(0.05)


### PR DESCRIPTION
This address https://github.com/jsk-ros-pkg/solidworks_urdf_exporter2/issues/106 - Note this only adds the convex hulls, extra collision shapes can be added later I think. 

<img width="3389" height="2025" alt="image" src="https://github.com/user-attachments/assets/9259b60d-11bd-4ff7-88fd-87a938647aa0" />

Generalizes the editor's CoACD-only collision feature into a selectable **collision mode** and adds a new convex-hull mode.

- Adds a third `<collision>` geometry option alongside `copy` (reuse visual mesh) and `coacd` (convex decomposition): **`hull`** emits a single convex hull STL per link — the "simple collision" choice path planning usually wants. No optional dependency as it uses trimesh only.
- `_collision_part_stls(src, mode, quality, cache_dir)` dispatches to either `_coacd_part_stls` (many parts, disk-cached) or the new `_hull_part_stls` (one watertight hull).
- Export wires hull through the same `<collision>`-expansion path as CoACD, preserving each block's `<origin>`. Hull parts are named `<base>_collision_hull.stl`; CoACD keeps its indexed `<base>_collision_<i>`.
- Renamed generic collision functions that are used for both CoACD and the convex hulls from `coacd_` to `collisions_`

# Editor UI

- The "CoACD collision" checkbox is replaced by a **collision mode selector** (Visual mesh / Convex hull / CoACD). The quality dropdown shows only for CoACD; the Generate/preview row shows for hull + CoACD.
- Preview generation, progress, blink, and the live self-collision model all work for hull as well as CoACD; progress/labels say "convex-hull" vs "CoACD" via i18n.

# Fixes 

- **Mode-switch race**: switching the collision-mode selector while a generate job was running left the job alive; on completion it reverted the selector to the old mode and re-applied the old parts to the live model + export. Switching now aborts the in-flight job (stops the client poll first so the cancelled job can't reach finalize), then cancels server-side and resets the gen UI. The Stop button still finalizes its partial result.