### PR TITLE
Fix ROS package mesh resolution in standalone Linux binary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 # extract / build all work WITHOUT these; collision + auto-limits degrade
 # gracefully when they are not installed.
 ui = [
-    "scikit-robot>=0.0.30",
+    "scikit-robot>=0.3.16",
     "python-fcl>=0.7",
     "viser",
 ]

--- a/sw2robot/editor/_autolimits_cli.py
+++ b/sw2robot/editor/_autolimits_cli.py
@@ -68,6 +68,8 @@ def main():
     from sw2robot.editor import autoinit
 
     _emit(event="loading")                    # model load is the slow first ~2 s
+    # skrobot (>=0.3.16) resolves package:// meshes itself, so load the URDF
+    # (glb-accelerated) directly -- no pre-resolved temp copy needed.
     load_urdf, is_tmp = _fast_urdf(urdf)
     try:
         robot = RobotModelFromURDF(urdf_file=load_urdf)

--- a/sw2robot/editor/package_uri.py
+++ b/sw2robot/editor/package_uri.py
@@ -1,0 +1,82 @@
+"""Resolve and serve ROS ``package://`` mesh references for the web editor.
+
+Package *resolution* is delegated to scikit-robot (>= 0.3.16), whose
+``get_path_with_cache`` resolves from ``ament_index`` / ``rospkg`` AND the
+sourced ROS search-path environment variables -- so it also works in the
+standalone binary, which bundles neither ROS Python package.
+
+What stays here is the editor's own concern: mapping a ``package://`` URI to a
+file so the server can hand the mesh bytes to the browser (which cannot read the
+filesystem), preferring the opened package's own folder first.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import urllib.parse
+
+_PACKAGE_NAME = re.compile(r"^[A-Za-z][A-Za-z0-9_.-]*$")
+
+
+def find_package(package):
+    """Return the filesystem root of a sourced ROS package, or ``None``.
+
+    Delegates to scikit-robot, which resolves via ``ament_index`` / ``rospkg``
+    and the ROS search-path environment variables (``ROS_PACKAGE_PATH`` /
+    ``AMENT_PREFIX_PATH`` / ``COLCON_PREFIX_PATH`` / ``CMAKE_PREFIX_PATH``) and
+    caches the result.
+    """
+    if not _PACKAGE_NAME.fullmatch(package or ""):
+        return None
+    try:
+        from skrobot.utils.urdf import get_path_with_cache
+        return get_path_with_cache(package)
+    except Exception:
+        # get_path_with_cache raises ImportError (no resolver installed) or
+        # LookupError (package not found); either way we have no path.
+        return None
+
+
+def _inside(root, relative):
+    root = os.path.normpath(root)
+    candidate = os.path.normpath(os.path.join(root, *relative.split("/")))
+    try:
+        if os.path.commonpath([root, candidate]) != root:
+            return None
+    except ValueError:
+        return None
+    return candidate
+
+
+def split_package_uri(uri):
+    """Return ``(package, relative_path)`` for a safe package URI."""
+    parsed = urllib.parse.urlsplit(uri)
+    package = parsed.netloc
+    relative = urllib.parse.unquote(parsed.path).lstrip("/").replace("\\", "/")
+    if parsed.scheme != "package" or not _PACKAGE_NAME.fullmatch(package or ""):
+        return None
+    if not relative or relative.startswith("../") or "/../" in relative:
+        return None
+    return package, relative
+
+
+def resolve_package_uri(uri, current_package=None):
+    """Resolve a package URI to an existing file.
+
+    ``current_package/<uri path>`` is intentionally checked first.  That is the
+    editor's historical behavior and supports exported packages whose folder
+    name differs from the package name embedded in the URDF.  The ROS lookup
+    (via scikit-robot) is an additive fallback only.
+    """
+    parts = split_package_uri(uri)
+    if parts is None:
+        return None
+    package, relative = parts
+    if current_package:
+        local = _inside(current_package, relative)
+        if local and os.path.isfile(local):
+            return local
+    root = find_package(package)
+    external = _inside(root, relative) if root else None
+    return external if external and os.path.isfile(external) else None

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -313,25 +313,34 @@ def _rewrite_package_urls(urdf_text, urdf_rel, pkg_dir):
     URDF served to the viewer; the on-disk file (and the ROS export) keep their
     original ``package://`` references.
 
-    A ref is rewritten only when its mesh actually EXISTS in this package -- so
-    own meshes load regardless of the URI's package name (folder need not match),
-    while a ref to another ROS package whose file is not here is left as
-    ``package://`` (unresolvable in-browser either way, but not mis-pointed)."""
+    Existing files in the opened package keep the historical relative ``/pkg/``
+    route.  A ref not found there falls back to a sourced ROS package and uses
+    ``/ros-pkg/<name>/``.  Unresolved refs stay untouched."""
+    from .package_uri import resolve_package_uri, split_package_uri
+
     depth = len([s for s in posixpath.dirname(urdf_rel).split("/") if s])
     prefix = "../" * depth
     root = os.path.normpath(pkg_dir)
 
     def repl(m):
-        rest = m.group(1)
+        quote, uri = m.group(1), m.group(2)
+        parts = split_package_uri(uri)
+        if parts is None:
+            return m.group(0)
+        package, rest = parts
         local = os.path.normpath(os.path.join(root, *rest.split("/")))
         try:
             inside = os.path.commonpath([root, local]) == root
         except ValueError:
             inside = False
-        if inside and os.path.exists(local):
-            return f'filename="{prefix}{rest}"'
+        if inside and os.path.isfile(local):     # a mesh ref -> file, not a dir
+            return f"filename={quote}{prefix}{rest}{quote}"
+        if resolve_package_uri(uri, pkg_dir):
+            package = urllib.parse.quote(package, safe="")
+            rest = urllib.parse.quote(rest, safe="/")
+            return f"filename={quote}/ros-pkg/{package}/{rest}{quote}"
         return m.group(0)                  # not in this package -- leave as-is
-    return re.sub(r'filename="package://[^/"]+/([^"]+)"', repl, urdf_text)
+    return re.sub(r"filename=([\"'])(package://[^\"']+)\1", repl, urdf_text)
 
 
 def _um_colors(state):
@@ -1488,6 +1497,9 @@ def _build_collision(urdf_path, key, pkg_dir=None):
         from skrobot.models.urdf import RobotModelFromURDF
 
         from . import autoinit
+        # skrobot (>=0.3.16) resolves package:// meshes itself (ament/rospkg +
+        # the sourced ROS env), so the URDF loads directly -- no pre-resolved
+        # temp copy needed.
         robot = RobotModelFromURDF(urdf_file=urdf_path)
         meshes = autoinit.link_meshes(robot)
         # prefer the CoACD convex parts (generated via the export panel) when
@@ -1771,8 +1783,14 @@ class _Handler(http.server.BaseHTTPRequestHandler):
         rel = posixpath.normpath(urllib.parse.unquote(rel)).lstrip("/")
         if rel.startswith(".."):
             return None
+        root = os.path.normpath(root)
         full = os.path.normpath(os.path.join(root, *rel.split("/")))
-        if not full.startswith(os.path.normpath(root)):
+        # commonpath (not startswith) so a sibling like <root>-evil can't pass
+        # the containment check; matches package_uri._inside
+        try:
+            if os.path.commonpath([root, full]) != root:
+                return None
+        except ValueError:                 # different drives (Windows) -> outside
             return None
         return full
 
@@ -1950,6 +1968,18 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 had = _sw.get("sess") is not None
                 _shutdown_sw()
                 return self._send_json({"released": had})
+            if path.startswith("/ros-pkg/"):
+                from .package_uri import find_package
+                rel = path[len("/ros-pkg/"):]
+                package, sep, package_rel = rel.partition("/")
+                root = find_package(urllib.parse.unquote(package)) if sep else None
+                full = self._resolve(root, package_rel) if root else None
+                if full is None or not os.path.isfile(full):
+                    return self.send_error(404)
+                if full.lower().endswith(".3dxml") \
+                        and query.get("glb") == ["1"]:
+                    return self._send_file(_convert_3dxml_to_glb(full))
+                return self._send_file(full)
             if path == "/api/collision/init":
                 if not cls.pkg_dir:
                     return self._send_json({"error": "no package open"}, 400)

--- a/tests/test_urdf_mode_webserver.py
+++ b/tests/test_urdf_mode_webserver.py
@@ -683,6 +683,44 @@ def test_package_uris_rewritten_for_viewer(tmp_path):
         webserver._um["state"] = None
 
 
+def test_external_package_uri_served_from_ros_environment(tmp_path, monkeypatch):
+    """A package:// ref absent from the opened package falls back to a sourced
+    ROS package, while the opened package and its URDF remain untouched."""
+    from sw2robot.editor import webserver
+
+    opened = tmp_path / "tutorial"
+    (opened / "urdf").mkdir(parents=True)
+    external = tmp_path / "src" / "nextage_description"
+    (external / "urdf" / "meshes").mkdir(parents=True)
+    (external / "package.xml").write_text(
+        "<package><name>nextage_description</name></package>", encoding="utf-8")
+    mesh = external / "urdf" / "meshes" / "WAIST Link.dae"
+    mesh.write_bytes(b"external-dae")
+    original = (
+        '<?xml version="1.0"?><robot name="r"><link name="base">'
+        '<visual><geometry><mesh filename="package://nextage_description/'
+        'urdf/meshes/WAIST%20Link.dae"/></geometry></visual></link></robot>')
+    urdf = opened / "urdf" / "r.urdf"
+    urdf.write_text(original, encoding="utf-8")
+    monkeypatch.setenv("ROS_PACKAGE_PATH", str(tmp_path / "src"))
+
+    httpd, port = webserver._bind_free_port(webserver._Handler, _free_port())
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{port}"
+    try:
+        info = _get_json(base, f"/api/open?path={urdf}")
+        served = _get(base, info["urdf"])
+        ref = re.search(r'filename="([^"]+)"', served).group(1)
+        assert ref == "/ros-pkg/nextage_description/urdf/meshes/WAIST%20Link.dae"
+        with urllib.request.urlopen(base + ref) as response:
+            assert response.read() == b"external-dae"
+        assert urdf.read_text(encoding="utf-8") == original
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        webserver._um["state"] = None
+
+
 def _mini_urdf_pkg(parent, name, body):
     p = parent / name
     (p / "urdf").mkdir(parents=True)


### PR DESCRIPTION
## Summary

Allow the standalone Linux binary to load URDF meshes referenced through `package://` from sourced ROS 1 and ROS 2 environments.

## Background

When running from Python, `skrobot` can resolve ROS package paths through `rospkg` or `ament_index_python`.

The PyInstaller Linux binary does not necessarily contain these ROS Python packages. Even after sourcing a ROS workspace, `skrobot` may therefore fail to resolve meshes from external packages.

## Changes
  - discover packages directly from sourced ROS environment variables:
    - `ROS_PACKAGE_PATH`
    - `AMENT_PREFIX_PATH`
    - `COLCON_PREFIX_PATH`
    - `CMAKE_PREFIX_PATH`
  - serve external package meshes to the browser through `/ros-pkg/`
  - resolve `package://` paths before passing URDFs to `skrobot`
  - use a temporary resolved URDF for collision detection and automatic joint
    limit calculation
  - preserve the original URDF unchanged
  - retain optional `rospkg` support for normal Python environments

## Example

After sourcing a workspace:

```bash
source ~/catkin_ws/devel/setup.bash
./sw2robot-web-linux-x64-vX.Y.Z
```

the binary can open a URDF containing:

<mesh filename="package://other_robot_description/meshes/base.dae"/>

even though ament_index_python is not bundled in the executable.