### PR TITLE
fix: invalidate cached part meshes when the source CAD is newer

### DIFF
--- a/sw2robot/exporter/mesh.py
+++ b/sw2robot/exporter/mesh.py
@@ -90,6 +90,31 @@ def _save_3dxml(model_doc, out_path):
     return False
 
 
+def _cache_is_fresh(cand, source_path):
+    """Whether a cached per-part mesh may be reused instead of re-exported.
+
+    Reuse only when the cache is real geometry (``>= _MIN_MESH_BYTES``) AND at
+    least as new as its source part file.  The reuse-by-name shortcut speeds up
+    re-runs, but keyed on the part name alone it also survives a CAD EDIT: the
+    edited part re-exports to the same ``<name>.3dxml`` the old (stale) file
+    already occupies, so without this mtime gate the change is silently masked
+    until the user wipes ``%TEMP%\\sw2robot\\output``.  Comparing mtimes lets an
+    edit since the last extract force a fresh export.
+
+    If the source mtime can't be read (part moved/renamed away), fall back to
+    reusing the cache -- we could not re-export it anyway."""
+    try:
+        if not (os.path.exists(cand)
+                and os.path.getsize(cand) >= _MIN_MESH_BYTES):
+            return False
+    except OSError:
+        return False
+    try:
+        return os.path.getmtime(cand) >= os.path.getmtime(source_path)
+    except OSError:
+        return True
+
+
 def export_meshes(app, doc, comps, meshes_dir, progress=None, by_path=None):
     """Fill ``component.mesh_file`` for every component; return mesh count.
 
@@ -124,13 +149,13 @@ def export_meshes(app, doc, comps, meshes_dir, progress=None, by_path=None):
         out = os.path.join(meshes_dir, comp.link_name + ".3dxml")
         reused = False
         for cand in (out, os.path.join(meshes_dir, comp.link_name + ".glb")):
-            if os.path.exists(cand) and os.path.getsize(cand) >= _MIN_MESH_BYTES:
+            if _cache_is_fresh(cand, path):
                 rel = os.path.join("meshes", os.path.basename(cand))
                 by_path[path] = rel
                 comp.mesh_file = rel
                 n += 1
                 reused = True
-                break  # reuse existing mesh (fast re-runs)
+                break  # reuse existing mesh (fast re-runs, unless CAD is newer)
         if reused:
             continue
         ok = False
@@ -193,8 +218,7 @@ def export_subgraph_meshes(app, subgraphs, meshes_dir, by_path=None):
             out = os.path.join(meshes_dir, base + ".3dxml")
             ok = False
             for cand in (out, os.path.join(meshes_dir, base + ".glb")):
-                if os.path.exists(cand) \
-                        and os.path.getsize(cand) >= _MIN_MESH_BYTES:
+                if _cache_is_fresh(cand, p):
                     out, ok = cand, True
                     break
             if not ok:

--- a/tests/test_mesh_cache_freshness.py
+++ b/tests/test_mesh_cache_freshness.py
@@ -1,0 +1,57 @@
+"""Per-part mesh cache invalidation (_cache_is_fresh).
+
+export_meshes reuses meshes/<part>.3dxml verbatim across re-extractions to keep
+re-runs fast.  Keyed on the part NAME alone, that reuse used to survive a CAD
+edit -- the edited part re-exports to the same filename the stale mesh already
+occupies, so the change was masked until the user wiped %TEMP%\\sw2robot\\output
+by hand (the reported bug).  _cache_is_fresh gates the reuse on mtime so an edit
+since the last extract forces a fresh export.
+"""
+import os
+
+from sw2robot.exporter.mesh import _MIN_MESH_BYTES, _cache_is_fresh
+
+
+def _write(path, size=_MIN_MESH_BYTES, mtime=None):
+    path.write_bytes(b"x" * size)
+    if mtime is not None:
+        os.utime(path, (mtime, mtime))
+    return path
+
+
+def test_cache_reused_when_newer_than_source(tmp_path):
+    src = _write(tmp_path / "part.SLDPRT", mtime=1000)
+    cache = _write(tmp_path / "part.3dxml", mtime=2000)
+    assert _cache_is_fresh(str(cache), str(src)) is True
+
+
+def test_stale_cache_forces_reexport(tmp_path):
+    # the bug: part edited AFTER the mesh was cached -> must not be reused
+    cache = _write(tmp_path / "part.3dxml", mtime=1000)
+    src = _write(tmp_path / "part.SLDPRT", mtime=2000)
+    assert _cache_is_fresh(str(cache), str(src)) is False
+
+
+def test_equal_mtime_is_reusable(tmp_path):
+    src = _write(tmp_path / "part.SLDPRT", mtime=1500)
+    cache = _write(tmp_path / "part.3dxml", mtime=1500)
+    assert _cache_is_fresh(str(cache), str(src)) is True
+
+
+def test_envelope_sized_cache_never_reused(tmp_path):
+    # a sub-_MIN_MESH_BYTES file is just the empty-document envelope
+    src = _write(tmp_path / "part.SLDPRT", mtime=1000)
+    cache = _write(tmp_path / "part.3dxml", size=_MIN_MESH_BYTES - 1, mtime=2000)
+    assert _cache_is_fresh(str(cache), str(src)) is False
+
+
+def test_missing_cache_not_reused(tmp_path):
+    src = _write(tmp_path / "part.SLDPRT", mtime=1000)
+    assert _cache_is_fresh(str(tmp_path / "absent.3dxml"), str(src)) is False
+
+
+def test_unreadable_source_falls_back_to_reuse(tmp_path):
+    # part moved/renamed away since extraction: we cannot re-export it, so the
+    # cache (all we have) is reused rather than dropped
+    cache = _write(tmp_path / "part.3dxml", mtime=1000)
+    assert _cache_is_fresh(str(cache), str(tmp_path / "gone.SLDPRT")) is True


### PR DESCRIPTION
export_meshes reused meshes/<part>.3dxml verbatim across re-extractions, keyed on the part name alone. A CAD edit that kept the part name re-exported to the same filename the stale mesh already occupied, so the change was masked until the output cache under %TEMP%\sw2robot\output was deleted by hand. Gate the reuse on mtime (cached mesh must be at least as new as its source part file) so an edit since the last extract forces a fresh export, while unchanged parts still reuse their cache for fast re-runs.