### PR TITLE
fix: build the Linux binary on ubuntu-22.04 for GLIBC 2.35 compat

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,11 @@ jobs:
             arch: arm64
             ext: '.zip'
             build_args: ''
-          - runner: ubuntu-latest
+          # Pin to ubuntu-22.04 (GLIBC 2.35), NOT ubuntu-latest (24.04, GLIBC
+          # 2.38).  glibc is backward-compatible, so a binary frozen against the
+          # OLDER 2.35 runs on both 22.04 and 24.04; freezing against 2.38 fails
+          # on 22.04 with "GLIBC_2.38 not found".  See issue #113.
+          - runner: ubuntu-22.04
             os: linux
             arch: x64
             ext: ''

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ chmod +x sw2robot-web-linux-x64-v<version>          # mark it executable once
 ./sw2robot-web-linux-x64-v<version> --port 8090     # opens http://localhost:8090
 ```
 
+The binary is frozen against GLIBC 2.35, so it runs on **Ubuntu 22.04 or newer**
+(22.04, 24.04, …).  On older distros you may hit a `GLIBC_2.xx not found` error
+at launch — in that case run from source (Option B below) instead.
+
 **Option B — run from source** (see [Install from source](#install-from-source-developers)
 below):
 


### PR DESCRIPTION
The Linux x64 release binary was frozen on ubuntu-latest (24.04, GLIBC 2.38), so it failed to launch on Ubuntu 22.04 with "GLIBC_2.38 not found". glibc is backward-compatible, so pinning the runner to ubuntu-22.04 (GLIBC 2.35) produces a binary that runs on both 22.04 and 24.04. Also document the supported Ubuntu versions in the README.

Fixes #113