### PR TITLE
Add primitive-shape <collision> modes (box/cylinder/sphere) via sciki…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,13 @@ dependencies = [
 
 [project.optional-dependencies]
 # the live self-collision highlight + the auto joint-limit sweep (skrobot FK +
-# python-fcl), plus the standalone viser GUI.  The web editor's view / edit /
-# extract / build all work WITHOUT these; collision + auto-limits degrade
-# gracefully when they are not installed.
+# python-fcl), plus the standalone viser GUI.  scikit-robot also powers the
+# `--collision primitive|box|cylinder|sphere` fitting (>=0.3.17 ships the
+# per-mesh primitive API, skrobot.utils.primitive_fitting).  The web editor's
+# view / edit / extract / build all work WITHOUT these; collision + auto-limits
+# degrade gracefully (clear error if a primitive mode is requested) when absent.
 ui = [
-    "scikit-robot>=0.3.16",
+    "scikit-robot>=0.3.17",
     "python-fcl>=0.7",
     "viser",
 ]

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -718,6 +718,10 @@ link; 'CoACD' decomposes each link into many convex parts.">
             <option value="copy" data-i18n="ui.collcopy">Visual mesh</option>
             <option value="hull" data-i18n="ui.collhull">Convex hull</option>
             <option value="coacd" data-i18n="ui.collcoacd">CoACD (convex parts)</option>
+            <option value="primitive" data-i18n="ui.collprimitive">Primitive (auto)</option>
+            <option value="box" data-i18n="ui.collbox">Box</option>
+            <option value="cylinder" data-i18n="ui.collcylinder">Cylinder</option>
+            <option value="sphere" data-i18n="ui.collsphere">Sphere</option>
           </select>
         </label>
         <select id="cquality"
@@ -1417,11 +1421,15 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
                   ja: 'ポータブルな ROS 2 (ament_cmake) パッケージ (<name>_description): package:// URL、選択した形式のメッシュ、launch/display.launch.py + rviz 設定付き（実行: ros2 launch <name>_description display.launch.py）' },
     'ui.expros2': { en: '⬇ ROS2 package', ja: '⬇ ROS2 パッケージ' },
     'ui.collmode': { en: 'collision', ja: '衝突形状' },
-    't.collmode': { en: "How <collision> geometry is produced for the ROS1/ROS2 packages: 'visual mesh' reuses the visual mesh as-is; 'convex hull' uses a single convex hull per link (simple, good for path planning); 'CoACD' decomposes each link into many convex parts (best for physics, slower — server needs the coacd package). Generate previews the hull/CoACD result in the viewer.",
-                    ja: 'ROS1/ROS2 パッケージの <collision> ジオメトリの生成方法: 「ビジュアルメッシュ」はメッシュをそのまま使用、「凸包」はリンクごとに単一の凸包（シンプル、経路計画向け）、「CoACD」は各リンクを多数の凸パーツに分解（物理向け・低速、サーバーに coacd パッケージが必要）。「生成」でビューアにプレビューします。' },
+    't.collmode': { en: "How <collision> geometry is produced for the ROS1/ROS2 packages: 'visual mesh' reuses the visual mesh as-is; 'convex hull' uses a single convex hull per link (simple, good for path planning); 'CoACD' decomposes each link into many convex parts (best for physics, slower — server needs the coacd package); 'primitive'/'box'/'cylinder'/'sphere' fit a native URDF primitive per link, no mesh file at all — the lightest collision ('primitive' auto-picks the best shape; server needs scikit-robot). Generate previews the result in the viewer.",
+                    ja: 'ROS1/ROS2 パッケージの <collision> ジオメトリの生成方法: 「ビジュアルメッシュ」はメッシュをそのまま使用、「凸包」はリンクごとに単一の凸包（シンプル、経路計画向け）、「CoACD」は各リンクを多数の凸パーツに分解（物理向け・低速、サーバーに coacd パッケージが必要）、「プリミティブ／直方体／円柱／球」はリンクごとに URDF ネイティブのプリミティブをフィット（メッシュファイル無しで最軽量、「プリミティブ」は最適形状を自動選択、サーバーに scikit-robot が必要）。「生成」でビューアにプレビューします。' },
     'ui.collcopy': { en: 'Visual mesh', ja: 'ビジュアルメッシュ' },
     'ui.collhull': { en: 'Convex hull', ja: '凸包' },
     'ui.collcoacd': { en: 'CoACD (convex parts)', ja: 'CoACD（凸パーツ）' },
+    'ui.collprimitive': { en: 'Primitive (auto)', ja: 'プリミティブ（自動）' },
+    'ui.collbox': { en: 'Box', ja: '直方体' },
+    'ui.collcylinder': { en: 'Cylinder', ja: '円柱' },
+    'ui.collsphere': { en: 'Sphere', ja: '球' },
     'coll.hullword': { en: 'convex-hull', ja: '凸包' },
     'ui.coacd': { en: 'CoACD collision', ja: 'CoACD 衝突形状' },
     'ui.cqbalanced': { en: 'Balanced', ja: 'バランス' },

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -2123,8 +2123,9 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                     return self._send_json(
                         {"error": f"unsupported ros version: {ros}"}, 400)
                 ros_version = int(ros)
+                from sw2robot.exporter.ros_export import COLLISION_MODES
                 collision = (query.get("collision") or ["copy"])[0]
-                if collision not in ("copy", "hull", "coacd"):
+                if collision not in COLLISION_MODES:
                     return self._send_json(
                         {"error": f"unsupported collision mode: {collision}"}, 400)
                 cquality = (query.get("cquality") or ["balanced"])[0]
@@ -2205,8 +2206,9 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 cls = type(self)
                 if not cls.pkg_dir:
                     return self._send_json({"error": "no package open"}, 400)
+                from sw2robot.exporter.ros_export import PREVIEW_COLLISION_MODES
                 mode = (query.get("mode") or ["coacd"])[0]
-                if mode not in ("coacd", "hull"):
+                if mode not in PREVIEW_COLLISION_MODES:
                     return self._send_json(
                         {"error": f"unsupported collision mode: {mode}"}, 400)
                 # quality only affects CoACD, but validate it regardless so a

--- a/sw2robot/exporter/export.py
+++ b/sw2robot/exporter/export.py
@@ -335,13 +335,18 @@ def main():
                     help="package-relative directory the --ros-pkg meshes go in "
                          "and that the URDF's package:// refs point at (default: "
                          "'meshes'); e.g. 'urdf/mesh' for a different layout")
-    ap.add_argument("--collision", choices=("copy", "hull", "coacd"),
+    ap.add_argument("--collision",
+                    choices=("copy", "hull", "coacd",
+                             "primitive", "box", "cylinder", "sphere"),
                     default="copy",
                     help="--ros-pkg <collision> geometry: 'copy' (default) "
                          "reuses the visual mesh as one STL; 'hull' replaces it "
                          "with a single convex hull STL; 'coacd' runs approximate "
                          "convex decomposition into convex part STLs (needs: pip "
-                         "install coacd)")
+                         "install coacd); 'primitive'/'box'/'cylinder'/'sphere' "
+                         "fit a native URDF primitive per link, no mesh file "
+                         "('primitive' auto-picks the best shape; needs: pip "
+                         "install -U scikit-robot)")
     ap.add_argument("--coacd-quality", choices=("balanced", "fine"),
                     default="balanced",
                     help="CoACD preset for --collision coacd: 'balanced' "

--- a/sw2robot/exporter/ros_export.py
+++ b/sw2robot/exporter/ros_export.py
@@ -446,6 +446,91 @@ def _collision_part_stls(src, mode, quality, cache_dir):
     return _coacd_part_stls(src, quality, cache_dir)
 
 
+# ------------------------------------------------ primitive collision shapes
+# Optionally replace each <collision>'s mesh with a fitted URDF primitive
+# (<box>/<cylinder>/<sphere>) instead of a mesh file -- the lightest collision
+# geometry there is (native URDF primitives, no STL), for path planning where a
+# coarse convex bound per link is enough.  The fitting lives UPSTREAM in
+# scikit-robot (fit_primitive_to_mesh + primitive_params_to_origin); we only
+# place the result.  scikit-robot is an OPTIONAL dependency -- its absence (or a
+# version predating the per-mesh primitive API) raises a clear error, like coacd.
+
+# collision-mode string -> primitive_type for fit_primitive_to_mesh
+# (None = auto-pick box/cylinder/sphere by voxel IoU)
+_PRIMITIVE_MODES = {"primitive": None, "box": "box",
+                    "cylinder": "cylinder", "sphere": "sphere"}
+# every supported <collision> mode (single source of truth for the CLI + web)
+COLLISION_MODES = ("copy", "hull", "coacd", *_PRIMITIVE_MODES)
+# modes that produce a viewer preview / need generation (everything but 'copy')
+PREVIEW_COLLISION_MODES = ("hull", "coacd", *_PRIMITIVE_MODES)
+
+
+def skrobot_primitive_available():
+    """True if scikit-robot exposes the per-mesh primitive-fitting API (the
+    release that ships ``skrobot.utils.primitive_fitting``)."""
+    import importlib.util
+    try:
+        return importlib.util.find_spec(
+            "skrobot.utils.primitive_fitting") is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def _fit_collision_primitive(src, primitive_type):
+    """``(params, M)`` for the source mesh ``src`` fitted to a URDF primitive:
+    ``params`` is scikit-robot's primitive dict (type + dimensions) and ``M`` is
+    the 4x4 primitive-origin transform in the mesh (source) frame.  ``oriented=
+    None`` lets scikit-robot pick the tighter of an axis-aligned / oriented fit
+    (and, when ``primitive_type`` is None, the best of box/cylinder/sphere) by
+    voxel IoU."""
+    import trimesh
+    from skrobot.utils import fit_primitive_to_mesh, primitive_params_to_origin
+    mesh = _load_mesh_metres(src)
+    params = fit_primitive_to_mesh(mesh, primitive_type=primitive_type,
+                                   oriented=None)
+    xyz, rpy = primitive_params_to_origin(params)
+    M = trimesh.transformations.euler_matrix(*rpy, axes="sxyz")
+    M[:3, 3] = xyz
+    return params, M
+
+
+def _primitive_geometry_el(params):
+    """A URDF ``<geometry>`` element for a fitted primitive dict.  The shape's
+    centre + rotation are carried by the ``<collision>``'s ``<origin>``, so the
+    geometry here is axis-aligned at the origin."""
+    geo = ET.Element("geometry")
+    t = params["type"]
+    if t == "box":
+        ET.SubElement(geo, "box").set(
+            "size", " ".join(_fmt_num(v) for v in params["extents"]))
+    elif t == "sphere":
+        ET.SubElement(geo, "sphere").set("radius", _fmt_num(params["radius"]))
+    elif t in ("cylinder", "capsule"):
+        cyl = ET.SubElement(geo, "cylinder")
+        cyl.set("radius", _fmt_num(params["radius"]))
+        length = float(params["height"])
+        if t == "capsule":            # URDF has no capsule; fold the caps in
+            length += 2 * float(params["radius"])
+        cyl.set("length", _fmt_num(length))
+    else:
+        raise ValueError(f"unsupported primitive type: {t!r}")
+    return geo
+
+
+def _collision_preview_meshes(src, mode, quality, cache_dir):
+    """``[trimesh, ...]`` in the source frame for a link's collision preview:
+    the convex STL part(s) for ``coacd``/``hull``, or the single fitted primitive
+    mesh for a primitive mode."""
+    import trimesh
+
+    if mode in _PRIMITIVE_MODES:
+        from skrobot.utils.primitive_fitting import create_primitive_mesh
+        params, _M = _fit_collision_primitive(src, _PRIMITIVE_MODES[mode])
+        return [create_primitive_mesh(params)]
+    return [trimesh.load(io.BytesIO(d), file_type="stl")
+            for d in _collision_part_stls(src, mode, quality, cache_dir)]
+
+
 # a fixed high-contrast palette so adjacent convex parts read apart in the viewer.
 # NO red/salmon: red is the self-collision highlight colour, so a red preview part
 # (a single-part hull is always palette[0]) would read as a collision.
@@ -608,7 +693,8 @@ def collision_preview_glbs(pkg_dir, robot_name, quality="balanced", progress=Non
     convex decomposition into many parts -- shares the on-disk part cache with
     the ROS export, so generating the preview also warms a later ``collision=
     'coacd'`` export; ``"hull"`` produces a single convex hull per link (fast,
-    no optional dependency).
+    no optional dependency); ``"primitive"`` / ``"box"`` / ``"cylinder"`` /
+    ``"sphere"`` fit a native URDF primitive per link (needs scikit-robot).
 
     Links are processed CONCURRENTLY in a thread pool -- CoACD releases the GIL,
     so this scales with cores (measured ~4x on a 12-core box).  ``max_workers``
@@ -639,9 +725,15 @@ def collision_preview_glbs(pkg_dir, robot_name, quality="balanced", progress=Non
             raise ValueError(
                 "CoACD collision decomposition needs the optional 'coacd' "
                 "package -- install it with: pip install coacd")
+    elif mode in _PRIMITIVE_MODES:
+        if not skrobot_primitive_available():
+            raise ValueError(
+                "primitive collision fitting needs scikit-robot with the "
+                "per-mesh primitive API -- install/upgrade it with: pip install "
+                "-U scikit-robot")
     elif mode != "hull":
         raise ValueError(f"unsupported collision mode: {mode!r} "
-                         "(use 'coacd' or 'hull')")
+                         f"(use one of {PREVIEW_COLLISION_MODES})")
     cache_dir = os.path.join(pkg_dir, "meshes", ".coacd_cache")
     preview_dir = os.path.join(cache_dir, "preview")
     os.makedirs(preview_dir, exist_ok=True)
@@ -691,8 +783,7 @@ def collision_preview_glbs(pkg_dir, robot_name, quality="balanced", progress=Non
         scene = trimesh.Scene()
         part_i = 0
         for src, mat in blocks:
-            for data in _collision_part_stls(src, mode, quality, cache_dir):
-                part = trimesh.load(io.BytesIO(data), file_type="stl")
+            for part in _collision_preview_meshes(src, mode, quality, cache_dir):
                 part.apply_transform(mat)
                 rgb = _COLLISION_PALETTE[part_i % len(_COLLISION_PALETTE)]
                 part.visual = trimesh.visual.ColorVisuals(
@@ -999,9 +1090,13 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
     STL (the "simple collision" alternative -- one convex shape per link, what
     path planning usually wants); ``'coacd'`` runs CoACD approximate convex
     decomposition, replacing each ``<collision>``'s mesh with a *set* of convex
-    part STLs (better for high-fidelity physics).  ``coacd_quality``
+    part STLs (better for high-fidelity physics); ``'primitive'`` / ``'box'`` /
+    ``'cylinder'`` / ``'sphere'`` fit a native URDF primitive per ``<collision>``
+    (no mesh file at all -- the lightest collision, ``'primitive'`` auto-picks
+    the best of box/cylinder/sphere by voxel IoU).  ``coacd_quality``
     (``'balanced'`` | ``'fine'``) picks the CoACD preset and is ignored for the
-    other modes.  ``'coacd'`` needs the optional ``coacd`` package; its absence
+    other modes.  ``'coacd'`` needs the optional ``coacd`` package and the
+    primitive modes need the optional ``scikit-robot`` package; their absence
     raises a clear error.  ``'hull'`` has no extra dependency.  CoACD
     decomposition is cached under ``meshes/.coacd_cache``.
 
@@ -1023,9 +1118,9 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
     before any entries are emitted, so a half-rewritten package never ships."""
     if ros_version not in (1, 2):
         raise ValueError(f"unsupported ros_version: {ros_version}")
-    if collision not in ("copy", "hull", "coacd"):
+    if collision not in COLLISION_MODES:
         raise ValueError(f"unsupported collision mode: {collision!r} "
-                         "(use 'copy', 'hull' or 'coacd')")
+                         f"(use one of {COLLISION_MODES})")
     if collision == "coacd":
         if coacd_quality not in _COACD_PRESETS:
             raise ValueError(
@@ -1035,6 +1130,11 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
             raise ValueError(
                 "CoACD collision decomposition needs the optional 'coacd' "
                 "package -- install it with: pip install coacd")
+    if collision in _PRIMITIVE_MODES and not skrobot_primitive_available():
+        raise ValueError(
+            "primitive collision fitting needs scikit-robot with the per-mesh "
+            "primitive API -- install/upgrade it with: pip install -U "
+            "scikit-robot")
     coacd_cache_dir = os.path.join(pkg_dir, "meshes", ".coacd_cache")
     if loop_closures is None:
         # the editor's ZIP export calls us directly (no model); pick up the
@@ -1095,6 +1195,9 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
     # mode + quality so a source shared by several links is built once (CoACD is
     # also disk-cached under .coacd_cache)
     coll_done = {}
+    # fitted primitives (primitive/box/cylinder/sphere): (params, M) keyed by
+    # source + mode so a source shared by several links is fitted once
+    prim_done = {}
 
     def _emit_collision(base, src):
         # build the convex collision part STL(s) for a source mesh per the
@@ -1157,6 +1260,57 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
                     "filename", f"package://{pkg}/{mesh_rel}/{name}")
                 link.insert(idx + k, nb)
 
+    def _fit_primitive_cached(base, src):
+        # fit (once per source+mode) the primitive for `src`; (params, M) or None
+        key = (os.path.abspath(src), collision)
+        if key in prim_done:
+            return prim_done[key]
+        try:
+            res = _fit_collision_primitive(src, _PRIMITIVE_MODES[collision])
+        except Exception as e:
+            errors.append(f"{base}: {collision} collision failed ({e!r})")
+            return None
+        prim_done[key] = res
+        return res
+
+    def _expand_collision_primitive(link):
+        # replace each convertible <collision>'s mesh with a fitted URDF primitive
+        # (<box>/<cylinder>/<sphere>), no mesh file: swap the <geometry> element
+        # and set the block <origin> to the primitive pose in the link frame.
+        # Blocks we can't fit (multi-mesh, external/missing, primitive already)
+        # are left untouched.
+        import numpy as np
+        for block in list(link.findall("collision")):
+            meshes = list(block.iter("mesh"))
+            if len(meshes) != 1:
+                continue                   # primitive or multi-mesh -- leave it
+            base, src, _ext = _resolve_mesh(pkg_dir, meshes[0].get("filename"),
+                                            own_pkgs=own_pkgs)
+            if base is None:
+                continue                   # external ref -- leave as-is
+            if src is None:
+                errors.append(f"no source mesh for '{base}'")
+                continue
+            res = _fit_primitive_cached(base, src)
+            if res is None:
+                continue
+            params, M = res
+            # the primitive is fitted in the source frame; place it in the link
+            # frame via the bake transform (origins were zeroed) or, when origins
+            # are kept, via the block's own <origin>
+            m_bake = bake.get(id(meshes[0]))
+            base_M = m_bake if m_bake is not None \
+                else _origin_matrix(block.find("origin"))
+            geo = block.find("geometry")
+            new_geo = _primitive_geometry_el(params)
+            if geo is not None:                # stdlib ElementTree: no .replace()
+                gi = list(block).index(geo)
+                block.remove(geo)
+                block.insert(gi, new_geo)
+            else:
+                block.append(new_geo)
+            _set_origin_el(block, np.asarray(base_M, float) @ M)
+
     if collision == "coacd":
         # CoACD is the heaviest per-mesh op; warm its disk cache for every unique
         # collision source IN PARALLEL (CoACD releases the GIL) so the serial
@@ -1168,6 +1322,21 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
             except Exception:
                 pass                        # the real error resurfaces in _emit_collision
         _parallel(_warm_coacd,
+                  set(_iter_sources(root, pkg_dir, own_pkgs, ("collision",))))
+    elif collision in _PRIMITIVE_MODES:
+        # primitive fitting voxelises the mesh (auto mode scores several
+        # candidates by IoU) -- a few hundred ms per unique source; warm them in
+        # parallel so the serial expansion below is all cache hits
+        def _warm_prim(src):
+            key = (os.path.abspath(src), collision)
+            if key in prim_done:
+                return
+            try:
+                prim_done[key] = _fit_collision_primitive(
+                    src, _PRIMITIVE_MODES[collision])
+            except Exception:
+                pass                    # the real error resurfaces in expansion
+        _parallel(_warm_prim,
                   set(_iter_sources(root, pkg_dir, own_pkgs, ("collision",))))
 
     def _verbatim(job):
@@ -1189,9 +1358,11 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
         link_color = colors.get(link.get("name"))
         if collision in ("coacd", "hull"):
             _expand_collision(link)
+        elif collision in _PRIMITIVE_MODES:
+            _expand_collision_primitive(link)
         for ctx, fmt in ctx_fmt:
-            if ctx == "collision" and collision in ("coacd", "hull"):
-                continue                   # handled by _expand_collision
+            if ctx == "collision" and collision != "copy":
+                continue                   # handled by the collision expanders
             for block in link.findall(ctx):
                 for mesh in block.iter("mesh"):
                     base, src, _ext = _resolve_mesh(pkg_dir, mesh.get("filename"),

--- a/tests/test_primitive_collision.py
+++ b/tests/test_primitive_collision.py
@@ -1,0 +1,123 @@
+"""collision='primitive'/'box'/'cylinder'/'sphere' replaces each <collision>'s
+mesh with a fitted native URDF primitive (no mesh file), via scikit-robot's
+per-mesh primitive fitting.  Skips when scikit-robot's primitive API is absent
+(it is an OPTIONAL dependency, like coacd)."""
+import os
+import shutil
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from sw2robot.exporter import ros_export
+from sw2robot.exporter.ros_export import (
+    build_ros_description,
+    skrobot_primitive_available,
+)
+
+_SAMPLE_MESH = os.path.join("examples", "fingertip", "meshes",
+                            "fingertip_back_1.3dxml")
+
+_needs_skrobot = pytest.mark.skipif(
+    not skrobot_primitive_available(),
+    reason="scikit-robot per-mesh primitive API not installed")
+
+_PRIMS = {"box", "cylinder", "sphere"}
+
+
+def _make_pkg(tmp_path, robot="fing", origin=None):
+    """A one-link built package (visual + collision reference the sample mesh),
+    optionally with a non-identity <collision> <origin>."""
+    if not os.path.exists(_SAMPLE_MESH):
+        pytest.skip("sample .3dxml mesh not present")
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "meshes").mkdir()
+    (tmp_path / "urdf").mkdir()
+    shutil.copy(_SAMPLE_MESH, tmp_path / "meshes" / "part.3dxml")
+    org = f'<origin xyz="{origin}" rpy="0 0 0"/>' if origin else ""
+    urdf = (
+        f'<?xml version="1.0"?>\n<robot name="{robot}">\n'
+        '  <link name="base_link">\n'
+        '    <visual><geometry>'
+        '<mesh filename="../meshes/part.3dxml"/></geometry></visual>\n'
+        f'    <collision>{org}<geometry>'
+        '<mesh filename="../meshes/part.3dxml"/></geometry></collision>\n'
+        '  </link>\n</robot>\n')
+    (tmp_path / "urdf" / f"{robot}.urdf").write_text(urdf, encoding="utf-8")
+    return str(tmp_path)
+
+
+def _collision_geo_child(files, robot):
+    root = ET.fromstring(
+        files[f"{robot}_description/urdf/{robot}_description.urdf"].decode())
+    link = root.find("link")
+    cols = link.findall("collision")
+    assert len(cols) == 1
+    return link, cols[0]
+
+
+@_needs_skrobot
+def test_primitive_auto_replaces_mesh_with_shape(tmp_path):
+    """collision='primitive' swaps the collision <mesh> for a fitted primitive
+    (box/cylinder/sphere); NO collision mesh file ships, the visual is untouched."""
+    pkg_dir = _make_pkg(tmp_path, robot="fing")
+    files = dict(build_ros_description(pkg_dir, "fing", collision="primitive"))
+
+    # no collision mesh file of any kind is emitted; the visual .dae still is
+    assert not any("_collision" in a for a in files)
+    assert "fing_description/meshes/part.stl" not in files
+    assert "fing_description/meshes/part.dae" in files
+
+    link, col = _collision_geo_child(files, "fing")
+    geo = col.find("geometry")
+    assert geo.find("mesh") is None                     # mesh replaced
+    shape = next(iter(geo))
+    assert shape.tag in _PRIMS
+    # the primitive carries a pose via <origin>
+    assert col.find("origin") is not None
+    # visual mesh path unchanged
+    assert (link.find("visual").find(".//mesh").get("filename")
+            == "package://fing_description/meshes/part.dae")
+
+
+@_needs_skrobot
+@pytest.mark.parametrize("mode,tag,attrs", [
+    ("box", "box", ("size",)),
+    ("cylinder", "cylinder", ("radius", "length")),
+    ("sphere", "sphere", ("radius",)),
+])
+def test_forced_primitive_type(tmp_path, mode, tag, attrs):
+    """Forcing box/cylinder/sphere yields exactly that URDF primitive with its
+    dimension attributes populated with positive numbers."""
+    pkg_dir = _make_pkg(tmp_path, robot="fp")
+    files = dict(build_ros_description(pkg_dir, "fp", collision=mode))
+    _link, col = _collision_geo_child(files, "fp")
+    shape = col.find("geometry").find(tag)
+    assert shape is not None
+    for a in attrs:
+        nums = [float(x) for x in shape.get(a).split()]
+        assert nums and all(n > 0 for n in nums)
+
+
+@_needs_skrobot
+def test_primitive_origin_composes_collision_origin(tmp_path):
+    """A non-identity <collision> <origin> is composed into the fitted
+    primitive's pose (not dropped): shifting the collision origin by +0.05 in x
+    shifts the primitive origin by the same amount."""
+    base = _make_pkg(tmp_path / "id", robot="o")
+    moved = _make_pkg(tmp_path / "mv", robot="o", origin="0.05 0 0")
+
+    def _x(pkg):
+        files = dict(build_ros_description(pkg, "o", collision="box"))
+        _l, col = _collision_geo_child(files, "o")
+        return float(col.find("origin").get("xyz").split()[0])
+
+    assert abs((_x(moved) - _x(base)) - 0.05) < 1e-6
+
+
+def test_primitive_needs_skrobot_raises(tmp_path, monkeypatch):
+    """Requesting a primitive mode without scikit-robot raises a clear, actionable
+    error (the optional-dependency contract, mirrored on coacd)."""
+    monkeypatch.setattr(ros_export, "skrobot_primitive_available", lambda: False)
+    pkg_dir = _make_pkg(tmp_path, robot="fing")
+    with pytest.raises(ValueError, match="scikit-robot"):
+        build_ros_description(pkg_dir, "fing", collision="primitive")


### PR DESCRIPTION
Fits a native URDF primitive per <collision> as a lightweight alternative to the CoACD / convex-hull mesh collisions (issue #106) -- the lightest collision geometry there is (no mesh file), for path planning where a coarse convex bound per link is enough.

New `collision` modes on the ROS export: `primitive` (auto-picks the best of box/cylinder/sphere by voxel IoU) and forced `box` / `cylinder` / `sphere`. Each replaces the <collision>'s <mesh> with a <box>/<cylinder>/<sphere> element plus the fitted pose on <origin>, composed with the bake transform (or the block's own origin when origins are kept).

The fitting lives upstream in scikit-robot (fit_primitive_to_mesh + primitive_params_to_origin, >=0.3.17); we only place the result. scikit-robot is an OPTIONAL dependency: a missing/older version raises a clear error and the modes degrade gracefully, exactly like the coacd extra.

Wired through the CLI (--collision), the web ZIP export + viewer preview, and the collision-mode selector. Adds tests covering auto/forced fitting, origin composition, and the optional-dependency error.


https://github.com/user-attachments/assets/8322c9dc-6c0c-4c01-9937-9749f2302fb1




