### PR TITLE
Unified progress panel + cancellation for every editor job

### DIFF
--- a/sw2robot/editor/_autolimits_cli.py
+++ b/sw2robot/editor/_autolimits_cli.py
@@ -84,16 +84,16 @@ def main():
     total = sum(1 for j in robot.joint_list
                 if type(j).__name__ in ("RotationalJoint", "LinearJoint"))
     _emit(event="start", total=total)
-    done = [0]
 
-    def progress(name, _res):
-        done[0] += 1
-        _emit(event="joint", i=done[0], total=total, joint=name)
+    def on_start(name, i, n):
+        # emit BEFORE each joint's sweep so the bar advances and names the joint
+        # currently being worked (a single joint can take seconds on a big model)
+        _emit(event="joint", i=i, total=n, joint=name)
 
     results = autoinit.sweep_limits(
         robot, meshes, step_deg=step_deg, max_deg=max_deg,
         margin_deg=margin_deg, margin_mm=margin_mm,
-        refine=True, progress=progress)
+        refine=True, on_start=on_start)
     out = [{"child": v["child"], "lower": v["lower"], "upper": v["upper"],
             "continuous": v["continuous"]}
            for v in results.values() if v.get("child")]

--- a/sw2robot/editor/autoinit.py
+++ b/sw2robot/editor/autoinit.py
@@ -313,7 +313,8 @@ def _prismatic_joints(robot):
 def sweep_limits(robot, meshes, step_deg=6.0, max_deg=180.0, margin_deg=2.0,
                  step_mm=5.0, max_mm=300.0, margin_mm=2.0,
                  margin_m=REST_MARGIN, only=None, progress=None, refine=True,
-                 refine_tol_deg=0.4, refine_tol_mm=0.2, sc=None, hull=False):
+                 refine_tol_deg=0.4, refine_tol_mm=0.2, sc=None, hull=False,
+                 on_start=None):
     """Per-joint self-collision limit sweep, from the HOME pose (all at 0).
 
     Sweeps REVOLUTE joints in radians (``step_deg`` / ``max_deg``) and PRISMATIC
@@ -406,7 +407,11 @@ def sweep_limits(robot, meshes, step_deg=6.0, max_deg=180.0, margin_deg=2.0,
 
     out = {}
     try:
-        for J in joints:
+        for _idx, J in enumerate(joints, 1):
+            # fire BEFORE the (possibly multi-second) sweep of this joint so a UI
+            # shows the joint currently being worked, not the last one finished
+            if on_start:
+                on_start(J.name, _idx, len(joints))
             pris = J in pjoints
             # per-joint sweep parameters in the joint's native unit
             if pris:

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -222,8 +222,10 @@
               white-space: nowrap; }
   #hovertip .key { background: #444; border: 1px solid #666;
                    border-radius: 3px; padding: 0 4px; font-family: monospace; }
-  #loadbar { position: absolute; left: 50%; top: 50%;
-             transform: translate(-50%, -50%); z-index: 7; display: none;
+  /* the single progress panel for every job -- extract, export, sweep and the
+     collision preview all render here (top-centred), one style (issue #21) */
+  #loadbar { position: absolute; left: 50%; top: 64px;
+             transform: translateX(-50%); z-index: 7; display: none;
              width: 340px; background: #1c2228ee; border: 1px solid #456;
              border-radius: 8px; padding: 14px 18px; text-align: center;
              pointer-events: none; }
@@ -239,14 +241,29 @@
   @keyframes lbslide {
     0% { margin-left: 0; } 50% { margin-left: 70%; }
     100% { margin-left: 0; } }
-  /* spinning gear for the CoACD "computing" banner */
-  #coacdstat { display: none; }
-  #coacdstat.on { display: flex; }
-  .coacd-spin { animation: coacdspin 1.1s linear infinite; }
-  @keyframes coacdspin { to { transform: rotate(360deg); } }
   #loadbar .lb-sub { font-size: 11px; color: #8a93a3; margin-top: 6px;
                      overflow: hidden; text-overflow: ellipsis;
                      white-space: nowrap; }
+  /* unified progress: per-stage checklist + live log tail (issue #21) */
+  #loadbar .lb-stages { display: none; margin-top: 10px; text-align: left; }
+  #loadbar .lb-stages .lb-stage { font-size: 11px; color: #8a93a3;
+                     line-height: 1.65; white-space: nowrap; overflow: hidden;
+                     text-overflow: ellipsis; }
+  #loadbar .lb-stages .lb-stage.done { color: #6ac26a; }
+  #loadbar .lb-stages .lb-stage.active { color: #fff; }
+  #loadbar .lb-stages .lb-ico { display: inline-block; width: 15px; }
+  #loadbar .lb-log { display: none; margin-top: 9px; text-align: left;
+                     font-family: ui-monospace, Menlo, Consolas, monospace;
+                     font-size: 10px; color: #6f7885; line-height: 1.5;
+                     max-height: 84px; overflow: hidden; }
+  #loadbar .lb-log div { white-space: nowrap; overflow: hidden;
+                     text-overflow: ellipsis; }
+  /* shared cancel control for cancellable jobs (extract / collision preview) */
+  #loadbar #lbstop { display: none; margin-top: 11px; pointer-events: auto;
+                     padding: 2px 12px; font-size: 11px; background: #3a1414;
+                     color: #ffb3b3; border: 1px solid #a33; border-radius: 3px;
+                     cursor: pointer; }
+  #loadbar #lbstop:disabled { opacity: .5; cursor: default; }
   /* end-coords placement panel (Blender-style gizmo HUD) */
   #ecpanel { position: absolute; left: 8px; top: 44px; z-index: 8;
              display: none; width: 212px; background: #1b2128f2;
@@ -399,26 +416,6 @@
          text-overflow:ellipsis"></div>
     <!-- CoACD collision-generation progress banner (top centre, below the view
          buttons): shows it is computing + which link, with a stop button -->
-    <div id="coacdstat" style="position:absolute;left:50%;top:64px;
-         transform:translateX(-50%);z-index:6;min-width:280px;max-width:80%;
-         flex-direction:column;align-items:stretch;gap:5px;
-         background:#10243aee;color:#bfe0ff;border:1px solid #2d6aa3;
-         border-radius:4px;padding:5px 10px;font-size:12px;
-         pointer-events:auto;white-space:nowrap">
-      <div style="display:flex;align-items:center;gap:8px">
-        <span class="coacd-spin" style="display:inline-block">⚙</span>
-        <span id="coacdstattext"
-              style="flex:1;overflow:hidden;text-overflow:ellipsis">CoACD …</span>
-        <button id="coacdstop" data-i18n="ui.coacdstop"
-                style="padding:1px 8px;font-size:11px;
-                       background:#3a1414;color:#ffb3b3;border:1px solid #a33;
-                       border-radius:3px;cursor:pointer">■ stop</button>
-      </div>
-      <div style="height:5px;background:#0a1622;border-radius:3px;overflow:hidden">
-        <div id="coacdbar" style="height:100%;width:0%;background:#4f9dde;
-             border-radius:3px;transition:width .25s"></div>
-      </div>
-    </div>
     <div id="emptyprompt" style="position:absolute;left:50%;top:50%;
          transform:translate(-50%,-50%);z-index:4;display:none;
          text-align:center;color:#7a828e;pointer-events:none">
@@ -457,6 +454,9 @@
       <div class="lb-text"></div>
       <div class="lb-track"><div class="lb-fill"></div></div>
       <div class="lb-sub"></div>
+      <div class="lb-stages"></div>
+      <div class="lb-log"></div>
+      <button id="lbstop" data-i18n="ui.coacdstop">■ stop</button>
     </div>
     <div id="selbar" style="position:absolute;top:40px;left:8px;z-index:5;
          display:none;gap:4px;align-items:center;background:#22252bdd;
@@ -1399,6 +1399,21 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
                       ja: a => `${a.what} パッケージを書き出し中（メッシュ変換）…` },
     'export.done': { en: a => `exported ${a.file}`, ja: a => `${a.file} を書き出しました` },
     'export.fail': { en: a => `export failed: ${a.e}`, ja: a => `書き出しに失敗: ${a.e}` },
+    'export.cancelling': { en: 'cancelling export …', ja: '書き出しを中止中 …' },
+    'export.cancelled': { en: 'export cancelled', ja: '書き出しを中止しました' },
+    // unified progress panel (issue #21): fallback title + per-stage labels
+    'prog.working': { en: 'working …', ja: '処理中 …' },
+    'prog.cancelling': { en: 'cancelling — finishing the current step …',
+                         ja: '中止中 — 現在の処理を完了しています …' },
+    'prog.s.connect': { en: 'connect SolidWorks', ja: 'SolidWorks 接続' },
+    'prog.s.extract': { en: 'extract assembly', ja: 'アセンブリ抽出' },
+    'prog.s.meshes': { en: 'export meshes', ja: 'メッシュ書き出し' },
+    'prog.s.build': { en: 'build package', ja: 'パッケージ構築' },
+    'prog.s.load': { en: 'load model', ja: 'モデル読み込み' },
+    'prog.s.sweep': { en: 'sweep joints', ja: '関節スイープ' },
+    'prog.s.collision': { en: 'collision shapes', ja: '衝突形状' },
+    'prog.s.convert': { en: 'convert meshes', ja: 'メッシュ変換' },
+    'prog.s.zip': { en: 'package + zip', ja: 'パッケージ化 + ZIP' },
     'ui.exppkgname': { en: 'package', ja: 'パッケージ名' },
     't.exppkgname': { en: 'ROS package name for the exported ROS1/ROS2 package (default <name>_description). Lowercase letters, digits and underscores only.',
                       ja: 'エクスポートする ROS1/ROS2 パッケージの名前（既定: <name>_description）。英小文字・数字・アンダースコアのみ。' },
@@ -1844,6 +1859,11 @@ function showLoadbar(text, { indet = false, delay = 0 } = {}) {
   const show = () => {
     loadbarEl.querySelector('.lb-text').textContent = text;
     loadbarEl.querySelector('.lb-sub').textContent = '';
+    // a plain loadbar has no stage checklist / log tail -- hide any left over
+    // from a previous unified-progress run so it doesn't bleed through
+    loadbarEl.querySelector('.lb-stages').style.display = 'none';
+    loadbarEl.querySelector('.lb-log').style.display = 'none';
+    clearProgressStop();          // a plain loadbar carries no cancel control
     loadbarEl.classList.toggle('indet', indet);
     if (indet) { loadbarEl.querySelector('.lb-fill').style.width = '30%'; }
     loadbarEl.style.display = 'block';
@@ -1868,8 +1888,120 @@ function updateLoadbar(frac, sub, text) {
 function hideLoadbar() {
   clearTimeout(loadbarTimer);
   loadbarTimer = null;
+  clearProgressStop();
   loadbarEl.style.display = 'none';
 }
+
+// ---- unified progress: one bar + per-stage checklist + log tail (issue #21)
+// Extract / export / limit-sweep all report into the server's single _prog
+// object (GET /api/progress); renderProgress paints it into #loadbar and
+// pollProgress drives one poll loop, resolving with the job's result.
+const PROG_STAGE_KEY = {
+  'connect SolidWorks': 'prog.s.connect',
+  'extract assembly': 'prog.s.extract',
+  'export meshes': 'prog.s.meshes',
+  'build package': 'prog.s.build',
+  'load model': 'prog.s.load',
+  'sweep joints': 'prog.s.sweep',
+  'collision': 'prog.s.collision',
+  'convert meshes': 'prog.s.convert',
+  'package + zip': 'prog.s.zip',
+};
+function stageLabel(name) {
+  const k = PROG_STAGE_KEY[name];
+  return k ? t(k) : name;
+}
+function renderProgress(st) {
+  loadbarEl.style.display = 'block';
+  const q = s => loadbarEl.querySelector(s);
+  // once stop is pressed, show a clear "cancelling" state until the job ends
+  // (a step already running -- e.g. a CoACD part -- has to finish first)
+  const cancelling = progressCancelling && st.running;
+  q('.lb-text').textContent = cancelling ? t('prog.cancelling')
+    : (st.label ? stageLabel(st.label) : t('prog.working'));
+  if (cancelling || st.frac == null) {
+    loadbarEl.classList.add('indet');
+    q('.lb-fill').style.width = '30%';
+  } else {
+    loadbarEl.classList.remove('indet');
+    q('.lb-fill').style.width = `${Math.round(st.frac * 100)}%`;
+  }
+  q('.lb-sub').textContent = st.sub || '';
+  const stagesEl = q('.lb-stages');
+  if (st.stages && st.stages.length) {
+    stagesEl.style.display = 'block';
+    stagesEl.replaceChildren();
+    for (const s of st.stages) {
+      const row = document.createElement('div');
+      row.className = 'lb-stage ' + s.state;
+      const ico = s.state === 'done' ? '✓' : s.state === 'active' ? '▸' : '○';
+      const sp = document.createElement('span');
+      sp.className = 'lb-ico'; sp.textContent = ico;
+      row.append(sp, document.createTextNode(stageLabel(s.name)));
+      stagesEl.append(row);
+    }
+  } else {
+    stagesEl.style.display = 'none';
+  }
+  const logEl = q('.lb-log');
+  const lines = st.log || [];
+  if (lines.length) {
+    logEl.style.display = 'block';
+    logEl.replaceChildren();
+    for (const ln of lines.slice(-8)) {
+      const d = document.createElement('div');
+      d.textContent = ln;
+      logEl.append(d);
+    }
+  } else {
+    logEl.style.display = 'none';
+  }
+}
+let progressPoll = null;
+// Poll /api/progress until the job ends.  onTick(st) runs each poll (e.g. to
+// stream log lines into the console).  Resolves {result, cancelled}; rejects on
+// a job error.  intervalMs defaults to 400.
+function pollProgress({ onTick, intervalMs = 400 } = {}) {
+  return new Promise((resolve, reject) => {
+    if (progressPoll) { clearInterval(progressPoll); }
+    progressPoll = setInterval(async () => {
+      let st;
+      try { st = await (await fetch('/api/progress')).json(); }
+      catch { return; }                         // transient: keep polling
+      renderProgress(st);
+      if (onTick) { try { onTick(st); } catch (_e) { /* non-fatal */ } }
+      if (st.done) {
+        clearInterval(progressPoll); progressPoll = null;
+        if (st.error) { reject(new Error(st.error)); }
+        else { resolve({ result: st.result, cancelled: !!st.cancelled }); }
+      }
+    }, intervalMs);
+  });
+}
+// Shared cancel control on the unified panel: a cancellable job registers a stop
+// callback (extract, collision preview); the #lbstop button runs it.  showLoadbar
+// / hideLoadbar clear it, so it only shows while a cancellable job owns the panel.
+const lbStop = document.getElementById('lbstop');
+let progressStopFn = null;
+let progressCancelling = false;      // stop pressed, job winding down
+function setProgressStop(fn) {
+  progressStopFn = fn;
+  progressCancelling = false;
+  if (lbStop) { lbStop.disabled = false; lbStop.style.display = 'inline-block'; }
+}
+function clearProgressStop() {
+  progressStopFn = null;
+  progressCancelling = false;
+  if (lbStop) { lbStop.style.display = 'none'; }
+}
+lbStop?.addEventListener('click', () => {
+  if (!progressStopFn) { return; }
+  lbStop.disabled = true;                    // one press; the job ends on its own
+  // some steps can't stop instantly (CoACD is atomic per part), so show a clear
+  // "cancelling" state right away rather than leaving the panel looking frozen
+  progressCancelling = true;
+  progressStopFn();
+});
 
 // ---- mesh loading with per-file progress -------------------------------
 const meshStats = { want: 0, done: 0, fail: 0 };
@@ -4324,21 +4456,10 @@ autolimitsBtn.addEventListener('click', async () => {
       + `&margin_mm=${encodeURIComponent(mm)}`);
     const data = await resp0.json();
     if (!resp0.ok || data.error) { throw new Error(data.error ?? resp0.status); }
-    let st = {};
-    while (true) {
-      await new Promise(r => setTimeout(r, 400));
-      try { st = await (await fetch('/api/auto_limits/status')).json(); }
-      catch { continue; }                       // transient: keep polling
-      if (st.total) {
-        updateLoadbar(st.n / st.total,
-                      t('auto.sweepProg', { n: st.n, total: st.total, j: st.joint }));
-      } else if (st.phase === 'loading') {
-        updateLoadbar(null, null, t('auto.sweepLoading'));
-      }
-      if (st.done) { break; }
-    }
-    if (st.error) { throw new Error(st.error); }
-    const results = st.results || [];
+    // unified progress: the sweep reports stages (load model -> sweep joints)
+    // and per-joint frac into _prog; pollProgress paints them + returns results
+    const { result } = await pollProgress();
+    const results = (result && result.results) || [];
     const limited = results.filter(r => !r.continuous);
     const cont = results.filter(r => r.continuous);
     log(t('auto.sweepDone', { l: limited.length, c: cont.length }), 'ok');
@@ -4454,11 +4575,7 @@ updateCollUI();
 // to overlay them (semi-transparent) on the visual meshes.
 const collPreviewGenBtn = document.getElementById('coacdgen');
 const collPreviewShow = document.getElementById('coacdshow');
-const collPreviewProg = document.getElementById('coacdprog');
-const collPreviewStat = document.getElementById('coacdstat');       // top banner
-const collPreviewStatText = document.getElementById('coacdstattext');
-const collPreviewStopBtn = document.getElementById('coacdstop');
-const collPreviewBar = document.getElementById('coacdbar');         // determinate fill
+const collPreviewProg = document.getElementById('coacdprog');       // inline summary
 
 // blink the links currently being decomposed (several run in parallel), so it
 // is obvious which parts are still computing -- toggle their hover tint on one
@@ -4564,36 +4681,41 @@ async function collPreviewTick() {
   // links the SERVER produced parts for (authoritative: the overlay GLBs load
   // asynchronously, so collPreviewGroups may still be empty right when the job ends)
   const produced = Object.keys(s.parts || {}).length;
-  if (collPreviewBar) {                              // determinate progress fill
-    collPreviewBar.style.width = total ? Math.round(done / total * 100) + '%' : '0%';
-  }
   // blink ALL links currently being decomposed (they run in parallel)
   const inflight = s.running ? (s.inflight || []) : [];
   collPreviewSetBlink(inflight);
-  if (s.error) {
-    collPreviewProg.textContent = '';
-    log(t('coacd.fail', { e: s.error }), 'err');
-  } else if (s.running) {
+  if (s.running) {
+    // paint the SAME unified panel as extract/export/sweep (issue #21) -- the
+    // per-link blink/mesh-pop above stays in the viewport, unaffected
     const label = inflight.length
       ? inflight.slice(0, 2).join(', ')
         + (inflight.length > 2 ? ` +${inflight.length - 2}` : '')
       : (s.current || '');
     const msg = t('coacd.prog', { done, total, link: label, what });
+    renderProgress({
+      job: 'collision', running: true, done: false,
+      stages: [{ name: 'build collision preview', state: 'active' }],
+      frac: total ? done / total : null,
+      label: 'build collision preview',
+      sub: total ? msg : (label || t('coacd.start')),
+      log: [],
+    });
     collPreviewProg.textContent = msg;
-    if (collPreviewStatText) { collPreviewStatText.textContent = msg; }   // top banner
-    collPreviewStat?.classList.add('on');
-  } else if (s.cancelled) {
-    collPreviewProg.textContent = t('coacd.cancelled', { n: produced });
-    log(t('coacd.cancelled', { n: produced }), 'warn');
-  } else {
-    collPreviewProg.textContent = t('coacd.done', { n: produced });
-    log(t('coacd.done', { n: produced }), 'ok');
   }
   if (!s.running) {
-    collPreviewStat?.classList.remove('on');
+    hideLoadbar();
     clearInterval(collPreviewPoll); collPreviewPoll = null;
     if (collPreviewGenBtn) { collPreviewGenBtn.disabled = false; }
-    if (collPreviewStopBtn) { collPreviewStopBtn.disabled = false; }
+    if (s.error) {
+      collPreviewProg.textContent = '';
+      log(t('coacd.fail', { e: s.error }), 'err');
+    } else if (s.cancelled) {
+      collPreviewProg.textContent = t('coacd.cancelled', { n: produced });
+      log(t('coacd.cancelled', { n: produced }), 'warn');
+    } else {
+      collPreviewProg.textContent = t('coacd.done', { n: produced });
+      log(t('coacd.done', { n: produced }), 'ok');
+    }
     if (produced > 0 && !collPreviewFinalized) {
       collPreviewFinalized = true;
       // 1) the URDF/ROS export should now ship these parts as <collision>:
@@ -4606,12 +4728,11 @@ async function collPreviewTick() {
     }
   }
 }
-collPreviewStopBtn?.addEventListener('click', async () => {
-  collPreviewStopBtn.disabled = true;
-  if (collPreviewStatText) { collPreviewStatText.textContent = t('coacd.stopping'); }
+// stop the preview (the unified panel's ■ stop registers this while it runs)
+function collPreviewStop() {
   log(t('coacd.stopping'));
-  try { await fetch('/api/collision/preview/cancel'); } catch (_e) { /* ignore */ }
-});
+  fetch('/api/collision/preview/cancel').catch(() => { /* ignore */ });
+}
 // Abandon the in-flight generate job (the user switched collision mode mid-run).
 // Stop polling FIRST so the now-cancelled job's completion can't reach the
 // finalize block and revert the selector to the old mode; then tell the server
@@ -4620,10 +4741,9 @@ function collPreviewAbort() {
   if (collPreviewPoll) { clearInterval(collPreviewPoll); collPreviewPoll = null; }
   collPreviewSetBlink([]);                         // stop the per-link blink timer
   try { fetch('/api/collision/preview/cancel'); } catch (_e) { /* ignore */ }
-  collPreviewStat?.classList.remove('on');         // hide the "computing" banner
+  hideLoadbar();                                   // drop the unified panel
   if (collPreviewProg) { collPreviewProg.textContent = ''; }
   if (collPreviewGenBtn) { collPreviewGenBtn.disabled = false; }
-  if (collPreviewStopBtn) { collPreviewStopBtn.disabled = false; }
 }
 collPreviewGenBtn?.addEventListener('click', async () => {
   if (collPreviewPoll) { return; }
@@ -4632,11 +4752,15 @@ collPreviewGenBtn?.addEventListener('click', async () => {
   collPreviewFinalized = false;
   setCollisionShown(true);                       // watch it build by default
   collPreviewGenBtn.disabled = true;
-  if (collPreviewStopBtn) { collPreviewStopBtn.disabled = false; }
   collPreviewProg.textContent = t('coacd.start');
-  if (collPreviewStatText) { collPreviewStatText.textContent = t('coacd.start'); }
-  if (collPreviewBar) { collPreviewBar.style.width = '0%'; }
-  collPreviewStat?.classList.add('on');                // show "computing" banner now
+  // show the unified panel immediately (same style/position as extract/export),
+  // with a ■ stop control wired to cancel this job
+  renderProgress({
+    job: 'collision', running: true, done: false,
+    stages: [{ name: 'build collision preview', state: 'active' }],
+    frac: null, label: 'build collision preview', sub: t('coacd.start'), log: [],
+  });
+  setProgressStop(collPreviewStop);
   const mode = collModeSel?.value || 'coacd';
   const q = cqualitySel?.value || 'balanced';
   const what = mode === 'hull' ? t('coll.hullword') : 'CoACD';
@@ -4651,7 +4775,7 @@ collPreviewGenBtn?.addEventListener('click', async () => {
   } catch (e) {
     collPreviewGenBtn.disabled = false;
     collPreviewProg.textContent = '';
-    collPreviewStat?.classList.remove('on');
+    hideLoadbar();
     log(t('coacd.fail', { e: e.message ?? e }), 'err');
   }
 });
@@ -4693,7 +4817,7 @@ expLinks.forEach(a => a.addEventListener('click', async ev => {
   // separate uniform-glb button is gone -- format is now a visual selector)
   const collMode = collModeSel?.value || 'copy';
   const mergeFixed = !!mergeFixedBox?.checked;
-  const url = `/api/export/zip?ros=${ros}&meshes=${vfmt}&colfmt=${cfmt}`
+  const query = `ros=${ros}&meshes=${vfmt}&colfmt=${cfmt}`
     + (name ? `&name=${encodeURIComponent(name)}` : '')
     + (urdf ? `&urdf=${encodeURIComponent(urdf)}` : '')
     + (meshdir ? `&meshdir=${encodeURIComponent(meshdir)}` : '')
@@ -4704,7 +4828,17 @@ expLinks.forEach(a => a.addEventListener('click', async ev => {
   showLoadbar(t('export.bar', { what }), { indet: true });
   log(t('export.start', { what }));
   try {
-    const resp = await fetch(url);
+    // ASYNC export: start the build (reports into _prog), watch the unified
+    // progress panel live, then download the finished bytes
+    const r0 = await (await fetch('/api/export/zip/start?' + query)).json();
+    if (r0.error) { throw new Error(r0.error); }
+    setProgressStop(() => {                     // ■ stop -> cooperative cancel
+      log(t('export.cancelling'), 'wrn');
+      fetch('/api/export/zip/cancel').catch(() => { /* ignore */ });
+    });
+    const { cancelled } = await pollProgress();
+    if (cancelled) { log(t('export.cancelled'), 'wrn'); return; }
+    const resp = await fetch('/api/export/zip/download');
     if (!resp.ok) {
       let msg = resp.status;
       try { msg = (await resp.json()).error ?? msg; } catch (_e) { /* not json */ }
@@ -6482,26 +6616,6 @@ function fmtSecs(s) {
                 : t('time.minSec', { m: Math.floor(s / 60),
                                      s: String(s % 60).padStart(2, '0') });
 }
-// put the loadbar back into the indeterminate (sweeping) state
-function loadbarIndet() {
-  loadbarEl.classList.add('indet');
-  loadbarEl.querySelector('.lb-fill').style.width = '30%';
-}
-// map an extract log line to a short, localised phase label
-function extractPhase(line) {
-  const rp = line.match(/^reading part: (.+)$/);
-  if (rp) return rp[1];                 // show WHICH part is being read
-  if (/starting SolidWorks/.test(line)) return t('phase.starting');
-  if (/reusing the warm/.test(line))    return t('phase.reuse');
-  if (/opening copy|loading the assembly/.test(line)) return t('phase.opening');
-  if (/components.*mate|reading components/.test(line)) return t('phase.components');
-  if (/sub-assembly internal mesh/.test(line)) return t('phase.subMesh');
-  if (/reading sub-assembly/.test(line)) return t('phase.subRead');
-  if (/full assembly mesh/.test(line))   return t('phase.fullMesh');
-  if (/saving graph/.test(line))         return t('phase.savingGraph');
-  if (/model from graph|build/.test(line)) return t('phase.buildUrdf');
-  return t('phase.extracting');
-}
 
 // extraction runs SolidWorks in a server-side thread that checks a cancel flag
 // at every progress checkpoint (per phase / per mesh), so it can be interrupted
@@ -6535,71 +6649,43 @@ async function extractFlow(p) {
   log(t('extract.started'));
   extracting = true;
   showLoadbar(t('extract.bar'), { indet: true });
+  setProgressStop(() => cancelExtraction());   // ■ stop on the unified panel
   const t0 = performance.now();
   let seen = 0;
-  const poll = setInterval(async () => {
-    let st;
-    try {
-      st = await (await fetch('/api/extract/status')).json();
-    } catch { return; }
-    for (; seen < st.log.length; seen++) { log(`  ${st.log[seen]}`); }
-    const elapsed = (performance.now() - t0) / 1000;       // seconds
-
-    if (!st.running) {
-      clearInterval(poll);
-      extracting = false;
-      if (st.cancelled) {
-        hideLoadbar();
-        document.getElementById('loadbackdrop').style.display = 'none';
-        statusEl.textContent = t('extract.cancelled');
-        log(t('extract.cancelled'), 'wrn');
-        return;
-      }
-      if (st.error) {
-        hideLoadbar();
-        document.getElementById('loadbackdrop').style.display = 'none';
-        log(t('extract.failed', { e: st.error }), 'err');
-        return;
-      }
-      log(t('extract.done', { time: fmtSecs(elapsed) }), 'ok');
-      openServerPath(st.package);   // its own loadbar takes over
+  const backdrop = document.getElementById('loadbackdrop');
+  try {
+    // the server now owns the stage/frac mapping (see _prog_extract_stage) --
+    // the client just streams new log lines; renderProgress paints the rest
+    const { result, cancelled } = await pollProgress({
+      intervalMs: 1000,
+      onTick: st => {
+        const lines = st.log || [];
+        for (; seen < lines.length; seen++) { log(`  ${lines[seen]}`); }
+        statusEl.textContent = t('extract.statusElapsed',
+          { time: fmtSecs((performance.now() - t0) / 1000) });
+      },
+    });
+    extracting = false;
+    if (cancelled) {
+      hideLoadbar();
+      backdrop.style.display = 'none';
+      statusEl.textContent = t('extract.cancelled');
+      log(t('extract.cancelled'), 'wrn');
       return;
     }
-
-    const lines = st.log;
-    const lastReal = [...lines].reverse()
-      .find(l => !l.startsWith('... still')) ?? '';
-    const heartbeat = [...lines].reverse()
-      .find(l => l.startsWith('... still'));
-    const alive = heartbeat &&
-      heartbeat.match(/(\d+) SolidWorks process/);
-    statusEl.textContent = t('extract.statusElapsed', { time: fmtSecs(elapsed) });
-
-    // B: determinate bar while exporting the per-link meshes (the bulk)
-    const mesh = lastReal.match(/exporting mesh (\d+)\/(\d+)/);
-    if (mesh) {
-      const i = +mesh[1], n = +mesh[2];
-      const name = lastReal.split(': ').slice(-1)[0] ?? '';
-      updateLoadbar(i / n, t('extract.meshBar', { i, n, name }).slice(0, 64),
-                    t('extract.meshSub', { time: fmtSecs(elapsed) }));
-      return;
+    log(t('extract.done', { time: fmtSecs((performance.now() - t0) / 1000) }), 'ok');
+    if (result && result.package) {
+      openServerPath(result.package);   // its own loadbar takes over
+    } else {
+      hideLoadbar();
+      backdrop.style.display = 'none';
     }
-    // C: cold-start reassurance -- "starting SolidWorks" can be ~30 s of
-    // silence; show that it's alive (heartbeat process count) so it never
-    // looks frozen
-    loadbarIndet();
-    if (/starting SolidWorks/.test(lastReal)) {
-      const sub = alive
-        ? t('extract.alive', { c: alive[1] })
-        : t('extract.coldStart');
-      updateLoadbar(null, sub, t('extract.startingBar', { time: fmtSecs(elapsed) }));
-      return;
-    }
-    // other phases: indeterminate with a phase label + elapsed
-    const aliveTxt = alive ? t('extract.aliveShort') : '';
-    updateLoadbar(null, t('extract.elapsed', { time: fmtSecs(elapsed), alive: aliveTxt }),
-                  t('extract.phaseRunning', { phase: extractPhase(lastReal) }));
-  }, 1000);
+  } catch (e) {
+    extracting = false;
+    hideLoadbar();
+    backdrop.style.display = 'none';
+    log(t('extract.failed', { e: e.message ?? e }), 'err');
+  }
 }
 
 function openAny(p) {

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -1134,6 +1134,7 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     'auto.applied': { en: a => `applied limits to ${a.n} joint(s) ✓ — reloading (Ctrl+Z to undo)`,
                       ja: a => `${a.n} 関節にリミットを適用 ✓ — reloading（Ctrl+Z で元に戻せます）` },
     'auto.fail': { en: a => `auto-limits failed: ${a.e}`, ja: a => `自動リミットに失敗: ${a.e}` },
+    'auto.cancelled': { en: 'limit sweep cancelled', ja: 'リミット探索を中止しました' },
     // origin
     'origin.seated': { en: 'base_link aligned to the world origin ⌖', ja: 'base_link を世界原点に合わせました ⌖' },
     // re-root
@@ -4458,7 +4459,14 @@ autolimitsBtn.addEventListener('click', async () => {
     if (!resp0.ok || data.error) { throw new Error(data.error ?? resp0.status); }
     // unified progress: the sweep reports stages (load model -> sweep joints)
     // and per-joint frac into _prog; pollProgress paints them + returns results
-    const { result } = await pollProgress();
+    setProgressStop(() => fetch('/api/auto_limits/cancel').catch(() => {}));
+    const { result, cancelled } = await pollProgress();
+    if (cancelled) {
+      hideLoadbar();
+      log(t('auto.cancelled'), 'wrn');
+      autolimitsBtn.disabled = false;
+      return;
+    }
     const results = (result && result.results) || [];
     const limited = results.filter(r => !r.continuous);
     const cont = results.filter(r => r.continuous);

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -1123,9 +1123,6 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     'auto.sweepStart': { en: 'self-collision limit sweep (coarse scan + binary search) — this takes a few seconds …',
                          ja: '自己干渉リミット探索（粗スキャン + 二分探索）— 数秒かかります …' },
     'auto.sweepBar': { en: 'searching joint limits …', ja: '関節リミットを探索中 …' },
-    'auto.sweepLoading': { en: 'loading model …', ja: 'モデルを読み込み中 …' },
-    'auto.sweepProg': { en: a => `joint ${a.n}/${a.total}${a.j ? ' — ' + a.j : ''}`,
-                        ja: a => `関節 ${a.n}/${a.total}${a.j ? ' — ' + a.j : ''}` },
     'auto.sweepDone': { en: a => `sweep done: ${a.l} joint(s) get limits, ${a.c} stay continuous — applying …`,
                         ja: a => `探索完了: ${a.l} 関節にリミット、${a.c} 関節は連続回転のまま — 適用中 …` },
     'auto.noRot': { en: 'no rotational joints to limit', ja: 'リミット対象の回転関節がありません' },
@@ -1247,16 +1244,6 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     'open.fail': { en: a => `open failed: ${a.e}`, ja: a => `オープンに失敗: ${a.e}` },
     'time.sec': { en: a => `${a.s}s`, ja: a => `${a.s}秒` },
     'time.minSec': { en: a => `${a.m}m${a.s}s`, ja: a => `${a.m}分${a.s}秒` },
-    'phase.starting': { en: 'starting SolidWorks', ja: 'SolidWorks を起動中' },
-    'phase.reuse': { en: 'reusing SolidWorks session', ja: 'SolidWorks セッション再利用' },
-    'phase.opening': { en: 'opening the assembly', ja: 'アセンブリ読込中' },
-    'phase.components': { en: 'reading components / mates', ja: '部品・メイト解析中' },
-    'phase.subMesh': { en: 'exporting sub-assembly mesh', ja: 'サブアセンブリのメッシュ出力中' },
-    'phase.subRead': { en: 'reading sub-assembly', ja: 'サブアセンブリ解析中' },
-    'phase.fullMesh': { en: 'exporting full assembly mesh', ja: '全体メッシュ出力中' },
-    'phase.savingGraph': { en: 'saving graph.json', ja: 'graph.json 保存中' },
-    'phase.buildUrdf': { en: 'building URDF', ja: 'URDF 生成中' },
-    'phase.extracting': { en: 'extracting', ja: '抽出中' },
     'extract.request': { en: a => `requesting SolidWorks extraction: ${a.p}`, ja: a => `SolidWorks 抽出を要求: ${a.p}` },
     'extract.statusRunning': { en: '⏳ extracting from SolidWorks …', ja: '⏳ SolidWorks から抽出中 …' },
     'extract.startFail': { en: a => `extract failed to start: ${a.e}`, ja: a => `抽出の開始に失敗: ${a.e}` },
@@ -1267,15 +1254,6 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     'extract.cancelling': { en: 'cancelling extraction … (stops at the next step)', ja: '抽出をキャンセル中 … (次の処理の区切りで停止します)' },
     'extract.cancelled': { en: 'extraction cancelled', ja: '抽出をキャンセルしました' },
     'extract.statusElapsed': { en: a => `⏳ extracting … ${a.time}`, ja: a => `⏳ 抽出中 … ${a.time}` },
-    'extract.meshBar': { en: a => `mesh ${a.i}/${a.n}  ${a.name}`, ja: a => `メッシュ ${a.i}/${a.n}  ${a.name}` },
-    'extract.meshSub': { en: a => `exporting meshes — ${a.time}`, ja: a => `メッシュ出力中 — ${a.time}` },
-    'extract.alive': { en: a => `SolidWorks alive ✓ (${a.c} processes) — first run ~30s`,
-                       ja: a => `SolidWorks 稼働中 ✓ (${a.c} プロセス) — 初回は約30秒` },
-    'extract.coldStart': { en: 'first run: SolidWorks takes ~30s to start', ja: '初回は SolidWorks の起動に約30秒かかります' },
-    'extract.startingBar': { en: a => `starting SolidWorks … ${a.time}`, ja: a => `SolidWorks を起動中 … ${a.time}` },
-    'extract.aliveShort': { en: '  · SolidWorks alive ✓', ja: '  · SolidWorks稼働中 ✓' },
-    'extract.elapsed': { en: a => `${a.time} elapsed${a.alive}`, ja: a => `${a.time} 経過${a.alive}` },
-    'extract.phaseRunning': { en: a => `${a.phase} …`, ja: a => `${a.phase} …` },
     // file browser
     'fs.error': { en: a => `📁 ${a.e}`, ja: a => `📁 ${a.e}` },
     'fs.packageHint': { en: '(package — click to open)', ja: '(パッケージ — クリックで開く)' },
@@ -4445,9 +4423,9 @@ autolimitsBtn.addEventListener('click', async () => {
   autolimitsBtn.disabled = true;
   op('autoLimits', {});
   log(t('auto.sweepStart'));
-  // Start ASYNC, then poll /api/auto_limits/status for per-joint progress.
-  // (Safe now: the sweep runs in a child process, so polling no longer steals
-  // its GIL the way the old in-process sweep did.)
+  // Start ASYNC, then watch the unified /api/progress panel (via pollProgress)
+  // for per-joint progress.  (Safe now: the sweep runs in a child process, so
+  // polling no longer steals its GIL the way the old in-process sweep did.)
   showLoadbar(t('auto.sweepBar'), { indet: true });
   try {
     const md = document.getElementById('marginDeg')?.value || '2';

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -226,7 +226,11 @@
      collision preview all render here (top-centred), one style (issue #21) */
   #loadbar { position: absolute; left: 50%; top: 64px;
              transform: translateX(-50%); z-index: 7; display: none;
-             width: 340px; background: #1c2228ee; border: 1px solid #456;
+             /* wide enough that a part/mesh/joint name mostly fits, but capped
+                to the viewport on narrow windows; long lines wrap (see .lb-sub /
+                .lb-log div) instead of scrolling or clipping */
+             width: min(560px, 92vw); box-sizing: border-box;
+             background: #1c2228ee; border: 1px solid #456;
              border-radius: 8px; padding: 14px 18px; text-align: center;
              pointer-events: none; }
   #loadbar .lb-text { font-size: 13px; color: #fff; margin-bottom: 8px;
@@ -241,9 +245,13 @@
   @keyframes lbslide {
     0% { margin-left: 0; } 50% { margin-left: 70%; }
     100% { margin-left: 0; } }
+  /* the current-item line (mesh / part / joint name, or the extract heartbeat):
+     wrap onto up to 2 lines and only then ellipsize, so its tail -- usually the
+     identifying part -- stays readable instead of being cut off */
   #loadbar .lb-sub { font-size: 11px; color: #8a93a3; margin-top: 6px;
-                     overflow: hidden; text-overflow: ellipsis;
-                     white-space: nowrap; }
+                     overflow: hidden; overflow-wrap: anywhere;
+                     display: -webkit-box; -webkit-box-orient: vertical;
+                     -webkit-line-clamp: 2; line-clamp: 2; }
   /* unified progress: per-stage checklist + live log tail (issue #21) */
   #loadbar .lb-stages { display: none; margin-top: 10px; text-align: left; }
   #loadbar .lb-stages .lb-stage { font-size: 11px; color: #8a93a3;
@@ -252,12 +260,16 @@
   #loadbar .lb-stages .lb-stage.done { color: #6ac26a; }
   #loadbar .lb-stages .lb-stage.active { color: #fff; }
   #loadbar .lb-stages .lb-ico { display: inline-block; width: 15px; }
+  /* font-size 10px * line-height 1.5 = 15px per line; keep max-height an exact
+     multiple (6 lines) so the tail is clipped ON a line boundary -- never with a
+     line sliced in half above the stop button */
   #loadbar .lb-log { display: none; margin-top: 9px; text-align: left;
                      font-family: ui-monospace, Menlo, Consolas, monospace;
                      font-size: 10px; color: #6f7885; line-height: 1.5;
-                     max-height: 84px; overflow: hidden; }
-  #loadbar .lb-log div { white-space: nowrap; overflow: hidden;
-                     text-overflow: ellipsis; }
+                     max-height: 90px; overflow: hidden; }
+  #loadbar .lb-log div { overflow: hidden; overflow-wrap: anywhere;
+                     display: -webkit-box; -webkit-box-orient: vertical;
+                     -webkit-line-clamp: 2; line-clamp: 2; }
   /* shared cancel control for cancellable jobs (extract / collision preview) */
   #loadbar #lbstop { display: none; margin-top: 11px; pointer-events: auto;
                      padding: 2px 12px; font-size: 11px; background: #3a1414;

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -618,6 +618,7 @@ def _export_zip(pkg_dir, robot_name, visual_fmt="dae", collision_fmt="stl",
     import zipfile
 
     from sw2robot.exporter.ros_export import (
+        ExportCancelled,
         build_ros_description,
         ros_pkg_name,
     )
@@ -641,6 +642,8 @@ def _export_zip(pkg_dir, robot_name, visual_fmt="dae", collision_fmt="stl",
         progress("zip", 0, n)
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
         for i, (arc, data) in enumerate(files):
+            if should_cancel and should_cancel():   # stop mid-compression
+                raise ExportCancelled()
             # a node under scripts/ must extract executable (0755) so ament's
             # install(PROGRAMS) + `colcon build --symlink-install` leaves a
             # runnable libexec entry that `ros2 launch` can find
@@ -720,13 +723,17 @@ def _export_fname(robot_name, pkg, params):
             else f"{pkg}.zip")
 
 
-def _run_export(pkg_dir, robot_name, urdf_rel, params):
-    """Background ZIP export; stashes the bytes for /api/export/zip/download."""
+def _run_export(pkg_dir, robot_name, urdf_rel, params, gen):
+    """Background ZIP export; stashes the bytes for /api/export/zip/download.
+    ``gen`` is this job's progress generation: cancelling abandons in-flight
+    CoACD parts, so their late progress reports must not touch a newer job."""
     from sw2robot.exporter.ros_export import ExportCancelled
     _stage_map = {"collision": "collision", "meshes": "convert meshes",
                   "zip": "package + zip"}
 
     def _bp(stage, done, total, detail=""):
+        if _prog_gen() != gen:      # a newer job owns the panel; drop stale ticks
+            return
         # title = the (i18n) stage name (renderProgress maps it), count in the
         # sub line; keep the bar animated (indeterminate) until the first item
         # of a stage completes, so a slow first CoACD part never looks frozen
@@ -1354,6 +1361,7 @@ _job_lock = threading.Lock()
 # results the client needs travel in _prog["result"].
 _prog = {"job": None, "running": False, "done": True, "cancelled": False,
          "error": None,
+         "gen": 0,          # bumped each job; lets stale reports be ignored
          "stages": [],      # [{"name": str, "state": "pending|active|done"}]
          "frac": None,      # 0..1 for a determinate bar, None = indeterminate
          "label": "", "sub": "",
@@ -1365,15 +1373,22 @@ _PROG_LOG_CAP = 200
 
 def _prog_start(job, stages, label=""):
     """Claim the shared progress object for ``job`` with a fresh ordered stage
-    list (list of stage names).  Returns False if a job is already running."""
+    list (list of stage names).  Returns the new generation id, or None if a job
+    is already running."""
     with _prog_lock:
         if _prog["running"]:
-            return False
+            return None
         _prog.update(
             job=job, running=True, done=False, cancelled=False, error=None,
+            gen=_prog["gen"] + 1,
             stages=[{"name": s, "state": "pending"} for s in stages],
             frac=None, label=label, sub="", log=[], result=None)
-        return True
+        return _prog["gen"]
+
+
+def _prog_gen():
+    with _prog_lock:
+        return _prog["gen"]
 
 
 def _prog_stage(name, frac=None, label=None):
@@ -2416,7 +2431,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 params, err = _parse_export_query(cls, query)
                 if err:
                     return self._send_json({"error": err[0]}, err[1])
-                if not _prog_start("export", _EXPORT_STAGES):
+                gen = _prog_start("export", _EXPORT_STAGES)
+                if gen is None:
                     return self._send_json(
                         {"error": "a job is already running"}, 409)
                 _export_cancel.clear()
@@ -2424,7 +2440,7 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                     _export_out.update(data=None, fname=None)
                 threading.Thread(
                     target=_run_export,
-                    args=(cls.pkg_dir, cls.robot_name, cls.urdf_rel, params),
+                    args=(cls.pkg_dir, cls.robot_name, cls.urdf_rel, params, gen),
                     daemon=True).start()
                 return self._send_json({"started": True})
             if path == "/api/export/zip/cancel":

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1709,7 +1709,8 @@ def _run_extract(sldasm):
         _preconvert_meshes(str(state.package_dir))
         progress(f"done -> {state.package_dir} (SolidWorks kept warm for "
                  f"the next extraction)")
-        _prog_finish(result={"package": str(state.package_dir)})
+        _job["running"] = False          # clear BEFORE _prog_finish opens the
+        _prog_finish(result={"package": str(state.package_dir)})   # busy-guard
     except _CancelExtract:
         # the COM sequence was aborted mid-flight, so the warm session may hold
         # a half-open doc -- tear it down so the next extraction starts clean
@@ -1722,12 +1723,14 @@ def _run_extract(sldasm):
         except Exception:
             pass
         _job["log"].append("cancelled.")
+        _job["running"] = False          # clear BEFORE _prog_finish (see above)
         _prog_finish(cancelled=True)
     except Exception as e:
         import traceback
 
         from sw2robot.exporter.swcom import SolidWorksUnavailable
         _job["error"] = f"{type(e).__name__}: {e}"
+        _job["running"] = False          # clear BEFORE _prog_finish (see above)
         _prog_finish(error=f"{type(e).__name__}: {e}")
         print(f"[sw2robot.web] extract FAILED: {e!r}")
         traceback.print_exc()     # full traceback -> the exact failing line
@@ -1743,7 +1746,11 @@ def _run_extract(sldasm):
             _shutdown_sw()         # tear the wedged session down, then forget it
     finally:
         hb_stop.set()
-        _job["running"] = False
+        # NB: _job["running"] is cleared in each branch ABOVE, just before its
+        # _prog_finish opens the shared busy-guard -- not here.  Clearing it in
+        # finally would race: a new extract can claim the guard and set
+        # running=True between a branch's _prog_finish and this line, and this
+        # line would then wrongly clobber the new job's flag back to False.
 
 
 # ---- live self-collision (autoinit.SelfCollision over the current URDF) --

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1462,9 +1462,10 @@ def _prog_extract_stage(msg):
     if m:
         i, n = int(m.group(1)), int(m.group(2))
         name = msg.split(": ", 1)[-1]
-        _prog_stage("export meshes", frac=(i / n) if n else None,
-                    label=f"exporting mesh {i}/{n}")
-        _prog_update(sub=name)
+        # title = stage name (i18n), count + current mesh in the sub -- same
+        # shape as the export/sweep panels
+        _prog_stage("export meshes", frac=(i / n) if n else None)
+        _prog_update(sub=f"{i}/{n}  {name}")
         return
     if msg.startswith("... still"):          # heartbeat: fill sub, keep stage
         _prog_update(sub=msg)

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -22,6 +22,7 @@ sw2robot.exporter already requires.
 """
 import argparse
 import contextlib
+import copy
 import http.server
 import json
 import os
@@ -592,7 +593,8 @@ exec ros2 launch "$PKG" display.launch.py
 def _export_zip(pkg_dir, robot_name, visual_fmt="dae", collision_fmt="stl",
                 ros_version=1, pkg_name=None, urdf_name=None, colors=None,
                 collision="copy", coacd_quality="balanced",
-                merge_fixed=False, mesh_dir=None):
+                merge_fixed=False, mesh_dir=None, progress=None,
+                should_cancel=None):
     """ZIP a portable ROS package (package:// URLs), named ``pkg_name`` if given
     else ``<robot_name>_description``; the URDF inside is named ``urdf_name`` if
     given, else the package name.
@@ -621,18 +623,23 @@ def _export_zip(pkg_dir, robot_name, visual_fmt="dae", collision_fmt="stl",
     )
     pkg = ros_pkg_name(robot_name, pkg_name)
     ctx_fmt = (("visual", visual_fmt), ("collision", collision_fmt))
+    files = build_ros_description(pkg_dir, robot_name,
+                                  ros_version=ros_version,
+                                  pkg_name=pkg,
+                                  urdf_name=urdf_name,
+                                  colors=colors,
+                                  collision=collision,
+                                  coacd_quality=coacd_quality,
+                                  merge_fixed=merge_fixed,
+                                  mesh_dir=mesh_dir,
+                                  ctx_fmt=ctx_fmt,
+                                  progress=progress,
+                                  should_cancel=should_cancel)
     buf = _io.BytesIO()
+    if progress:
+        progress("zip", 0, len(files))
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
-        for arc, data in build_ros_description(pkg_dir, robot_name,
-                                               ros_version=ros_version,
-                                               pkg_name=pkg,
-                                               urdf_name=urdf_name,
-                                               colors=colors,
-                                               collision=collision,
-                                               coacd_quality=coacd_quality,
-                                               merge_fixed=merge_fixed,
-                                               mesh_dir=mesh_dir,
-                                               ctx_fmt=ctx_fmt):
+        for arc, data in files:
             # a node under scripts/ must extract executable (0755) so ament's
             # install(PROGRAMS) + `colcon build --symlink-install` leaves a
             # runnable libexec entry that `ros2 launch` can find
@@ -643,7 +650,110 @@ def _export_zip(pkg_dir, robot_name, visual_fmt="dae", collision_fmt="stl",
                 z.writestr(zi, data)
             else:
                 z.writestr(arc, data)
+    if progress:
+        progress("zip", len(files), len(files))
     return pkg, buf.getvalue()
+
+
+# ---- async ZIP export (observable, one at a time) ---------------------------
+# The sync /api/export/zip blocks the download with no feedback; CoACD-on-export
+# is minutes.  The editor instead starts /api/export/zip/start (a background job
+# reporting into _prog), watches /api/progress, then fetches the finished bytes
+# from /api/export/zip/download.  The sync endpoint stays for the launch_it.sh
+# curl one-liner, which needs a direct URL.
+_EXPORT_STAGES = ["collision", "convert meshes", "package + zip"]
+_export_out = {"data": None, "fname": None}
+_export_lock = threading.Lock()
+# cooperative cancel for the async export (checked between links/meshes; CoACD
+# is not interruptible mid-link, so a cancel lands at the next boundary)
+_export_cancel = threading.Event()
+
+
+def _parse_export_query(cls, query):
+    """Validate the shared /api/export/zip[/start] query params.  Returns
+    ``(kwargs_for__export_zip, None)`` or ``(None, (error_str, code))``."""
+    if not cls.pkg_dir:
+        return None, ("no package open", 400)
+    visual_fmt = (query.get("meshes") or ["dae"])[0]
+    if visual_fmt not in ("dae", "stl", "glb"):
+        return None, (f"unsupported visual mesh format: {visual_fmt}", 400)
+    collision_fmt = (query.get("colfmt") or ["stl"])[0]
+    if collision_fmt not in ("stl", "glb"):
+        return None, (f"unsupported collision mesh format: {collision_fmt}", 400)
+    ros = (query.get("ros") or ["1"])[0]
+    if ros not in ("1", "2"):
+        return None, (f"unsupported ros version: {ros}", 400)
+    from sw2robot.exporter.ros_export import COLLISION_MODES
+    collision = (query.get("collision") or ["copy"])[0]
+    if collision not in COLLISION_MODES:
+        return None, (f"unsupported collision mode: {collision}", 400)
+    cquality = (query.get("cquality") or ["balanced"])[0]
+    if cquality not in ("balanced", "fine"):
+        return None, (f"unsupported collision quality: {cquality}", 400)
+    # the ROS exporter hardcodes the urdf/<robot_name>.urdf + meshes/ layout; in
+    # URDF-input mode the opened file may sit elsewhere, so fail clearly instead
+    # of with a confusing missing-file 500
+    if not _cad_mode(cls.pkg_dir) \
+            and os.path.normpath(os.path.join(cls.pkg_dir, cls.urdf_rel)) \
+            != os.path.normpath(os.path.join(
+                cls.pkg_dir, "urdf", cls.robot_name + ".urdf")):
+        return None, ("export needs the standard <pkg>/urdf/<name>.urdf + "
+                      "<pkg>/meshes/ layout; open the URDF from inside a "
+                      "urdf/ folder", 400)
+    return {
+        "visual_fmt": visual_fmt, "collision_fmt": collision_fmt,
+        "ros_version": int(ros), "collision": collision,
+        "coacd_quality": cquality,
+        "merge_fixed": (query.get("mergefixed") or ["0"])[0] == "1",
+        "pkg_name": (query.get("name") or [""])[0].strip() or None,
+        "urdf_name": (query.get("urdf") or [""])[0].strip() or None,
+        "mesh_dir": (query.get("meshdir") or [""])[0].strip() or None,
+    }, None
+
+
+def _export_fname(robot_name, pkg, params):
+    return (f"{robot_name}_glb.zip"
+            if params["visual_fmt"] == "glb" and params["collision_fmt"] == "glb"
+            else f"{pkg}.zip")
+
+
+def _run_export(pkg_dir, robot_name, urdf_rel, params):
+    """Background ZIP export; stashes the bytes for /api/export/zip/download."""
+    from sw2robot.exporter.ros_export import ExportCancelled
+    _stage_map = {"collision": "collision", "meshes": "convert meshes",
+                  "zip": "package + zip"}
+
+    def _bp(stage, done, total, detail=""):
+        _prog_stage(_stage_map.get(stage, stage),
+                    frac=(done / total) if total else None,
+                    label=(f"{done}/{total}" if total else None))
+        if detail:
+            _prog_update(sub=detail)
+    try:
+        # URDF-input mode keeps the on-disk URDF pristine and serves edits live;
+        # materialize them so the exporter picks them up (no-op in CAD mode)
+        colors = (_read_colors(pkg_dir, urdf_rel) if _cad_mode(pkg_dir)
+                  else _um_colors(_um["state"]))
+        with _um_materialized(pkg_dir, urdf_rel):
+            pkg, data = _export_zip(pkg_dir, robot_name, colors=colors,
+                                    progress=_bp,
+                                    should_cancel=_export_cancel.is_set,
+                                    **params)
+        fname = _export_fname(robot_name, pkg, params)
+        with _export_lock:
+            _export_out.update(data=data, fname=fname)
+        _prog_finish(result={"ready": True, "fname": fname,
+                             "download": "/api/export/zip/download"})
+        print(f"[sw2robot.web] export ready: {fname} ({len(data)} bytes)")
+    except ExportCancelled:
+        _prog_finish(cancelled=True)
+        print("[sw2robot.web] export CANCELLED by user")
+    except ValueError as e:
+        _prog_finish(error=str(e))
+    except Exception as e:
+        import traceback
+        traceback.print_exc()
+        _prog_finish(error=f"{type(e).__name__}: {e}")
 
 
 # --- joint/link rename overlay (joints.yaml link_names / joint_names) --------
@@ -1228,6 +1338,130 @@ _job = {"running": False, "log": [], "error": None, "package": None,
 _job_lock = threading.Lock()
 
 
+# ---- unified progress: ONE live view for the heavy jobs ---------------------
+# Extract, ZIP export, CoACD/primitive preview and the joint-limit sweep all
+# report into this single object, polled at /api/progress, so the UI shows one
+# bar + a per-stage checklist + a log tail instead of three ad-hoc status feeds
+# (issue #21).  The jobs are already one-at-a-time; _prog_start is the single
+# global busy-guard (it also stops, say, an export starting mid-extract).
+# The per-job dicts (_job / _coll_preview_job / _limjob) stay as the source of
+# truth for job-specific mechanics (cancel flags, the CoACD parts map, the
+# sweep pump); _prog is purely the client-facing reporting surface, and job
+# results the client needs travel in _prog["result"].
+_prog = {"job": None, "running": False, "done": True, "cancelled": False,
+         "error": None,
+         "stages": [],      # [{"name": str, "state": "pending|active|done"}]
+         "frac": None,      # 0..1 for a determinate bar, None = indeterminate
+         "label": "", "sub": "",
+         "log": [],         # full list; the client tails the last few
+         "result": None}    # job-specific payload (package / results / parts)
+_prog_lock = threading.Lock()
+_PROG_LOG_CAP = 200
+
+
+def _prog_start(job, stages, label=""):
+    """Claim the shared progress object for ``job`` with a fresh ordered stage
+    list (list of stage names).  Returns False if a job is already running."""
+    with _prog_lock:
+        if _prog["running"]:
+            return False
+        _prog.update(
+            job=job, running=True, done=False, cancelled=False, error=None,
+            stages=[{"name": s, "state": "pending"} for s in stages],
+            frac=None, label=label, sub="", log=[], result=None)
+        return True
+
+
+def _prog_stage(name, frac=None, label=None):
+    """Advance to the named stage: every earlier stage -> done, this -> active,
+    later ones stay pending.  Monotonic -- a stage before the current one never
+    regresses the checklist (extract messages can arrive slightly out of order).
+    ``frac`` sets the bar (None = indeterminate)."""
+    with _prog_lock:
+        names = [s["name"] for s in _prog["stages"]]
+        if name in names:
+            idx = names.index(name)
+            cur = next((i for i, s in enumerate(_prog["stages"])
+                        if s["state"] == "active"),
+                       sum(1 for s in _prog["stages"] if s["state"] == "done"))
+            if idx > cur:                     # advancing: clear the old detail
+                _prog["sub"] = ""
+            if idx >= cur:                    # never move the checklist backwards
+                for i, s in enumerate(_prog["stages"]):
+                    s["state"] = ("done" if i < idx
+                                  else "active" if i == idx else "pending")
+        _prog["label"] = label if label is not None else name
+        _prog["frac"] = frac
+
+
+def _prog_update(frac=None, label=None, sub=None, result=None):
+    with _prog_lock:
+        if frac is not None:
+            _prog["frac"] = frac
+        if label is not None:
+            _prog["label"] = label
+        if sub is not None:
+            _prog["sub"] = sub
+        if result is not None:
+            _prog["result"] = result
+
+
+def _prog_log(line):
+    with _prog_lock:
+        _prog["log"].append(str(line))
+        del _prog["log"][:-_PROG_LOG_CAP]
+
+
+def _prog_finish(error=None, result=None, cancelled=False):
+    with _prog_lock:
+        if error is None and not cancelled:
+            for s in _prog["stages"]:
+                s["state"] = "done"
+            _prog["frac"] = 1.0
+        if result is not None:
+            _prog["result"] = result
+        _prog.update(running=False, done=True, error=error,
+                     cancelled=cancelled)
+
+
+def _prog_snapshot():
+    with _prog_lock:
+        return copy.deepcopy(_prog)
+
+
+# The extract pipeline reports free-text strings through one progress callback
+# (core/export were built before the stage model).  Rather than restructure the
+# exporter, classify those strings into stages HERE -- the server owns the
+# stage/frac mapping, so the client just renders it (no more log-regex parsing).
+_EXTRACT_STAGES = ["connect SolidWorks", "extract assembly",
+                   "export meshes", "build package"]
+_EXTRACT_MESH_RE = re.compile(r"exporting mesh (\d+)/(\d+)")
+
+
+def _prog_extract_stage(msg):
+    m = _EXTRACT_MESH_RE.search(msg)
+    if m:
+        i, n = int(m.group(1)), int(m.group(2))
+        name = msg.split(": ", 1)[-1]
+        _prog_stage("export meshes", frac=(i / n) if n else None,
+                    label=f"exporting mesh {i}/{n}")
+        _prog_update(sub=name)
+        return
+    if msg.startswith("... still"):          # heartbeat: fill sub, keep stage
+        _prog_update(sub=msg)
+        return
+    low = msg.lower()
+    if "throwaway copy" in low or "solidworks" in low:
+        _prog_stage("connect SolidWorks")
+    elif low.startswith("reading ") or "sub-assembly" in low \
+            or "limit mate" in low:
+        _prog_stage("extract assembly")
+    elif low.startswith("exporting "):
+        _prog_stage("export meshes")
+    elif "building urdf" in low or "reusing your joint config" in low:
+        _prog_stage("build package")
+
+
 class _CancelExtract(Exception):
     """Raised from the progress callback to abort the extract cooperatively
     when the user asked to cancel (via /api/extract/cancel)."""
@@ -1378,7 +1612,10 @@ def _run_extract(sldasm):
         # (per phase, per mesh), so raising here aborts at the next checkpoint
         if _job.get("cancel"):
             raise _CancelExtract()
-        _job["log"].append(str(msg))
+        msg = str(msg)
+        _job["log"].append(msg)          # heartbeat + legacy /status still read this
+        _prog_log(msg)
+        _prog_extract_stage(msg)         # classify -> unified stage/frac
         print(f"[sw2robot.web] extract: {msg}")
 
     # COM calls (launch, first contact with an idle session, OpenDoc6
@@ -1408,10 +1645,13 @@ def _run_extract(sldasm):
             except Exception:
                 detail = "process count unavailable"
             phase = (real() or ["starting"])[-1]
-            _job["log"].append(f"... still waiting "
-                               f"({int(time.time() - last_t)}s in this "
-                               f"phase, {int(time.time() - t0)}s total, "
-                               f"{detail}) -- phase: {phase[:70]}")
+            line = (f"... still waiting "
+                    f"({int(time.time() - last_t)}s in this "
+                    f"phase, {int(time.time() - t0)}s total, "
+                    f"{detail}) -- phase: {phase[:70]}")
+            _job["log"].append(line)
+            _prog_log(line)
+            _prog_update(sub=line)
 
     threading.Thread(target=heartbeat, daemon=True).start()
     try:
@@ -1449,22 +1689,26 @@ def _run_extract(sldasm):
         _preconvert_meshes(str(state.package_dir))
         progress(f"done -> {state.package_dir} (SolidWorks kept warm for "
                  f"the next extraction)")
+        _prog_finish(result={"package": str(state.package_dir)})
     except _CancelExtract:
         # the COM sequence was aborted mid-flight, so the warm session may hold
         # a half-open doc -- tear it down so the next extraction starts clean
         _job["cancelled"] = True
         _job["log"].append("cancelled by user; resetting SolidWorks session ...")
+        _prog_log("cancelled by user; resetting SolidWorks session ...")
         print("[sw2robot.web] extract CANCELLED by user")
         try:
             _shutdown_sw()
         except Exception:
             pass
         _job["log"].append("cancelled.")
+        _prog_finish(cancelled=True)
     except Exception as e:
         import traceback
 
         from sw2robot.exporter.swcom import SolidWorksUnavailable
         _job["error"] = f"{type(e).__name__}: {e}"
+        _prog_finish(error=f"{type(e).__name__}: {e}")
         print(f"[sw2robot.web] extract FAILED: {e!r}")
         traceback.print_exc()     # full traceback -> the exact failing line
         # Drop the cached session on anything that smells like a lost/failed
@@ -1565,6 +1809,7 @@ def _run_coll_preview_job(pkg_dir, robot_name, urdf_rel, quality, mode="coacd"):
             if link not in _coll_preview_job["inflight"]:
                 _coll_preview_job["inflight"].append(link)
             _coll_preview_job["current"] = link
+        _prog_update(sub=link)
 
     def _progress(done, total, link, rel):    # a link finished
         with _coll_preview_lock:
@@ -1574,6 +1819,13 @@ def _run_coll_preview_job(pkg_dir, robot_name, urdf_rel, quality, mode="coacd"):
                 _coll_preview_job["inflight"].remove(link)
             if rel:
                 _coll_preview_job["parts"][link] = "/pkg/" + rel
+            parts = dict(_coll_preview_job["parts"])
+        # unified progress: one stage, frac per link; the client reads
+        # result.parts each poll and pops each mesh into the viewer as it lands
+        _prog_stage("build collision preview",
+                    frac=(done / total) if total else None,
+                    label=(f"{done}/{total} links" if total else None))
+        _prog_update(result={"parts": parts, "mode": mode})
 
     def _should_cancel():
         with _coll_preview_lock:
@@ -1589,16 +1841,19 @@ def _run_coll_preview_job(pkg_dir, robot_name, urdf_rel, quality, mode="coacd"):
             stopped = _coll_preview_job["cancel"]
             _coll_preview_job.update(running=False, current=None, inflight=[],
                               cancelled=stopped)
+            parts = dict(_coll_preview_job["parts"])
         # the live self-collision model can now use these convex parts -- drop
         # the current one so the next /api/collision/init rebuilds with them
         with _coll_lock:
             _coll.update(key=None, ctx=None)
+        _prog_finish(result={"parts": parts, "mode": mode}, cancelled=stopped)
         print(f"[sw2robot.web] collision preview "
               f"{'cancelled' if stopped else 'ready'}: "
-              f"{len(_coll_preview_job['parts'])} links")
+              f"{len(parts)} links")
     except Exception as e:
         with _coll_preview_lock:
             _coll_preview_job.update(running=False, error=repr(e))
+        _prog_finish(error=repr(e))
         print(f"[sw2robot.web] collision preview FAILED: {e!r}")
 
 
@@ -1665,6 +1920,7 @@ def _run_auto_limits(pkg_dir, urdf_rel, step_deg, max_deg,
                 with _limjob_lock:        # non-JSON (skrobot warnings): keep a tail
                     _limjob["log"].append(line)
                     del _limjob["log"][:-50]
+                _prog_log(line)
                 continue
             with _limjob_lock:
                 kind = ev.get("event")
@@ -1677,6 +1933,17 @@ def _run_auto_limits(pkg_dir, urdf_rel, step_deg, max_deg,
                     _limjob.update(n=ev.get("i", 0),
                                    total=ev.get("total", _limjob["total"]),
                                    joint=ev.get("joint"))
+            # mirror into the unified progress view
+            if kind == "loading":
+                _prog_stage("load model")
+            elif kind == "start":
+                _prog_stage("sweep joints", frac=0.0)
+            elif kind == "joint":
+                i, tot = ev.get("i", 0), ev.get("total", 0)
+                _prog_stage("sweep joints",
+                            frac=(i / tot) if tot else None,
+                            label=(f"{i}/{tot} joints" if tot else None))
+                _prog_update(sub=ev.get("joint") or "")
 
     pump = threading.Thread(target=_pump, daemon=True)
     pump.start()
@@ -2034,6 +2301,11 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                     _limjob.update(running=True, log=[], error=None,
                                    results=None, n=0, total=0, joint=None,
                                    phase="loading")
+                if not _prog_start("limits", ["load model", "sweep joints"]):
+                    with _limjob_lock:
+                        _limjob.update(running=False)
+                    return self._send_json(
+                        {"error": "a job is already running"}, 409)
 
                 # NB: must NOT be named `_job` -- that shadows the module-global
                 # `_job` (the extraction job) across this whole method and breaks
@@ -2047,6 +2319,7 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                     with _limjob_lock:
                         _limjob.update(results=results, error=err,
                                        running=False)
+                    _prog_finish(error=err, result={"results": results})
 
                 threading.Thread(target=_sweep_job, daemon=True).start()
                 return self._send_json({"started": True})
@@ -2066,16 +2339,18 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                         and target.lower().endswith(".sldasm")):
                     return self._send_json(
                         {"error": f"not a .sldasm file: {target}"}, 400)
+                if not _prog_start("extract", _EXTRACT_STAGES):
+                    return self._send_json(
+                        {"error": "a job is already running"}, 409)
                 with _job_lock:
-                    if _job["running"]:
-                        return self._send_json(
-                            {"error": "an extraction is already running"},
-                            409)
                     _job.update(running=True, log=[], error=None,
                                 package=None, cancel=False, cancelled=False)
                 threading.Thread(target=_run_extract, args=(target,),
                                  daemon=True).start()
                 return self._send_json({"started": True})
+            if path == "/api/progress":
+                # unified live view for extract / export / collision / limits
+                return self._send_json(_prog_snapshot())
             if path == "/api/extract/status":
                 return self._send_json(_job)
             if path == "/api/extract/cancel":
@@ -2105,71 +2380,23 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 _preconvert_meshes(pkg)
                 return self._send_json(self._info())
             if path == "/api/export/zip":
+                # SYNCHRONOUS export: kept for the launch_it.sh curl one-liner
+                # (which needs a direct URL).  The editor uses the async
+                # /start + /download pair below so the build shows progress.
                 cls = type(self)
-                if not cls.pkg_dir:
-                    return self._send_json({"error": "no package open"}, 400)
-                visual_fmt = (query.get("meshes") or ["dae"])[0]
-                if visual_fmt not in ("dae", "stl", "glb"):
-                    return self._send_json(
-                        {"error": f"unsupported visual mesh format: {visual_fmt}"},
-                        400)
-                collision_fmt = (query.get("colfmt") or ["stl"])[0]
-                if collision_fmt not in ("stl", "glb"):
-                    return self._send_json(
-                        {"error": f"unsupported collision mesh format: "
-                         f"{collision_fmt}"}, 400)
-                ros = (query.get("ros") or ["1"])[0]
-                if ros not in ("1", "2"):
-                    return self._send_json(
-                        {"error": f"unsupported ros version: {ros}"}, 400)
-                ros_version = int(ros)
-                from sw2robot.exporter.ros_export import COLLISION_MODES
-                collision = (query.get("collision") or ["copy"])[0]
-                if collision not in COLLISION_MODES:
-                    return self._send_json(
-                        {"error": f"unsupported collision mode: {collision}"}, 400)
-                cquality = (query.get("cquality") or ["balanced"])[0]
-                if cquality not in ("balanced", "fine"):
-                    return self._send_json(
-                        {"error": f"unsupported collision quality: {cquality}"},
-                        400)
-                merge_fixed = (query.get("mergefixed") or ["0"])[0] == "1"
-                pkg_name = (query.get("name") or [""])[0].strip() or None
-                urdf_name = (query.get("urdf") or [""])[0].strip() or None
-                mesh_dir = (query.get("meshdir") or [""])[0].strip() or None
-                # the ROS exporter hardcodes the urdf/<robot_name>.urdf + meshes/
-                # layout; in URDF-input mode the opened file may sit elsewhere, so
-                # fail clearly instead of with a confusing missing-file 500
-                if not _cad_mode(cls.pkg_dir) \
-                        and os.path.normpath(os.path.join(cls.pkg_dir, cls.urdf_rel)) \
-                        != os.path.normpath(os.path.join(
-                            cls.pkg_dir, "urdf", cls.robot_name + ".urdf")):
-                    return self._send_json(
-                        {"error": "export needs the standard "
-                         "<pkg>/urdf/<name>.urdf + <pkg>/meshes/ layout; open the "
-                         "URDF from inside a urdf/ folder"}, 400)
+                params, err = _parse_export_query(cls, query)
+                if err:
+                    return self._send_json({"error": err[0]}, err[1])
                 try:
-                    # URDF-input mode keeps the on-disk URDF pristine and serves
-                    # edits live; materialize them so the exporter picks them up
                     colors = (_read_colors(cls.pkg_dir, cls.urdf_rel)
                               if _cad_mode(cls.pkg_dir)
                               else _um_colors(_um["state"]))
                     with _um_materialized(cls.pkg_dir, cls.urdf_rel):
-                        pkg, data = _export_zip(cls.pkg_dir, cls.robot_name, visual_fmt,
-                                                collision_fmt,
-                                                ros_version=ros_version,
-                                                pkg_name=pkg_name,
-                                                urdf_name=urdf_name,
-                                                colors=colors,
-                                                collision=collision,
-                                                coacd_quality=cquality,
-                                                merge_fixed=merge_fixed,
-                                                mesh_dir=mesh_dir)
+                        pkg, data = _export_zip(cls.pkg_dir, cls.robot_name,
+                                                colors=colors, **params)
                 except ValueError as e:
                     return self._send_json({"error": str(e)}, 400)
-                fname = (f"{cls.robot_name}_glb.zip"
-                         if visual_fmt == "glb" and collision_fmt == "glb"
-                         else f"{pkg}.zip")
+                fname = _export_fname(cls.robot_name, pkg, params)
                 self.send_response(200)
                 self.send_header("Content-Type", "application/zip")
                 self.send_header("Content-Disposition",
@@ -2177,6 +2404,48 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 self.send_header("Content-Length", str(len(data)))
                 self.end_headers()
                 self.wfile.write(data)
+                return None
+            if path == "/api/export/zip/start":
+                # ASYNC export: build in a background thread reporting into _prog;
+                # the client watches /api/progress then GETs /download.
+                cls = type(self)
+                params, err = _parse_export_query(cls, query)
+                if err:
+                    return self._send_json({"error": err[0]}, err[1])
+                if not _prog_start("export", _EXPORT_STAGES):
+                    return self._send_json(
+                        {"error": "a job is already running"}, 409)
+                _export_cancel.clear()
+                with _export_lock:
+                    _export_out.update(data=None, fname=None)
+                threading.Thread(
+                    target=_run_export,
+                    args=(cls.pkg_dir, cls.robot_name, cls.urdf_rel, params),
+                    daemon=True).start()
+                return self._send_json({"started": True})
+            if path == "/api/export/zip/cancel":
+                # cooperative: _run_export checks _export_cancel between
+                # links/meshes and finishes as cancelled at the next boundary
+                snap = _prog_snapshot()
+                running = snap["job"] == "export" and snap["running"]
+                if running:
+                    _export_cancel.set()
+                return self._send_json({"cancelling": running})
+            if path == "/api/export/zip/download":
+                with _export_lock:
+                    data, fname = _export_out["data"], _export_out["fname"]
+                if data is None:
+                    return self._send_json(
+                        {"error": "no finished export to download"}, 404)
+                self.send_response(200)
+                self.send_header("Content-Type", "application/zip")
+                self.send_header("Content-Disposition",
+                                 f'attachment; filename="{fname}"')
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+                with _export_lock:               # single-shot: free the bytes
+                    _export_out.update(data=None, fname=None)
                 return None
             if path == "/api/launch_it.sh":
                 # one-liner build+launch (robot-compiler style):
@@ -2231,6 +2500,9 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 with _coll_preview_lock:
                     if _coll_preview_job["running"]:
                         return self._send_json({"error": "already running"}, 409)
+                if not _prog_start("collision", ["build collision preview"]):
+                    return self._send_json(
+                        {"error": "a job is already running"}, 409)
                 _reset_coll_preview_job()
                 with _coll_preview_lock:
                     _coll_preview_job.update(running=True, quality=quality, mode=mode)

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1883,8 +1883,11 @@ def _run_coll_preview_job(pkg_dir, robot_name, urdf_rel, quality, mode="coacd"):
 # collision lock while it sweeps (it mutates joint angles), so the live drag
 # check pauses for its duration.
 _limjob = {"running": False, "log": [], "error": None, "results": None,
-           "n": 0, "total": 0, "joint": None, "phase": None}
+           "n": 0, "total": 0, "joint": None, "phase": None, "proc": None}
 _limjob_lock = threading.Lock()
+# set by /api/auto_limits/cancel; the sweep runs in a subprocess, so cancelling
+# just kills it (no partial result -- the user is aborting)
+_limjob_cancel = threading.Event()
 
 
 def _run_auto_limits(pkg_dir, urdf_rel, step_deg, max_deg,
@@ -1922,6 +1925,8 @@ def _run_auto_limits(pkg_dir, urdf_rel, step_deg, max_deg,
     _t0 = time.time()
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE, text=True, cwd=cwd)
+    with _limjob_lock:
+        _limjob["proc"] = proc          # so /api/auto_limits/cancel can kill it
 
     # Drain stderr LIVE in a thread: the CLI emits per-joint progress there as
     # JSON lines (stdout carries only the final results JSON).  Reading it as it
@@ -1956,13 +1961,12 @@ def _run_auto_limits(pkg_dir, urdf_rel, step_deg, max_deg,
             if kind == "loading":
                 _prog_stage("load model")
             elif kind == "start":
-                _prog_stage("sweep joints", frac=0.0)
+                _prog_stage("sweep joints")     # animated until the 1st joint
             elif kind == "joint":
                 i, tot = ev.get("i", 0), ev.get("total", 0)
-                _prog_stage("sweep joints",
-                            frac=(i / tot) if tot else None,
-                            label=(f"{i}/{tot} joints" if tot else None))
-                _prog_update(sub=ev.get("joint") or "")
+                # title = stage name (i18n), count + current joint in the sub
+                _prog_stage("sweep joints", frac=(i / tot) if tot else None)
+                _prog_update(sub=f"{i}/{tot}  {ev.get('joint') or ''}".strip())
 
     pump = threading.Thread(target=_pump, daemon=True)
     pump.start()
@@ -1985,6 +1989,10 @@ def _run_auto_limits(pkg_dir, urdf_rel, step_deg, max_deg,
         timer.cancel()
         proc.wait()
         pump.join(timeout=2)
+        with _limjob_lock:
+            _limjob["proc"] = None
+    if _limjob_cancel.is_set():         # killed by /api/auto_limits/cancel
+        return None, "__cancelled__"
     if timed_out["v"]:
         return None, "sweep timed out"
     if proc.returncode != 0:
@@ -2319,12 +2327,13 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                             {"error": "a limit sweep is already running"}, 409)
                     _limjob.update(running=True, log=[], error=None,
                                    results=None, n=0, total=0, joint=None,
-                                   phase="loading")
+                                   phase="loading", proc=None)
                 if not _prog_start("limits", ["load model", "sweep joints"]):
                     with _limjob_lock:
                         _limjob.update(running=False)
                     return self._send_json(
                         {"error": "a job is already running"}, 409)
+                _limjob_cancel.clear()
 
                 # NB: must NOT be named `_job` -- that shadows the module-global
                 # `_job` (the extraction job) across this whole method and breaks
@@ -2335,13 +2344,29 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                             pkg, rel, step, mx, margin_deg, margin_mm)
                     except Exception as e:           # never leave it "running"
                         results, err = None, f"{type(e).__name__}: {e}"
+                    cancelled = err == "__cancelled__"
                     with _limjob_lock:
-                        _limjob.update(results=results, error=err,
+                        _limjob.update(results=results,
+                                       error=None if cancelled else err,
                                        running=False)
-                    _prog_finish(error=err, result={"results": results})
+                    _prog_finish(error=None if cancelled else err,
+                                 cancelled=cancelled,
+                                 result={"results": results})
 
                 threading.Thread(target=_sweep_job, daemon=True).start()
                 return self._send_json({"started": True})
+            if path == "/api/auto_limits/cancel":
+                # kill the sweep subprocess (no partial result -- user aborts)
+                with _limjob_lock:
+                    running, proc = _limjob["running"], _limjob["proc"]
+                if running:
+                    _limjob_cancel.set()
+                    if proc is not None:
+                        try:
+                            proc.kill()
+                        except Exception:
+                            pass
+                return self._send_json({"cancelling": running})
             if path == "/api/auto_limits/status":
                 with _limjob_lock:
                     return self._send_json(

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -2361,7 +2361,16 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                                  cancelled=cancelled,
                                  result={"results": results})
 
-                threading.Thread(target=_sweep_job, daemon=True).start()
+                try:
+                    threading.Thread(target=_sweep_job, daemon=True).start()
+                except Exception as e:
+                    # release the guard the never-started worker can't (see the
+                    # export /start handler for why)
+                    with _limjob_lock:
+                        _limjob.update(running=False)
+                    _prog_finish(error=f"{type(e).__name__}: {e}")
+                    return self._send_json(
+                        {"error": f"failed to start sweep: {e}"}, 500)
                 return self._send_json({"started": True})
             if path == "/api/auto_limits/cancel":
                 # kill the sweep subprocess (no partial result -- user aborts)
@@ -2397,8 +2406,17 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 with _job_lock:
                     _job.update(running=True, log=[], error=None,
                                 package=None, cancel=False, cancelled=False)
-                threading.Thread(target=_run_extract, args=(target,),
-                                 daemon=True).start()
+                try:
+                    threading.Thread(target=_run_extract, args=(target,),
+                                     daemon=True).start()
+                except Exception as e:
+                    # release the guard the never-started worker can't (see the
+                    # export /start handler for why)
+                    with _job_lock:
+                        _job.update(running=False)
+                    _prog_finish(error=f"{type(e).__name__}: {e}")
+                    return self._send_json(
+                        {"error": f"failed to start extract: {e}"}, 500)
                 return self._send_json({"started": True})
             if path == "/api/progress":
                 # unified live view for extract / export / collision / limits
@@ -2476,10 +2494,19 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 _export_cancel.clear()
                 with _export_lock:
                     _export_out.update(data=None, fname=None)
-                threading.Thread(
-                    target=_run_export,
-                    args=(cls.pkg_dir, cls.robot_name, cls.urdf_rel, params, gen),
-                    daemon=True).start()
+                try:
+                    threading.Thread(
+                        target=_run_export,
+                        args=(cls.pkg_dir, cls.robot_name, cls.urdf_rel,
+                              params, gen),
+                        daemon=True).start()
+                except Exception as e:
+                    # the worker never ran, so it can't release the guard --
+                    # do it here, else _prog stays "running" and wedges every
+                    # later job with no way back short of a restart
+                    _prog_finish(error=f"{type(e).__name__}: {e}")
+                    return self._send_json(
+                        {"error": f"failed to start export: {e}"}, 500)
                 return self._send_json({"started": True})
             if path == "/api/export/zip/cancel":
                 # cooperative: _run_export checks _export_cancel between
@@ -2564,11 +2591,20 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 _reset_coll_preview_job()
                 with _coll_preview_lock:
                     _coll_preview_job.update(running=True, quality=quality, mode=mode)
-                threading.Thread(
-                    target=_run_coll_preview_job,
-                    args=(cls.pkg_dir, cls.robot_name, cls.urdf_rel, quality,
-                          mode),
-                    daemon=True).start()
+                try:
+                    threading.Thread(
+                        target=_run_coll_preview_job,
+                        args=(cls.pkg_dir, cls.robot_name, cls.urdf_rel, quality,
+                              mode),
+                        daemon=True).start()
+                except Exception as e:
+                    # release the guard the never-started worker can't (see the
+                    # export /start handler for why)
+                    with _coll_preview_lock:
+                        _coll_preview_job.update(running=False)
+                    _prog_finish(error=f"{type(e).__name__}: {e}")
+                    return self._send_json(
+                        {"error": f"failed to start collision preview: {e}"}, 500)
                 return self._send_json(
                     {"running": True, "quality": quality, "mode": mode})
             if path == "/api/collision/preview/cancel":

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -636,10 +636,11 @@ def _export_zip(pkg_dir, robot_name, visual_fmt="dae", collision_fmt="stl",
                                   progress=progress,
                                   should_cancel=should_cancel)
     buf = _io.BytesIO()
+    n = len(files)
     if progress:
-        progress("zip", 0, len(files))
+        progress("zip", 0, n)
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
-        for arc, data in files:
+        for i, (arc, data) in enumerate(files):
             # a node under scripts/ must extract executable (0755) so ament's
             # install(PROGRAMS) + `colcon build --symlink-install` leaves a
             # runnable libexec entry that `ros2 launch` can find
@@ -650,8 +651,10 @@ def _export_zip(pkg_dir, robot_name, visual_fmt="dae", collision_fmt="stl",
                 z.writestr(zi, data)
             else:
                 z.writestr(arc, data)
-    if progress:
-        progress("zip", len(files), len(files))
+            # DEFLATE on hundreds of mesh files takes seconds -- report per file
+            # so the "package + zip" counter moves instead of sitting at 0/N
+            if progress:
+                progress("zip", i + 1, n)
     return pkg, buf.getvalue()
 
 
@@ -724,11 +727,12 @@ def _run_export(pkg_dir, robot_name, urdf_rel, params):
                   "zip": "package + zip"}
 
     def _bp(stage, done, total, detail=""):
-        _prog_stage(_stage_map.get(stage, stage),
-                    frac=(done / total) if total else None,
-                    label=(f"{done}/{total}" if total else None))
-        if detail:
-            _prog_update(sub=detail)
+        # title = the (i18n) stage name (renderProgress maps it), count in the
+        # sub line; keep the bar animated (indeterminate) until the first item
+        # of a stage completes, so a slow first CoACD part never looks frozen
+        name = _stage_map.get(stage, stage)
+        _prog_stage(name, frac=((done / total) if (total and done) else None))
+        _prog_update(sub=(f"{done}/{total}" if total else (detail or "")))
     try:
         # URDF-input mode keeps the on-disk URDF pristine and serves edits live;
         # materialize them so the exporter picks them up (no-op in CAD mode)

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -2428,6 +2428,11 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 # SYNCHRONOUS export: kept for the launch_it.sh curl one-liner
                 # (which needs a direct URL).  The editor uses the async
                 # /start + /download pair below so the build shows progress.
+                # NB: deliberately OUTSIDE the shared _prog busy-guard -- the
+                # one-liner is fire-and-forget and expects the zip bytes back, so
+                # it can't act on a 409.  It therefore runs even while an editor
+                # job holds _prog (both may then warm CoACD / the disk cache at
+                # once; the cache uses atomic writes, so that is safe if slower).
                 cls = type(self)
                 params, err = _parse_export_query(cls, query)
                 if err:

--- a/sw2robot/exporter/ros_export.py
+++ b/sw2robot/exporter/ros_export.py
@@ -209,6 +209,34 @@ def _parallel(func, items, max_workers=None):
         return list(ex.map(func, items))
 
 
+def _parallel_cancellable(func, items, should_cancel, max_workers=None):
+    """Like :func:`_parallel`, but returns promptly (raising :class:`ExportCancelled`)
+    once ``should_cancel`` turns true -- WITHOUT waiting for the tasks already
+    running, which finish in the background (a CoACD part can't be interrupted
+    mid-run; its result is just cached).  Not-yet-started tasks are cancelled.
+    This lets a cancel land within ~0.2 s instead of after the whole parallel
+    wave.  ``func`` must not raise (catch + sentinel, like _parallel)."""
+    items = list(items)
+    if not items:
+        return
+    if should_cancel is None:
+        _parallel(func, items, max_workers)
+        return
+    from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
+    ex = ThreadPoolExecutor(max_workers=_pool_workers(len(items), max_workers))
+    futs = [ex.submit(func, x) for x in items]
+    try:
+        pending = set(futs)
+        while pending:
+            if should_cancel():
+                raise ExportCancelled()
+            _done, pending = wait(pending, timeout=0.2,
+                                  return_when=FIRST_COMPLETED)
+    finally:
+        # never block on the in-flight tasks; drop the pending (unstarted) ones
+        ex.shutdown(wait=False, cancel_futures=True)
+
+
 def _atomic_write(path, data):
     """Write ``data`` (bytes) to ``path`` via a unique temp + ``os.replace`` so a
     concurrent writer (another export hitting the same cache key) can't see a
@@ -1370,7 +1398,7 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
             except Exception:
                 pass                        # the real error resurfaces in _emit_collision
             _warm_tick(src, len(_coacd_srcs))
-        _parallel(_warm_coacd, _coacd_srcs)
+        _parallel_cancellable(_warm_coacd, _coacd_srcs, should_cancel)
     elif collision in _PRIMITIVE_MODES:
         # primitive fitting voxelises the mesh (auto mode scores several
         # candidates by IoU) -- a few hundred ms per unique source; warm them in
@@ -1390,7 +1418,7 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
                 except Exception:
                     pass                # the real error resurfaces in expansion
             _warm_tick(src, len(_prim_srcs))
-        _parallel(_warm_prim, _prim_srcs)
+        _parallel_cancellable(_warm_prim, _prim_srcs, should_cancel)
 
     def _verbatim(job):
         # already the target format, no colour override, no bake: the source is

--- a/sw2robot/exporter/ros_export.py
+++ b/sw2robot/exporter/ros_export.py
@@ -196,44 +196,31 @@ def _pool_workers(n_items, max_workers=None):
     return max(1, min(cap, n_items))
 
 
-def _parallel(func, items, max_workers=None):
-    """``[func(x) for x in items]`` but concurrent (thread pool) -- only for
-    GIL-releasing work (CoACD).  Order is preserved.  ``func`` MUST NOT raise
-    (catch + return a sentinel) -- a raised exception aborts the batch."""
-    items = list(items)
-    if len(items) <= 1:
-        return [func(x) for x in items]
-    from concurrent.futures import ThreadPoolExecutor
-    with ThreadPoolExecutor(max_workers=_pool_workers(len(items),
-                                                      max_workers)) as ex:
-        return list(ex.map(func, items))
+def _parallel_cancellable(func, items, should_cancel=None, max_workers=None):
+    """Concurrent fan-out (thread pool) for GIL-releasing work (CoACD /
+    primitive fitting).  ``func`` MUST NOT raise (catch + return a sentinel);
+    results are not collected.
 
-
-def _parallel_cancellable(func, items, should_cancel, max_workers=None):
-    """Like :func:`_parallel`, but returns promptly (raising :class:`ExportCancelled`)
-    once ``should_cancel`` turns true -- WITHOUT waiting for the tasks already
-    running, which finish in the background (a CoACD part can't be interrupted
-    mid-run; its result is just cached).  Not-yet-started tasks are cancelled.
-    This lets a cancel land within ~0.2 s instead of after the whole parallel
-    wave.  ``func`` must not raise (catch + sentinel, like _parallel)."""
+    Without ``should_cancel`` it simply runs every item and returns.  With one,
+    it returns promptly -- raising :class:`ExportCancelled` within ~0.2 s once
+    ``should_cancel`` turns true -- WITHOUT waiting for the tasks already
+    running (they finish in the background, since a CoACD part can't be
+    interrupted mid-run; its result is just cached), and drops the not-yet-
+    started ones."""
     items = list(items)
     if not items:
         return
-    if should_cancel is None:
-        _parallel(func, items, max_workers)
-        return
     from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
     ex = ThreadPoolExecutor(max_workers=_pool_workers(len(items), max_workers))
-    futs = [ex.submit(func, x) for x in items]
+    pending = {ex.submit(func, x) for x in items}
     try:
-        pending = set(futs)
         while pending:
-            if should_cancel():
+            if should_cancel and should_cancel():
                 raise ExportCancelled()
             _done, pending = wait(pending, timeout=0.2,
                                   return_when=FIRST_COMPLETED)
     finally:
-        # never block on the in-flight tasks; drop the pending (unstarted) ones
+        # don't block on in-flight tasks when cancelling; drop unstarted ones
         ex.shutdown(wait=False, cancel_futures=True)
 
 

--- a/sw2robot/exporter/ros_export.py
+++ b/sw2robot/exporter/ros_export.py
@@ -1058,12 +1058,18 @@ def _iter_sources(root, pkg_dir, own_pkgs, contexts):
                         yield src
 
 
+class ExportCancelled(Exception):
+    """Raised out of :func:`build_ros_description` when ``should_cancel`` turns
+    true, so a caller (the editor's async export) can report a clean cancel
+    rather than a half-built package."""
+
+
 def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
                           ctx_fmt=_CTX_FMT, ros_version=1, pkg_name=None,
                           urdf_name=None, colors=None, collision="copy",
                           coacd_quality="balanced", merge_fixed=False,
                           mesh_dir=None, loop_closures=None,
-                          zero_origins=True):
+                          zero_origins=True, progress=None, should_cancel=None):
     """``pkg_dir`` (a built package) -> ``[(arcname, bytes), ...]`` for a portable
     ROS package, all behind ``package://`` URLs.  The package is named
     ``pkg_name`` if given (validated, see :func:`ros_pkg_name`), else
@@ -1115,7 +1121,17 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
 
     Reads the on-disk ``urdf/<robot_name>.urdf`` (which already carries the
     editor's applied edits).  A missing/unconvertible mesh aborts the export
-    before any entries are emitted, so a half-rewritten package never ships."""
+    before any entries are emitted, so a half-rewritten package never ships.
+
+    ``progress`` -- if given -- is called ``progress(stage, done, total, detail)``
+    as work advances, with ``stage`` one of ``"collision"`` (per unique
+    CoACD/primitive source warmed) or ``"meshes"`` (per unique mesh converted),
+    so a UI can show a live per-stage bar.
+
+    ``should_cancel`` -- if given -- is a zero-arg predicate checked between
+    links/meshes; once it returns true the build raises :class:`ExportCancelled`
+    (CoACD is not interruptible mid-link, so a cancel lands at the next
+    boundary)."""
     if ros_version not in (1, 2):
         raise ValueError(f"unsupported ros_version: {ros_version}")
     if collision not in COLLISION_MODES:
@@ -1164,6 +1180,8 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
     # findall()/iter() traversals below ignore them.
     _parser = ET.XMLParser(target=ET.TreeBuilder(insert_comments=True))
     root = ET.parse(urdf_path, parser=_parser).getroot()
+    if should_cancel and should_cancel():     # cancelled before any heavy work
+        raise ExportCancelled()
     # Mass-only links (weight kept, geometry dropped) are folded into their fixed
     # parent on every export, independent of merge_fixed; build() persisted their
     # (final) names beside the package so this detached step knows them.
@@ -1191,6 +1209,21 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
     files = []
     used_names = set()
     errors = []
+
+    def _report(stage, done, total, detail=""):
+        # progress(stage, done, total, detail): stage in {"collision", "meshes"}.
+        # Optional; a caller (the editor's async export) maps it onto its UI.
+        if progress:
+            try:
+                progress(stage, done, total, detail)
+            except Exception:
+                pass
+
+    def _ckcancel():
+        # cooperative cancel: checked between links/meshes (CoACD itself is not
+        # interruptible mid-link, so a cancel lands at the next boundary)
+        if should_cancel and should_cancel():
+            raise ExportCancelled()
     # convex collision parts ('coacd' = many, 'hull' = one): keyed by source +
     # mode + quality so a source shared by several links is built once (CoACD is
     # also disk-cached under .coacd_cache)
@@ -1311,33 +1344,53 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
                 block.append(new_geo)
             _set_origin_el(block, np.asarray(base_M, float) @ M)
 
+    _warm_lock = threading.Lock()
+    _warm_state = {"n": 0}
+
+    def _warm_tick(src, total):
+        with _warm_lock:
+            _warm_state["n"] += 1
+            done = _warm_state["n"]
+        _report("collision", done, total, os.path.basename(src))
+
     if collision == "coacd":
         # CoACD is the heaviest per-mesh op; warm its disk cache for every unique
         # collision source IN PARALLEL (CoACD releases the GIL) so the serial
         # expansion below is all cache hits.  'hull' is fast and not disk-cached,
         # so it needs no warming -- _emit_collision builds it inline.
+        _coacd_srcs = list(set(
+            _iter_sources(root, pkg_dir, own_pkgs, ("collision",))))
+        _report("collision", 0, len(_coacd_srcs))
+
         def _warm_coacd(src):
+            if should_cancel and should_cancel():
+                return                      # drain the pool fast once cancelled
             try:
                 _coacd_part_stls(src, coacd_quality, coacd_cache_dir)
             except Exception:
                 pass                        # the real error resurfaces in _emit_collision
-        _parallel(_warm_coacd,
-                  set(_iter_sources(root, pkg_dir, own_pkgs, ("collision",))))
+            _warm_tick(src, len(_coacd_srcs))
+        _parallel(_warm_coacd, _coacd_srcs)
     elif collision in _PRIMITIVE_MODES:
         # primitive fitting voxelises the mesh (auto mode scores several
         # candidates by IoU) -- a few hundred ms per unique source; warm them in
         # parallel so the serial expansion below is all cache hits
+        _prim_srcs = list(set(
+            _iter_sources(root, pkg_dir, own_pkgs, ("collision",))))
+        _report("collision", 0, len(_prim_srcs))
+
         def _warm_prim(src):
+            if should_cancel and should_cancel():
+                return                      # drain the pool fast once cancelled
             key = (os.path.abspath(src), collision)
-            if key in prim_done:
-                return
-            try:
-                prim_done[key] = _fit_collision_primitive(
-                    src, _PRIMITIVE_MODES[collision])
-            except Exception:
-                pass                    # the real error resurfaces in expansion
-        _parallel(_warm_prim,
-                  set(_iter_sources(root, pkg_dir, own_pkgs, ("collision",))))
+            if key not in prim_done:
+                try:
+                    prim_done[key] = _fit_collision_primitive(
+                        src, _PRIMITIVE_MODES[collision])
+                except Exception:
+                    pass                # the real error resurfaces in expansion
+            _warm_tick(src, len(_prim_srcs))
+        _parallel(_warm_prim, _prim_srcs)
 
     def _verbatim(job):
         # already the target format, no colour override, no bake: the source is
@@ -1352,7 +1405,9 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
     # order; phase 2 then produces each job's bytes exactly once.
     jobs = {}                              # key -> job dict
     job_order = []                         # keys, first-seen order (file order)
+    _ckcancel()                        # cancel requested during collision warm?
     for link in root.findall("link"):
+        _ckcancel()
         # colour overrides are keyed by LINK name in URDF-input mode and by the
         # component/mesh basename in the CAD path -- accept either
         link_color = colors.get(link.get("name"))
@@ -1416,8 +1471,11 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
     # ---- phase 2: produce the mesh bytes (serial; the cache makes it cheap) ---
     # each unique job converts once; the disk cache makes a re-export near-instant
     # and the in-memory load-once means visual + collision share a single load
-    for key in job_order:
+    _n_jobs = len(job_order)
+    for _i, key in enumerate(job_order):
+        _ckcancel()
         job = jobs[key]
+        _report("meshes", _i, _n_jobs, job["base"])
         src, fmt, color, transform = (job["src"], job["fmt"], job["color"],
                                       job["transform"])
         try:
@@ -1440,6 +1498,7 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
             errors.append(f"{job['base']}: {fmt} convert failed ({e!r})")
             continue
         files.append((f"{pkg}/{mesh_rel}/{job['name']}", data))
+    _report("meshes", _n_jobs, _n_jobs)
 
     if errors:
         raise RuntimeError("ROS description export failed: " + "; ".join(errors))

--- a/tests/e2e/run.mjs
+++ b/tests/e2e/run.mjs
@@ -381,24 +381,40 @@ check('box-select: undo restores joint types',
       movRestored === movBefore, `back to ${movRestored}`);
 }  // end if (!SMOKE) -- auto-limits + box-select block
 
-// ---- 10. extraction loading UI (mock /api/extract*, no SolidWorks) ---------
-// B: determinate bar during mesh export; C: cold-start reassurance; seconds.
+// ---- 10. extraction loading UI (mock /api/progress, no SolidWorks) ---------
+// The server owns the stage/frac mapping now (unified progress, issue #21), so
+// the client just renders GET /api/progress: cold start = the "connect
+// SolidWorks" stage (indeterminate); mesh export = the "export meshes" stage
+// with a determinate bar + "i/n" sub.
 await page.evaluate(() => {
   window._phase = 'start';
+  const S = (a) => [
+    { name: 'connect SolidWorks', state: a[0] },
+    { name: 'extract assembly', state: a[1] },
+    { name: 'export meshes', state: a[2] },
+    { name: 'build package', state: a[3] }];
+  window._P = {
+    start: { job: 'extract', running: true, done: false, cancelled: false,
+      error: null, stages: S(['active', 'pending', 'pending', 'pending']),
+      frac: null, label: 'connect SolidWorks',
+      sub: '... still waiting (10s in this phase, 20s total, '
+           + '1 SolidWorks process(es) alive)',
+      log: ['starting SolidWorks (this can take a minute) ...'], result: null },
+    mesh: { job: 'extract', running: true, done: false, cancelled: false,
+      error: null, stages: S(['done', 'done', 'active', 'pending']),
+      frac: 30 / 55, label: 'export meshes', sub: '30/55  linkB_1',
+      log: ['exporting mesh 30/55: linkB_1'], result: null },
+    done: { job: 'extract', running: false, done: true, cancelled: false,
+      error: null, stages: S(['done', 'done', 'done', 'done']), frac: 1,
+      label: '', sub: '', log: ['done'], result: { package: 'output/x' } },
+  };
   const of = window.fetch.bind(window);
   window.fetch = async (u, opts) => {
     const url = typeof u === 'string' ? u : u?.url;
     const J = o => new Response(JSON.stringify(o),
       { headers: { 'Content-Type': 'application/json' } });
     if (url && url.includes('/api/extract?')) return J({ started: true });
-    if (url && url.includes('/api/extract/status')) {
-      if (window._phase === 'start') return J({ running: true, error: null, log: [
-        'starting SolidWorks (this can take a minute) ...',
-        '... still waiting (10s in this phase, 20s total, 1 SolidWorks process(es) alive)'] });
-      if (window._phase === 'mesh') return J({ running: true, error: null,
-        log: ['starting SolidWorks ...', 'exporting mesh 30/55: linkB_1'] });
-      return J({ running: false, error: null, log: ['done'], package: 'output/x' });
-    }
+    if (url && url.includes('/api/progress')) return J(window._P[window._phase]);
     return of(u, opts);
   };
   window.sw2robot.extractFlow('C:/fake/thing.SLDASM');
@@ -412,16 +428,15 @@ const lbar = () => page.evaluate(() => {
 });
 await sleep(2500);
 const cold = await lbar();
-check('extract-ui: cold-start indeterminate + alive + seconds',
-      cold.indet && /SolidWorks を起動中/.test(cold.text)
-      && /稼働中 ✓/.test(cold.sub) && /\d+秒/.test(cold.text)
-      && !/min/.test(cold.text + cold.sub), JSON.stringify(cold));
+check('extract-ui: cold-start indeterminate + connect stage + waiting',
+      cold.indet && /SolidWorks/.test(cold.text)
+      && /still waiting/.test(cold.sub), JSON.stringify(cold));
 await page.evaluate(() => { window._phase = 'mesh'; });
 await sleep(1600);
 const meshb = await lbar();
-check('extract-ui: mesh export determinate bar (30/55) + seconds',
+check('extract-ui: mesh export determinate bar (30/55)',
       !meshb.indet && meshb.fill >= 50 && meshb.fill <= 60
-      && /メッシュ 30\/55/.test(meshb.sub) && /\d+秒/.test(meshb.text),
+      && /メッシュ/.test(meshb.text) && /30\/55/.test(meshb.sub),
       JSON.stringify(meshb));
 await page.evaluate(() => { window._phase = 'done'; });
 await sleep(1500);
@@ -440,8 +455,11 @@ await page.evaluate(() => {
     if (url && url.includes('/api/fs'))           // server browser root
       return J({ path: '', parent: null, dirs: [], files: [] });
     if (url && url.includes('/api/extract?')) return J({ started: true });
-    if (url && url.includes('/api/extract/status'))
-      return J({ running: true, error: null, log: ['starting SolidWorks ...'] });
+    if (url && url.includes('/api/progress'))
+      return J({ job: 'extract', running: true, done: false, cancelled: false,
+        error: null, stages: [{ name: 'connect SolidWorks', state: 'active' }],
+        frac: null, label: 'connect SolidWorks', sub: '',
+        log: ['starting SolidWorks ...'], result: null });
     return of(u, opts);
   };
 });

--- a/tests/test_ros_export.py
+++ b/tests/test_ros_export.py
@@ -1085,3 +1085,40 @@ def test_visual_and_collision_formats_are_independent(tmp_path, vfmt, cfmt):
     mesh_arcs = {a for a in files if a.startswith("mix_description/meshes/")}
     assert mesh_arcs == {f"mix_description/meshes/part.{vfmt}",
                          f"mix_description/meshes/part.{cfmt}"}
+
+
+def test_build_ros_description_reports_progress(tmp_path):
+    """build_ros_description invokes the progress callback for the mesh-convert
+    stage with monotonically advancing counts ending at the total (issue #21)."""
+    from sw2robot.exporter.ros_export import build_ros_description
+
+    pkg_dir = _make_pkg(tmp_path, robot="rp")
+    events = []
+    build_ros_description(
+        pkg_dir, "rp",
+        progress=lambda stage, done, total, detail: events.append(
+            (stage, done, total)))
+
+    mesh = [(d, tot) for (s, d, tot) in events if s == "meshes"]
+    assert mesh, "no mesh-conversion progress reported"
+    total = mesh[-1][1]
+    assert total >= 1
+    dones = [d for d, _ in mesh]
+    assert dones == sorted(dones)             # never regresses
+    assert dones[-1] == total                 # ends at 100%
+    assert all(tot == total for _d, tot in mesh)
+
+
+def test_build_ros_description_cancels(tmp_path):
+    """should_cancel turning true aborts the build with ExportCancelled rather
+    than emitting a half-built package (issue #21 export stop button)."""
+    import pytest as _pytest
+
+    from sw2robot.exporter.ros_export import (
+        ExportCancelled,
+        build_ros_description,
+    )
+
+    pkg_dir = _make_pkg(tmp_path, robot="rc")
+    with _pytest.raises(ExportCancelled):
+        build_ros_description(pkg_dir, "rc", should_cancel=lambda: True)

--- a/tests/test_ros_export.py
+++ b/tests/test_ros_export.py
@@ -1122,3 +1122,23 @@ def test_build_ros_description_cancels(tmp_path):
     pkg_dir = _make_pkg(tmp_path, robot="rc")
     with _pytest.raises(ExportCancelled):
         build_ros_description(pkg_dir, "rc", should_cancel=lambda: True)
+
+
+def test_build_ros_description_cancels_during_collision_warm(tmp_path):
+    """A cancel during the parallel CoACD warm aborts promptly via
+    _parallel_cancellable (issue #21 — cancel mid-step, not after the whole
+    phase), rather than running the whole batch first."""
+    import pytest as _pytest
+
+    from sw2robot.exporter.ros_export import (
+        ExportCancelled,
+        build_ros_description,
+        coacd_available,
+    )
+
+    if not coacd_available():
+        _pytest.skip("coacd not installed")
+    pkg_dir = _make_pkg(tmp_path, robot="rw")
+    with _pytest.raises(ExportCancelled):
+        build_ros_description(pkg_dir, "rw", collision="coacd",
+                              should_cancel=lambda: True)

--- a/tests/test_urdf_mode_webserver.py
+++ b/tests/test_urdf_mode_webserver.py
@@ -1090,3 +1090,70 @@ def test_coacd_cancel_stops_at_link_boundary(server, monkeypatch):
     assert s.get("running") is False
     assert s.get("cancelled") is True
     assert 0 < s.get("done") < total         # stopped early, after some progress
+
+
+def test_async_export_progress_and_download(server):
+    """The async export (issue #21): /start runs a background build reporting
+    into /api/progress, /download returns the finished zip once, and its file
+    list matches the synchronous /api/export/zip endpoint."""
+    import io
+    import time
+    import zipfile
+
+    r = _get_json(server, "/api/export/zip/start?ros=1&meshes=stl&colfmt=stl")
+    assert r.get("started") is True
+
+    st = {}
+    deadline = time.time() + 60
+    while time.time() < deadline:
+        st = _get_json(server, "/api/progress")
+        if st.get("done"):
+            break
+        time.sleep(0.1)
+    assert st.get("done") and not st.get("error"), st
+    assert st.get("job") == "export"
+    assert st["result"]["ready"] is True
+    # the checklist ended fully done and the bar hit 100%
+    assert all(s["state"] == "done" for s in st["stages"])
+    assert st["frac"] == 1.0
+
+    code, data = _get_status(server, "/api/export/zip/download")
+    assert code == 200
+    assert data[:2] == b"PK"                      # a real zip
+    async_names = set(zipfile.ZipFile(io.BytesIO(data)).namelist())
+
+    # single-shot: the bytes are freed after one download
+    code2, _ = _get_status(server, "/api/export/zip/download")
+    assert code2 == 404
+
+    # same package contents as the synchronous endpoint
+    with urllib.request.urlopen(
+            server + "/api/export/zip?ros=1&meshes=stl&colfmt=stl") as resp:
+        sync = resp.read()
+    sync_names = set(zipfile.ZipFile(io.BytesIO(sync)).namelist())
+    assert async_names == sync_names
+
+
+def test_export_start_rejects_second_job(server):
+    """_prog_start is a single global busy-guard: a second heavy job while an
+    export is in flight is refused with 409."""
+    import time
+
+    r = _get_json(server, "/api/export/zip/start?ros=1&meshes=stl&colfmt=stl")
+    assert r.get("started") is True
+    try:
+        # a second start (or any other job) must 409 while one is running.  The
+        # export can finish very fast on the tiny fixture, so only assert the
+        # guard IF it is still running.
+        st = _get_json(server, "/api/progress")
+        if st.get("running"):
+            code, body = _get_status(
+                server, "/api/export/zip/start?ros=1&meshes=stl&colfmt=stl")
+            assert code == 409
+    finally:
+        deadline = time.time() + 60
+        while time.time() < deadline:
+            if _get_json(server, "/api/progress").get("done"):
+                break
+            time.sleep(0.1)
+        _get_status(server, "/api/export/zip/download")   # drain the stash

--- a/tests/test_urdf_mode_webserver.py
+++ b/tests/test_urdf_mode_webserver.py
@@ -1135,25 +1135,18 @@ def test_async_export_progress_and_download(server):
 
 
 def test_export_start_rejects_second_job(server):
-    """_prog_start is a single global busy-guard: a second heavy job while an
-    export is in flight is refused with 409."""
-    import time
+    """_prog_start is a single global busy-guard: any heavy job while another
+    holds it is refused with 409.  Assert this deterministically by holding the
+    guard directly -- racing a real export to still be running is flaky on the
+    tiny fixture (it can finish before the second request lands)."""
+    from sw2robot.editor import webserver
 
-    r = _get_json(server, "/api/export/zip/start?ros=1&meshes=stl&colfmt=stl")
-    assert r.get("started") is True
+    gen = webserver._prog_start("extract", ["load model"])
+    assert gen is not None, "guard should be free at the start of the test"
     try:
-        # a second start (or any other job) must 409 while one is running.  The
-        # export can finish very fast on the tiny fixture, so only assert the
-        # guard IF it is still running.
-        st = _get_json(server, "/api/progress")
-        if st.get("running"):
-            code, body = _get_status(
-                server, "/api/export/zip/start?ros=1&meshes=stl&colfmt=stl")
-            assert code == 409
+        code, body = _get_status(
+            server, "/api/export/zip/start?ros=1&meshes=stl&colfmt=stl")
+        assert code == 409
+        assert b"already running" in body
     finally:
-        deadline = time.time() + 60
-        while time.time() < deadline:
-            if _get_json(server, "/api/progress").get("done"):
-                break
-            time.sleep(0.1)
-        _get_status(server, "/api/export/zip/download")   # drain the stash
+        webserver._prog_finish()                          # release the guard


### PR DESCRIPTION
Addresses #123

One live progress view for every long-running editor job, and every one of them is cancellable. Previously each job had its own feed and UI — extract streamed a text log the client regex-parsed, the collision preview had its own top banner, the limit sweep its own counter, and the ZIP export was a blocking download with no feedback and no way to stop it.

## Unified panel

All four jobs — **extract, ZIP export, collision (CoACD/primitive) preview, and the joint-limit sweep** — now report into one server-side `_prog` object (`GET /api/progress`) and render through a single top-centred panel: a bar, a per-stage checklist, a live log tail, and a shared ■ stop button. Each panel reads the same way — stage name as the title, count in the sub-line, animated bar until the first item of a stage completes so nothing looks frozen. The collision preview keeps its per-link 3D blink + mesh-popping; only its separate banner was folded in.

Extract's free-text log lines are classified into stages **server-side**, so the client no longer parses them.

## Async, cancellable export

The ZIP export is now a background job: `/api/export/zip/start` → poll `/api/progress` → `/api/export/zip/download`. `build_ros_description` gained a `progress` callback and a `should_cancel` predicate. Cancelling lands **mid-step** (~0.2 s), not after the whole phase:

- the parallel CoACD/primitive warm stops waiting on the in-flight wave (a CoACD part can't be interrupted mid-run, so it finishes in the background and its result is cached; not-yet-started parts are dropped);
- the zip compression checks per file.

A generation id guards against late progress from abandoned parts touching a newer job. The synchronous `/api/export/zip` stays for the `launch_it.sh` one-liner.

## Sweep: finer progress + cancel

The limit sweep now reports at each joint's **start** (names the joint being worked, advances the bar as each begins, animated while loading the model and between joints) instead of only jumping after a joint finishes. `/api/auto_limits/cancel` kills the sweep subprocess so it can be stopped mid-run.

## Notes

- Polling, not SSE — the threaded `http.server` makes it the simpler, robust choice.
- Tests: `build_ros_description` progress callback + cancel (incl. mid-warm), async export round-trip vs the sync endpoint, the global one-job busy-guard; the puppeteer e2e updated to the new `/api/progress` panel.
- `_parallel` folded into `_parallel_cancellable` (its only caller).
