### PR TITLE
Add an action recorder: keycast overlay, log export, session replay, and screen recording

### DIFF
--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -21,6 +21,13 @@
   #views button { font-size: 11px; padding: 3px 8px; opacity: .85; }
   #views button.toggle.active { background: #3d6fb4; border-color: #7db8ff;
            color: #fff; opacity: 1; }
+  /* replay/record live in #toolrow, not #views -- give them the same active tint */
+  #toolrow button.toggle.active { background: #3d6fb4; border-color: #7db8ff;
+           color: #fff; }
+  /* recording: red + slow pulse so it's obvious a capture is live */
+  #record.active { background: #c0392b; border-color: #ff8a7a; color: #fff;
+           animation: recpulse 1.2s ease-in-out infinite; }
+  @keyframes recpulse { 50% { opacity: .5; } }
   #panel { width: 340px; padding: 12px; overflow-y: auto; flex-shrink: 0;
            background: #22252b; border-left: 1px solid #333;
            display: flex; flex-direction: column; }
@@ -597,6 +604,9 @@
       </button>
       <button id="replay" class="toggle" data-i18n-title="t.replay"
               title="記録を再生。クリック: .json を読み込んで再生 ・ Shift+クリック: 現在のセッションを再生">▷
+      </button>
+      <button id="record" class="toggle" data-i18n-title="t.record"
+              title="タブを録画。クリック: 開始/停止 ・ Shift+クリック: replayを自動録画">⏺
       </button>
       <input id="replayfile" type="file" accept=".json,application/json"
              style="display:none">
@@ -1416,6 +1426,12 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     'replay.done': { en: a => `▷ replay done (${a.done} played, ${a.skipped} skipped)`, ja: a => `▷ 再生完了（${a.done} 実行 / ${a.skipped} スキップ）` },
     'replay.stepFail': { en: a => `▷ replay: ${a.op} failed: ${a.e}`, ja: a => `▷ 再生: ${a.op} 失敗: ${a.e}` },
     'replay.badFile': { en: a => `▷ replay: could not read file: ${a.e}`, ja: a => `▷ 再生: ファイルを読めませんでした: ${a.e}` },
+    't.record': { en: 'record a video of the tab (all UI + the keycast overlay). Click: start / stop (the browser asks to share this tab once) · Shift+click: auto-record a replay of this session end to end. Saves a .webm.',
+                  ja: 'タブの動画を録画（全UI＋keycastオーバーレイ込み）。クリック: 開始/停止（最初に「このタブを共有」の確認あり）・ Shift+クリック: 現セッションのreplayを最初から最後まで自動録画。.webm で保存。' },
+    'rec.on': { en: '⏺ recording… (click again to stop)', ja: '⏺ 録画中…（もう一度クリックで停止）' },
+    'rec.saved': { en: a => `⏺ saved ${a.file} (${a.kb} KB)`, ja: a => `⏺ ${a.file} を保存しました（${a.kb} KB）` },
+    'rec.cancelled': { en: '⏺ recording cancelled (tab not shared)', ja: '⏺ 録画をキャンセルしました（タブ未共有）' },
+    'rec.unsupported': { en: '⏺ this browser cannot record the screen (getDisplayMedia/MediaRecorder missing)', ja: '⏺ このブラウザは画面録画に対応していません（getDisplayMedia/MediaRecorder なし）' },
     't.autolimits': { en: 'sweep each rotary joint over ±2π(±360°) to the self-collision angle (coarse scan + binary search) and auto-set lower/upper. Joints free over the full ±2π become continuous. Ctrl+Z to undo.',
                       ja: '各回転関節を ±2π(±360°)の範囲で自己干渉が起きる角度まで掃引(粗スキャン+二分探索)して lower/upper を自動設定。±2π まで自由に回る関節は continuous に。Ctrl+Zで戻せます' },
     'ui.autolimits': { en: '🛠 auto joint limits (self-collision, ±2π)', ja: '🛠 自動関節リミット (自己干渉, ±2π)' },
@@ -2013,6 +2029,54 @@ async function replayLog(entries, { speed = 1, maxGap = 1500 } = {}) {
     document.getElementById('replay')?.classList.remove('active');
   }
   log(t('replay.done', { done, skipped }), 'ok');
+}
+
+// ---- screen recording: capture the whole tab (all UI + the keycast overlay)
+// to a .webm via getDisplayMedia + MediaRecorder.  The browser asks "share
+// this tab" once per recording (the required user gesture); after that it is
+// hands-off.  Pairs with replay: Shift-click records a replay end to end. ------
+let _rec = null;                 // { recorder, chunks, stream } while recording
+let _recStarting = false;        // guards the async gap before _rec is assigned
+async function startScreenRecording() {
+  if (_rec || _recStarting) { return _rec; }   // already recording / share dialog open
+  if (!navigator.mediaDevices?.getDisplayMedia || !window.MediaRecorder) {
+    log(t('rec.unsupported'), 'err'); return null;
+  }
+  let stream;
+  _recStarting = true;
+  try {
+    stream = await navigator.mediaDevices.getDisplayMedia({
+      video: { frameRate: 30 }, audio: false });
+  } catch { log(t('rec.cancelled'), 'wrn'); return null; }
+  finally { _recStarting = false; }
+  const mime = ['video/webm;codecs=vp9', 'video/webm;codecs=vp8', 'video/webm']
+    .find(m => MediaRecorder.isTypeSupported(m)) || 'video/webm';
+  const chunks = [];
+  const recorder = new MediaRecorder(stream, { mimeType: mime });
+  recorder.ondataavailable = e => { if (e.data.size) { chunks.push(e.data); } };
+  recorder.onstop = () => {
+    stream.getTracks().forEach(tr => tr.stop());
+    const blob = new Blob(chunks, { type: mime });
+    const pkg = (currentInfo?.name || 'sw2robot').replace(/[^\w.-]+/g, '_');
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = `${pkg}-demo.webm`; a.click();
+    URL.revokeObjectURL(url);
+    log(t('rec.saved', { file: a.download, kb: Math.round(blob.size / 1024) }), 'ok');
+  };
+  // the browser's own "Stop sharing" chip ends the track -> finalise cleanly
+  stream.getVideoTracks()[0].addEventListener('ended', stopScreenRecording);
+  recorder.start();
+  _rec = { recorder, chunks, stream };
+  document.getElementById('record')?.classList.add('active');
+  log(t('rec.on'), 'ok');
+  return _rec;
+}
+function stopScreenRecording() {
+  if (!_rec) { return; }
+  const r = _rec; _rec = null;
+  document.getElementById('record')?.classList.remove('active');
+  if (r.recorder.state !== 'inactive') { r.recorder.stop(); }  // onstop downloads
 }
 
 async function refreshCompMeta() {
@@ -7267,6 +7331,9 @@ window.sw2robot = {
   oplog: () => oplog.slice(),            // ② a copy of the raw action stream
   replay: (entries, opts) => replayLog(entries ?? oplog.slice(), opts),
   cancelReplay: replayCancel,
+  record: () => startScreenRecording(),  // 🎥 screen recording (for tooling/tests)
+  stopRecord: stopScreenRecording,
+  isRecording: () => !!_rec,
   axisGlyphs: () => [...axisGlyphs.entries()].map(([name, g]) => ({
     name, visible: g.visible, children: g.children.length,
     inScene: !!g.parent })),
@@ -7305,6 +7372,15 @@ document.getElementById('replayfile').addEventListener('change', async ev => {
     replayLog(entries);
   } catch (e) {
     log(t('replay.badFile', { e: e.message ?? e }), 'err');
+  }
+});
+document.getElementById('record').addEventListener('click', async e => {
+  if (_rec) { stopScreenRecording(); return; }           // click again = stop
+  const wantReplay = e.shiftKey && oplog.length;
+  const started = await startScreenRecording();          // asks to share the tab
+  if (started && wantReplay) {                            // Shift = record a replay
+    await replayLog(oplog.slice());
+    stopScreenRecording();
   }
 });
 

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -592,6 +592,9 @@
       <button id="bug" data-i18n-title="t.bug"
               title="壊れたらこれ: 操作ログ+状態をサーバーに送る">🐞
       </button>
+      <button id="savelog" data-i18n-title="t.savelog"
+              title="操作ログをダウンロード。クリック: .txt ・ Shift+クリック: .json">⤓
+      </button>
     </div>
     <div id="autorow">
       <button id="autolimits" style="width:100%" data-i18n="ui.autolimits"
@@ -1399,6 +1402,9 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     't.renamelist': { en: 'rename joints/links in a list', ja: '関節名・リンク名を一覧で改名' },
     'ui.renamelist': { en: '≣ rename', ja: '≣ 改名' },
     't.bug': { en: 'broken? this sends the op-log + state to the server', ja: '壊れたらこれ: 操作ログ+状態をサーバーに送る' },
+    't.savelog': { en: 'download the action log (what you did). Click: readable .txt · Shift+click: raw .json (for replay).',
+                   ja: '操作ログ（何をしたか）をダウンロード。クリック: 読みやすい .txt ・ Shift+クリック: 生 .json（再生用）。' },
+    'log.saved': { en: a => `⤓ saved ${a.file} (${a.n} actions)`, ja: a => `⤓ ${a.file} を保存しました（${a.n} 操作）` },
     't.autolimits': { en: 'sweep each rotary joint over ±2π(±360°) to the self-collision angle (coarse scan + binary search) and auto-set lower/upper. Joints free over the full ±2π become continuous. Ctrl+Z to undo.',
                       ja: '各回転関節を ±2π(±360°)の範囲で自己干渉が起きる角度まで掃引(粗スキャン+二分探索)して lower/upper を自動設定。±2π まで自由に回る関節は continuous に。Ctrl+Zで戻せます' },
     'ui.autolimits': { en: '🛠 auto joint limits (self-collision, ±2π)', ja: '🛠 自動関節リミット (自己干渉, ±2π)' },
@@ -1870,6 +1876,70 @@ function op(name, args = {}) {
   if (oplog.length > 400) { oplog.splice(0, 100); }
   // notify live listeners; a bad subscriber must never break the action itself
   for (const fn of opSubs) { try { fn(entry); } catch { /* ignore */ } }
+}
+
+// Human-readable label for a semantic action from the op() stream -- the
+// shared vocabulary used by the screencast overlay, the log export, and (later)
+// replay.  View navigation (orbit/pan/zoom) never calls op(), so it can't
+// appear here: the noise is gone by construction, not by filtering.  An unknown
+// op falls back to a Title-cased name, so a newly-instrumented action shows up
+// for free (add a nicer entry here when you want one).
+const OP_LABEL = {
+  select:      a => a.link ? 'Select: ' + a.link : 'Deselect',
+  setColor:    a => 'Colour: ' + a.link,
+  eye:         a => (a.hide ? 'Hide: ' : 'Show: ') + a.link,
+  setMaterial: a => 'Material: ' + a.link,
+  setInertial: a => 'Inertial: ' + a.link,
+  exclude:     () => 'Exclude',
+  autoLimits:  () => 'Auto limits',
+  reRoot:      a => 'Make root: ' + a.link,
+  align:       () => 'Align to face',
+  remove_port: () => 'Remove end-coords',
+  add_port:    () => 'Add end-coords',
+  setJoint:    a => {
+    const j = viewer.robot?.joints?.[a.joint];
+    const um = j ? _jointUnit(j.jointType) : null;
+    const disp = um ? um.toDisp(a.value).toFixed(um.dec) + um.unit
+                    : (+a.value).toFixed(3);
+    return `Joint ${a.joint} → ${disp}`;
+  },
+  resetPose:   () => 'Reset pose',
+  boxSelect:   a => `Box select (${a.n})`,
+  boxToggle:   a => 'Toggle: ' + a.name,
+  setMimic:    a => 'Mimic → ' + a.master,
+  clearMimic:  a => 'Clear mimic: ' + a.child,
+  loadRobot:   a => 'Load' + (a.name ? ': ' + a.name : ''),
+  rootPose:    a => 'Root pose: ' + a.what,
+  clearViewer: () => 'Clear scene',
+  undo:        () => 'Undo',
+  redo:        () => 'Redo',
+};
+function opLabel(e) {
+  return OP_LABEL[e.op] ? OP_LABEL[e.op](e)
+                        : e.op.charAt(0).toUpperCase() + e.op.slice(1);
+}
+
+// ---- action-log export (③): the same op() stream the overlay shows, written
+// out for a bug report / tutorial notes.  Text is human-readable
+// ("+12.3s  Select: base_link"); JSON is the raw oplog, which replay reads. ---
+function actionLogText() {
+  const t0 = oplog.length ? oplog[0].t : 0;   // times relative to the first action
+  return oplog.map(e => `${('+' + ((e.t - t0) / 1000).toFixed(1) + 's').padStart(8)}  `
+                        + opLabel(e)).join('\n') + '\n';
+}
+function downloadActionLog(kind = 'txt') {
+  const raw = kind === 'json';
+  const body = raw ? JSON.stringify(oplog, null, 2) : actionLogText();
+  const pkg = (currentInfo?.name || 'sw2robot').replace(/[^\w.-]+/g, '_');
+  const blob = new Blob([body], {
+    type: raw ? 'application/json' : 'text/plain;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${pkg}-actions.${raw ? 'json' : 'txt'}`;
+  document.body.appendChild(a); a.click(); a.remove();   // in-DOM click for Firefox
+  URL.revokeObjectURL(url);
+  log(t('log.saved', { file: a.download, n: oplog.length }), 'ok');
 }
 
 async function refreshCompMeta() {
@@ -7119,6 +7189,8 @@ window.sw2robot = {
   boxSelected: () => [...boxSelected],
   bulkType: t => bulkSetType(t),
   select: n => selectLink(n),
+  actionLogText,                         // ③ readable log (for tests / tooling)
+  exportLog: kind => downloadActionLog(kind),
   axisGlyphs: () => [...axisGlyphs.entries()].map(([name, g]) => ({
     name, visible: g.visible, children: g.children.length,
     inScene: !!g.parent })),
@@ -7141,6 +7213,8 @@ window.sw2robot = {
 };
 document.getElementById('bug').addEventListener('click',
   () => window.sw2robot.report());
+document.getElementById('savelog').addEventListener('click',
+  e => downloadActionLog(e.shiftKey ? 'json' : 'txt'));
 
 // re-render the dynamic (JS-built) UI in the new language when toggled.
 // data-i18n static chrome is handled by applyStaticI18n in the loader script.
@@ -7182,44 +7256,6 @@ document.querySelectorAll('#langbar button').forEach(b =>
   };
   const isMod = k => k === 'Control' || k === 'Shift' || k === 'Alt' ||
                      k === 'Meta';
-
-  // Human-readable label for a semantic action from the op() stream.  View
-  // navigation (orbit/pan/zoom) never calls op(), so it can't appear here --
-  // the noise is gone by construction, not by filtering.  Unknown ops fall
-  // back to a Title-cased name so a newly-instrumented action shows up for
-  // free (just add a nicer entry here when you want one).
-  const OP_LABEL = {
-    select:      a => a.link ? 'Select: ' + a.link : 'Deselect',
-    setColor:    a => 'Colour: ' + a.link,
-    eye:         a => (a.hide ? 'Hide: ' : 'Show: ') + a.link,
-    setMaterial: a => 'Material: ' + a.link,
-    setInertial: a => 'Inertial: ' + a.link,
-    exclude:     () => 'Exclude',
-    autoLimits:  () => 'Auto limits',
-    reRoot:      a => 'Make root: ' + a.link,
-    align:       () => 'Align to face',
-    remove_port: () => 'Remove end-coords',
-    add_port:    () => 'Add end-coords',
-    setJoint:    a => {
-      const j = viewer.robot?.joints?.[a.joint];
-      const um = j ? _jointUnit(j.jointType) : null;
-      const disp = um ? um.toDisp(a.value).toFixed(um.dec) + um.unit
-                      : (+a.value).toFixed(3);
-      return `Joint ${a.joint} → ${disp}`;
-    },
-    resetPose:   () => 'Reset pose',
-    boxSelect:   a => `Box select (${a.n})`,
-    boxToggle:   a => 'Toggle: ' + a.name,
-    setMimic:    a => 'Mimic → ' + a.master,
-    clearMimic:  a => 'Clear mimic: ' + a.child,
-    loadRobot:   a => 'Load' + (a.name ? ': ' + a.name : ''),
-    rootPose:    a => 'Root pose: ' + a.what,
-    clearViewer: () => 'Clear scene',
-    undo:        () => 'Undo',
-    redo:        () => 'Redo',
-  };
-  const opLabel = e => (OP_LABEL[e.op] ? OP_LABEL[e.op](e)
-                        : e.op.charAt(0).toUpperCase() + e.op.slice(1));
 
   let last = null;                // { el, label, count, timer } for ×N merge
 

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -340,6 +340,10 @@
     animation: keycap-in .08s ease-out;
     transition: opacity .25s ease; white-space: nowrap; }
   #keyoverlay .keycap.mouse { background: rgba(34, 56, 92, .85); }
+  /* semantic action (from the op() stream) — greenish so it reads as
+     "something happened", distinct from a raw keypress */
+  #keyoverlay .keycap.op { background: rgba(28, 66, 48, .86);
+                           border-color: rgba(120, 230, 170, .35); }
   #keyoverlay .keycap.fading { opacity: 0; }
   #keyoverlay .keycap .mult { font-size: 12px; color: #9fd0ff;
                               font-weight: 700; }
@@ -1348,8 +1352,8 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     't.posedrag': { en: 'OFF: drag to orbit the view / ON: drag a link to move its joint',
                     ja: 'OFF: ドラッグで視点回転 / ON: リンクをドラッグして関節を動かす' },
     't.gridcap': { en: 'grid pitch', ja: 'グリッド間隔' },
-    't.keycast': { en: 'demo recording: show pressed keys / mouse in the bottom-left',
-                   ja: 'デモ録画用: 押したキー/マウス操作を画面左下に表示' },
+    't.keycast': { en: 'demo recording: show pressed keys and each action (select, add-port, re-root …) in the bottom-left. View navigation (orbit / pan / zoom) is intentionally not shown.',
+                   ja: 'デモ録画用: 押したキーと各操作（選択・ポート追加・ルート化…）を画面左下に表示。視点操作（回転/pan/ズーム）はあえて表示しません。' },
     'ui.emptyDrop': { en: 'Click here to open a package',
                       ja: 'クリックしてパッケージを開く' },
     'ui.emptyPick': { en: 'recent files · paste a full path · 🗄 on the right',
@@ -1858,9 +1862,14 @@ let massOnlyLinks = new Set(); // links flagged mass-only (weight kept, no mesh)
 // it's broken" moment in the USER's long-lived session can be inspected
 // (and replayed in tests) instead of guessed at -------------------------
 const oplog = [];
+const opSubs = [];               // live subscribers (keycast overlay, future recorders)
+function onOp(fn) { opSubs.push(fn); }   // subscribe to the semantic action stream
 function op(name, args = {}) {
-  oplog.push({ t: Math.round(performance.now()), op: name, ...args });
+  const entry = { t: Math.round(performance.now()), op: name, ...args };
+  oplog.push(entry);
   if (oplog.length > 400) { oplog.splice(0, 100); }
+  // notify live listeners; a bad subscriber must never break the action itself
+  for (const fn of opSubs) { try { fn(entry); } catch { /* ignore */ } }
 }
 
 async function refreshCompMeta() {
@@ -2621,9 +2630,14 @@ playBtn.addEventListener('click', () => {
   log(playMode ? t('play.on') : t('play.off'), 'ok');
 });
 document.getElementById('playhome').addEventListener('click', () => {
-  for (const [name, r] of playRows) {
-    previewJoint(name, Math.min(r.hi, Math.max(r.lo, 0)));
-  }
+  let n = 0;
+  withJointOpSuppressed(() => {
+    for (const [name, r] of playRows) {
+      previewJoint(name, Math.min(r.hi, Math.max(r.lo, 0)));
+      n += 1;
+    }
+  });
+  if (n) { op('resetPose', { n }); }   // one action, not n joint edits
 });
 
 viewer.addEventListener('angle-change', e => {
@@ -2638,7 +2652,47 @@ viewer.addEventListener('angle-change', e => {
     pr.slider.value = a;
     pr.val.value = pr.fmt(a);
   }
+  _recordJointEdit(e.detail);
 });
+
+// ---- record a joint move as ONE semantic op per settle --------------------
+// angle-change fires every frame while a slider or a pose-drag moves, so a
+// single drag would flood the action log (and the screencast overlay).  We
+// debounce per joint: when a joint's value stops changing for a moment, emit
+// one op('setJoint').  Programmatic moves (pose restore on reload, snap-to-rest
+// on a type flip, reset-pose) run inside withJointOpSuppressed(), so the model
+// updates without the move being logged as if the user did it by hand.
+let _joSuppress = 0;
+function withJointOpSuppressed(fn) {
+  _joSuppress += 1;
+  try { return fn(); } finally { _joSuppress -= 1; }
+}
+const _joPending = new Map();      // joint name -> { val, suppressed, timer }
+function _recordJointEdit(name) {
+  const j = viewer.robot?.joints?.[name];
+  // only user-drivable joints: a mimic follows its master and a fixed joint
+  // can't move, so an angle-change on either is a side effect, not an edit
+  if (!j || j.mimicJoint || j.jointType === 'fixed') { return; }
+  // stamp suppression at event time: a programmatic burst runs synchronously
+  // while _joSuppress > 0, so its last event marks the entry suppressed even
+  // though the debounce timer fires later, after the flag has been cleared.
+  const suppressed = _joSuppress > 0;
+  const prev = _joPending.get(name);
+  if (prev) {
+    clearTimeout(prev.timer);
+    // a programmatic (suppressed) move must not erase a real pending edit that
+    // hasn't fired yet -- flush it now so the user's drag isn't lost
+    if (suppressed && !prev.suppressed) { op('setJoint', { joint: name, value: prev.val }); }
+  }
+  const val = Number(j.angle);
+  const timer = setTimeout(() => {
+    const p = _joPending.get(name);
+    _joPending.delete(name);
+    if (!p || p.suppressed) { return; }        // programmatic move: don't log
+    op('setJoint', { joint: name, value: p.val });
+  }, 350);
+  _joPending.set(name, { val, suppressed, timer });
+}
 
 // ---- joint axis markers: depth-test OFF so they shine through the meshes;
 // children of the joint Object3D, so they follow FK for free ---------------
@@ -4356,7 +4410,7 @@ function patchJointTypeLive(j, type) {
   if (type === 'fixed') {
     if (j.jointType !== 'fixed') {
       axisMemory.set(j.name, j.axis.toArray());  // remember for un-fixing later
-      j.setJointValue(0);                         // return to rest before locking
+      withJointOpSuppressed(() => j.setJointValue(0));   // rest before locking
     }
     j.jointType = 'fixed';
     return;
@@ -4372,7 +4426,7 @@ function patchJointTypeLive(j, type) {
     // the background rebuild persists the authoritative range for next reload.
     if (!(hi > lo)) { j.limit = { lower: -Math.PI, upper: Math.PI }; }
   }
-  j.setJointValue(0);
+  withJointOpSuppressed(() => j.setJointValue(0));
 }
 
 // re-render everything that reads a joint's type WITHOUT touching the 3D scene
@@ -6369,13 +6423,15 @@ viewer.addEventListener('geometry-loaded', () => {
     if (restore) {
       // joint edit reload: keep the camera, put the pose back
       let n = 0;
-      for (const [name, v] of Object.entries(restore.angles)) {
-        const j = viewer.robot.joints[name];
-        if (j && j.jointType !== 'fixed' && !j.mimicJoint) {
-          viewer.setJointValue(name, v);
-          n += 1;
+      withJointOpSuppressed(() => {
+        for (const [name, v] of Object.entries(restore.angles)) {
+          const j = viewer.robot.joints[name];
+          if (j && j.jointType !== 'fixed' && !j.mimicJoint) {
+            viewer.setJointValue(name, v);
+            n += 1;
+          }
         }
-      }
+      });
       if (restore.linkWorlds) {
         // the model jumped in scene space (re-root / root frame change):
         // move the CAMERA by the same rigid transform so the view looks
@@ -6426,11 +6482,16 @@ viewer.addEventListener('urdf-error', e => {
 });
 
 function resetPose() {
-  for (const j of Object.values(viewer.robot?.joints ?? {})) {
-    if (j.jointType !== 'fixed' && !j.mimicJoint) {
-      viewer.setJointValue(j.name, 0);
+  let n = 0;
+  withJointOpSuppressed(() => {
+    for (const j of Object.values(viewer.robot?.joints ?? {})) {
+      if (j.jointType !== 'fixed' && !j.mimicJoint) {
+        viewer.setJointValue(j.name, 0);
+        n += 1;
+      }
     }
-  }
+  });
+  if (n) { op('resetPose', { n }); }   // one action, not n joint edits
 }
 document.getElementById('reset').addEventListener('click', resetPose);
 
@@ -7119,9 +7180,46 @@ document.querySelectorAll('#langbar button').forEach(b =>
     'ArrowUp': '↑', 'ArrowDown': '↓', 'ArrowLeft': '←', 'ArrowRight': '→',
     'Control': 'Ctrl', 'Meta': 'Cmd',
   };
-  const MOUSE = { 0: 'L-Click', 1: 'M-Click', 2: 'R-Click' };
   const isMod = k => k === 'Control' || k === 'Shift' || k === 'Alt' ||
                      k === 'Meta';
+
+  // Human-readable label for a semantic action from the op() stream.  View
+  // navigation (orbit/pan/zoom) never calls op(), so it can't appear here --
+  // the noise is gone by construction, not by filtering.  Unknown ops fall
+  // back to a Title-cased name so a newly-instrumented action shows up for
+  // free (just add a nicer entry here when you want one).
+  const OP_LABEL = {
+    select:      a => a.link ? 'Select: ' + a.link : 'Deselect',
+    setColor:    a => 'Colour: ' + a.link,
+    eye:         a => (a.hide ? 'Hide: ' : 'Show: ') + a.link,
+    setMaterial: a => 'Material: ' + a.link,
+    setInertial: a => 'Inertial: ' + a.link,
+    exclude:     () => 'Exclude',
+    autoLimits:  () => 'Auto limits',
+    reRoot:      a => 'Make root: ' + a.link,
+    align:       () => 'Align to face',
+    remove_port: () => 'Remove end-coords',
+    add_port:    () => 'Add end-coords',
+    setJoint:    a => {
+      const j = viewer.robot?.joints?.[a.joint];
+      const um = j ? _jointUnit(j.jointType) : null;
+      const disp = um ? um.toDisp(a.value).toFixed(um.dec) + um.unit
+                      : (+a.value).toFixed(3);
+      return `Joint ${a.joint} → ${disp}`;
+    },
+    resetPose:   () => 'Reset pose',
+    boxSelect:   a => `Box select (${a.n})`,
+    boxToggle:   a => 'Toggle: ' + a.name,
+    setMimic:    a => 'Mimic → ' + a.master,
+    clearMimic:  a => 'Clear mimic: ' + a.child,
+    loadRobot:   a => 'Load' + (a.name ? ': ' + a.name : ''),
+    rootPose:    a => 'Root pose: ' + a.what,
+    clearViewer: () => 'Clear scene',
+    undo:        () => 'Undo',
+    redo:        () => 'Redo',
+  };
+  const opLabel = e => (OP_LABEL[e.op] ? OP_LABEL[e.op](e)
+                        : e.op.charAt(0).toUpperCase() + e.op.slice(1));
 
   let last = null;                // { el, label, count, timer } for ×N merge
 
@@ -7142,7 +7240,7 @@ document.querySelectorAll('#langbar button').forEach(b =>
       return;
     }
     const el = document.createElement('span');
-    el.className = 'keycap' + (kind === 'mouse' ? ' mouse' : '');
+    el.className = 'keycap' + (kind && kind !== 'key' ? ' ' + kind : '');
     el.append(document.createTextNode(label));
     const m = document.createElement('span');
     m.className = 'mult';
@@ -7175,25 +7273,16 @@ document.querySelectorAll('#langbar button').forEach(b =>
     if (!on || e.repeat) return;
     show(chord(e, e.key), 'key');
   }
-  function onMouse(e) {
-    if (!on) return;
-    const name = MOUSE[e.button];
-    if (!name) return;
-    const mods = [];
-    if (e.ctrlKey)  mods.push('Ctrl');
-    if (e.altKey)   mods.push('Alt');
-    if (e.shiftKey) mods.push('Shift');
-    show([...mods, name].join(' + '), 'mouse');
-  }
-  function onWheel(e) {
-    if (!on) return;
-    show(e.deltaY < 0 ? 'Scroll ↑' : 'Scroll ↓', 'mouse');
-  }
 
-  // capture phase so we see the event before any field/control consumes it
+  // Semantic actions come from the op() stream, NOT from raw mouse/wheel
+  // events -- so a click that only orbits/pans/zooms the camera produces
+  // nothing, while a click that selects a link, adds a port, re-roots, etc.
+  // shows its meaning ("Select: base_link").  Keyboard is still read raw
+  // above, because a keypress is almost always an intentional command.
+  onOp(e => { if (on) show(opLabel(e), 'op'); });
+
+  // capture phase so we see the keypress before any field/control consumes it
   window.addEventListener('keydown', onKey, true);
-  window.addEventListener('mousedown', onMouse, true);
-  window.addEventListener('wheel', onWheel, { capture: true, passive: true });
 
   toggle.addEventListener('click', () => {
     on = toggle.classList.toggle('active');

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -357,6 +357,19 @@
   @keyframes keycap-in {
     from { transform: translateY(6px) scale(.92); opacity: 0; }
     to   { transform: none; opacity: 1; } }
+  /* ---- synthetic replay cursor (glides between action spots) ---- */
+  #replaycursor { position: fixed; left: 0; top: 0; z-index: 20; display: none;
+    margin: -2px 0 0 -2px; pointer-events: none;
+    filter: drop-shadow(0 1px 2px rgba(0, 0, 0, .55));
+    transition: left .35s cubic-bezier(.4, 0, .2, 1),
+                top  .35s cubic-bezier(.4, 0, .2, 1); }
+  #replaycursor svg { display: block; }
+  #replaycursor.click::after { content: ''; position: absolute; left: 3px; top: 3px;
+    border: 2px solid #4db8ff; border-radius: 50%; transform: translate(-50%, -50%);
+    animation: curpulse .5s ease-out; }
+  @keyframes curpulse {
+    from { width: 6px; height: 6px; opacity: .9; }
+    to   { width: 42px; height: 42px; opacity: 0; } }
 </style>
 <script type="importmap">
 {
@@ -556,6 +569,10 @@
     <div id="linkinfo"></div>
     <div id="keyoverlay" aria-hidden="true"></div>
   </div>
+  <!-- synthetic pointer shown only during replay (glides to each action) -->
+  <div id="replaycursor" aria-hidden="true"><svg width="24" height="24"
+       viewBox="0 0 24 24"><path d="M4 2 L4 20 L9 15 L12.5 22 L15 21 L12 14 L19 14 Z"
+       fill="#fff" stroke="#111" stroke-width="1.3" stroke-linejoin="round"/></svg></div>
   <div id="resizer" data-i18n-title="t.resizer" title="ドラッグでパネル幅を調整"></div>
   <div id="panel">
     <div id="langbar" style="display:flex;gap:4px;justify-content:flex-end;
@@ -1425,6 +1442,8 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     'replay.empty': { en: 'replay: nothing to play', ja: '再生: 再生する操作がありません' },
     'replay.done': { en: a => `▷ replay done (${a.done} played, ${a.skipped} skipped)`, ja: a => `▷ 再生完了（${a.done} 実行 / ${a.skipped} スキップ）` },
     'replay.stepFail': { en: a => `▷ replay: ${a.op} failed: ${a.e}`, ja: a => `▷ 再生: ${a.op} 失敗: ${a.e}` },
+    'replay.partial': { en: a => `▷ replay was partial — these actions can't be replayed and were skipped: ${a.ops}`,
+                        ja: a => `▷ 再生は部分的です — 次の操作は再生できずスキップしました: ${a.ops}` },
     'replay.badFile': { en: a => `▷ replay: could not read file: ${a.e}`, ja: a => `▷ 再生: ファイルを読めませんでした: ${a.e}` },
     't.record': { en: 'record a video of the tab (all UI + the keycast overlay). Click: start / stop (the browser asks to share this tab once) · Shift+click: auto-record a replay of this session end to end. Saves a .webm.',
                   ja: 'タブの動画を録画（全UI＋keycastオーバーレイ込み）。クリック: 開始/停止（最初に「このタブを共有」の確認あり）・ Shift+クリック: 現セッションのreplayを最初から最後まで自動録画。.webm で保存。' },
@@ -1910,6 +1929,36 @@ function op(name, args = {}) {
   for (const fn of opSubs) { try { fn(entry); } catch { /* ignore */ } }
 }
 
+// ---- camera track: sampled SEPARATELY from op() (so it never touches the
+// overlay / action log), throttled, so replay can move the view the way it
+// moved during recording -- the "someone is looking around" feel. -----------
+const camlog = [];               // { t, op:'camera', pos:[x,y,z], tgt:[x,y,z] }
+let _camLastT = 0;
+viewer.controls.addEventListener('change', () => {
+  if (_replaying) { return; }                     // don't record our own playback
+  const now = Math.round(performance.now());
+  if (now - _camLastT < 100) { return; }          // ~10 keyframes/sec max
+  _camLastT = now;
+  const p = viewer.camera.position, g = viewer.controls.target;
+  camlog.push({ t: now, op: 'camera',
+                pos: [p.x, p.y, p.z], tgt: [g.x, g.y, g.z] });
+  if (camlog.length > 4000) { camlog.splice(0, 1000); }
+});
+// actions + camera keyframes merged into one time-ordered stream for replay/export
+function fullTimeline() {
+  return [...oplog, ...camlog].sort((a, b) => (a.t ?? 0) - (b.t ?? 0));
+}
+// a fresh session (new package / cleared viewer): the old actions + camera
+// keyframes reference a robot/coordinate-frame that no longer exists, so
+// replaying/exporting them would be garbage -- drop everything, timers included.
+function _resetSessionLogs() {
+  oplog.length = 0;
+  camlog.length = 0;
+  _camLastT = 0;
+  for (const p of _joPending.values()) { clearTimeout(p.timer); }
+  _joPending.clear();
+}
+
 // Human-readable label for a semantic action from the op() stream -- the
 // shared vocabulary used by the screencast overlay, the log export, and (later)
 // replay.  View navigation (orbit/pan/zoom) never calls op(), so it can't
@@ -1961,7 +2010,7 @@ function actionLogText() {
 }
 function downloadActionLog(kind = 'txt') {
   const raw = kind === 'json';
-  const body = raw ? JSON.stringify(oplog, null, 2) : actionLogText();
+  const body = raw ? JSON.stringify(fullTimeline(), null, 2) : actionLogText();
   const pkg = (currentInfo?.name || 'sw2robot').replace(/[^\w.-]+/g, '_');
   const blob = new Blob([body], {
     type: raw ? 'application/json' : 'text/plain;charset=utf-8' });
@@ -1979,13 +2028,44 @@ function downloadActionLog(kind = 'txt') {
 // (joints move, links select) for a demo video.  Only a SAFE, non-destructive
 // subset is replayable; anything else (rename/exclude/add_port/... which mutate
 // server state) is skipped with a log line.  Add an entry here to grow it. ----
+// glide a joint from its current angle to `to` (easeInOutQuad) instead of
+// snapping, so a replayed drag looks like a hand moving it.  Non-blocking: the
+// replay loop keeps its recorded timing while the joint eases in the background.
+const _tweenGen = new Map();     // joint -> generation, so a newer tween wins
+let _activeTweens = 0;           // eases still running (replayLog drains these)
+function _cancelTweens() {        // invalidate every running tween (bump all gens)
+  for (const n of _tweenGen.keys()) { _tweenGen.set(n, (_tweenGen.get(n) || 0) + 1); }
+}
+function tweenJoint(name, to, dur = 500) {
+  const j = viewer.robot?.joints?.[name];
+  if (!j) { return; }
+  op('setJoint', { joint: name, value: to });     // announce label once (not logged)
+  const from = Number(j.angle) || 0;
+  const gen = (_tweenGen.get(name) || 0) + 1;
+  _tweenGen.set(name, gen);
+  if (Math.abs(to - from) < 1e-6) {
+    withJointOpSuppressed(() => viewer.setJointValue(name, to)); return;
+  }
+  const t0 = performance.now();
+  _activeTweens += 1;
+  let live = true;
+  const finish = () => { if (live) { live = false; _activeTweens -= 1; } };
+  const step = () => {
+    // stop only when SUPERSEDED (a newer tween, or _cancelTweens on stop/reset/
+    // reload).  NOT gated on _replaying: the last action's ease starts as the
+    // replay loop ends and must finish (replayLog drains us before resolving).
+    if (_tweenGen.get(name) !== gen) { finish(); return; }
+    const k = Math.min(1, (performance.now() - t0) / dur);
+    const e = k < 0.5 ? 2 * k * k : 1 - Math.pow(-2 * k + 2, 2) / 2;
+    withJointOpSuppressed(() => viewer.setJointValue(name, from + (to - from) * e));
+    if (k < 1) { requestAnimationFrame(step); } else { finish(); }
+  };
+  requestAnimationFrame(step);
+}
 const REPLAY = {
   select:    e => selectLink(e.link),
-  setJoint:  e => withJointOpSuppressed(() => {   // debounce off; we know the value
-    viewer.setJointValue(e.joint, e.value);
-    op('setJoint', { joint: e.joint, value: e.value });   // announce (not logged)
-  }),
-  resetPose: () => resetPose(),
+  setJoint:  e => tweenJoint(e.joint, e.value),
+  resetPose: () => { _cancelTweens(); resetPose(); },   // stop any in-flight glide first
   eye:       e => {
     if (hiddenLinks.has(e.link) === !!e.hide) { return; }   // already in target state
     toggleLinkVisible(e.link, jointRecForLink(e.link)?.row);  // pass the row so its UI updates
@@ -2003,32 +2083,90 @@ const REPLAY = {
   boxToggle: e => toggleBoxLink(e.name),
   undo:      () => doHistory('undo'),
   redo:      () => doHistory('redo'),
+  camera:    e => {                               // move the view to a keyframe
+    if (!e.pos || !e.tgt) { return; }
+    viewer.camera.position.set(e.pos[0], e.pos[1], e.pos[2]);
+    viewer.controls.target.set(e.tgt[0], e.tgt[1], e.tgt[2]);
+    viewer.controls.update();
+    viewer.redraw();
+  },
 };
-function replayCancel() { _replaying = false; }
+
+// ---- synthetic cursor: a fake pointer that glides to each action's on-screen
+// spot and pulses on click-like ops, so an automated replay reads as "someone
+// is operating it" rather than things happening by themselves. ---------------
+const CLICK_OPS = new Set(['select', 'eye', 'reRoot', 'add_port', 'remove_port',
+                           'boxToggle', 'setColor', 'setMaterial']);
+const _cursorV = new THREE.Vector3();
+const _cursorView = new THREE.Vector3();
+function _actionScreenPos(e) {
+  if (!viewer.robot || !viewer.camera) { return null; }
+  const obj = e.op === 'setJoint' ? viewer.robot.joints?.[e.joint]
+            : viewer.robot.links?.[e.link || e.child || e.name];
+  if (!obj) { return null; }
+  obj.getWorldPosition(_cursorV);
+  // reject points BEHIND the camera: the perspective divide would mirror them
+  // to a bogus on-screen spot (view space looks down -z, so front is z < 0)
+  _cursorView.copy(_cursorV).applyMatrix4(viewer.camera.matrixWorldInverse);
+  if (_cursorView.z >= 0) { return null; }
+  return _projToScreen(_cursorV, viewer.getBoundingClientRect());
+}
+function _showCursor(on) {
+  const c = document.getElementById('replaycursor');
+  if (c) { c.style.display = on ? 'block' : 'none'; }
+}
+function _moveCursor(x, y, click) {
+  const c = document.getElementById('replaycursor');
+  if (!c) { return; }
+  c.style.left = x + 'px'; c.style.top = y + 'px';
+  if (click) { c.classList.remove('click'); void c.offsetWidth; c.classList.add('click'); }
+}
+function replayCancel() { _cancelTweens(); _replaying = false; }   // stop eases where they are
 async function replayLog(entries, { speed = 1, maxGap = 1500 } = {}) {
   if (_replaying) { return; }                   // no re-entrancy
   if (!Array.isArray(entries) || !entries.length) {
     log(t('replay.empty'), 'wrn'); return;
   }
+  _cancelTweens();                              // drop any ease left over from a prior run
+  speed = speed > 0 ? speed : 1;               // guard against a 0 / negative speed
   _replaying = true;
   document.getElementById('replay')?.classList.add('active');
-  let done = 0, skipped = 0, prev = entries[0].t ?? 0;
+  _showCursor(true);
+  let done = 0, prev = entries[0].t ?? 0;
+  const skippedOps = new Set();                // distinct non-replayable op names
   try {
     for (const e of entries) {
       const wait = Math.min(maxGap, Math.max(0, (e.t ?? prev) - prev)) / speed;
       prev = e.t ?? prev;
+      const fn = REPLAY[e.op];
+      // only track the cursor for ops that actually replay (camera has no
+      // on-screen spot; a skipped op must NOT show a phantom click) -- start the
+      // glide NOW so the pointer arrives as the action fires
+      const pos = (fn && e.op !== 'camera') ? _actionScreenPos(e) : null;
+      if (pos) { _moveCursor(pos.x, pos.y, false); }
       if (wait) { await new Promise(r => setTimeout(r, wait)); }
       if (!_replaying) { break; }                // cancelled mid-run
-      const fn = REPLAY[e.op];
-      if (!fn) { skipped += 1; continue; }
+      if (pos && CLICK_OPS.has(e.op)) { _moveCursor(pos.x, pos.y, true); }  // click pulse
+      if (!fn) { skippedOps.add(e.op); continue; }
       try { fn(e); done += 1; }
       catch (err) { log(t('replay.stepFail', { op: e.op, e: err.message ?? err }), 'wrn'); }
+    }
+    // let the final ease(s) finish before resolving, so a caller that stops a
+    // screen recording on our promise captures the full motion (bounded so a
+    // stuck tween can't hang the await)
+    const drainUntil = performance.now() + 800;
+    while (_replaying && _activeTweens > 0 && performance.now() < drainUntil) {
+      await new Promise(r => setTimeout(r, 30));
     }
   } finally {
     _replaying = false;
     document.getElementById('replay')?.classList.remove('active');
+    _showCursor(false);
   }
-  log(t('replay.done', { done, skipped }), 'ok');
+  log(t('replay.done', { done, skipped: skippedOps.size }), 'ok');
+  // not just a count: name the actions we couldn't replay, so a "done" that
+  // silently dropped rename/exclude/add_port/... reads as the partial it is
+  if (skippedOps.size) { log(t('replay.partial', { ops: [...skippedOps].join(', ') }), 'wrn'); }
 }
 
 // ---- screen recording: capture the whole tab (all UI + the keycast overlay)
@@ -2060,7 +2198,8 @@ async function startScreenRecording() {
     const pkg = (currentInfo?.name || 'sw2robot').replace(/[^\w.-]+/g, '_');
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
-    a.href = url; a.download = `${pkg}-demo.webm`; a.click();
+    a.href = url; a.download = `${pkg}-demo.webm`;
+    document.body.appendChild(a); a.click(); a.remove();   // in-DOM click for Firefox
     URL.revokeObjectURL(url);
     log(t('rec.saved', { file: a.download, kb: Math.round(blob.size / 1024) }), 'ok');
   };
@@ -6612,6 +6751,7 @@ viewer.addEventListener('geometry-loaded', () => {
   hideLoadbar();
   document.getElementById('loadbackdrop').style.display = 'none';  // new model in
   log(t('mesh.allLoaded'), 'ok');
+  _cancelTweens();               // a replay ease must not keep driving the NEW robot
   const restore = pendingRestore;
   pendingRestore = null;
   requestAnimationFrame(() => {
@@ -6760,6 +6900,7 @@ function clearViewer() {
   document.title = 'sw2robot';
   statusEl.textContent = t('view.cleared');
   viewer.redraw();
+  _resetSessionLogs();           // emptied the viewer -> start a fresh recording
   log(t('view.cleared'), 'ok');
 }
 document.getElementById('clearview').addEventListener('click', clearViewer);
@@ -6767,6 +6908,9 @@ document.getElementById('clearview').addEventListener('click', clearViewer);
 // ---- loading entry points -----------------------------------------------
 function loadRobot(info, { drop = false, keepPose = false,
                            followCamera = false } = {}) {
+  // a keepPose reload is the SAME session (edit rebuild); anything else is a
+  // fresh package -> drop the old actions/camera so they can't replay onto it
+  if (!keepPose) { _resetSessionLogs(); }
   op('loadRobot', { name: info?.name, keepPose, drop });
   cancelEndcoords();        // a rebuild invalidates any open placement session
   document.getElementById('emptyprompt').style.display = 'none';
@@ -7329,7 +7473,8 @@ window.sw2robot = {
   actionLogText,                         // ③ readable log (for tests / tooling)
   exportLog: kind => downloadActionLog(kind),
   oplog: () => oplog.slice(),            // ② a copy of the raw action stream
-  replay: (entries, opts) => replayLog(entries ?? oplog.slice(), opts),
+  timeline: () => fullTimeline(),        // actions + camera keyframes, time-ordered
+  replay: (entries, opts) => replayLog(entries ?? fullTimeline(), opts),
   cancelReplay: replayCancel,
   record: () => startScreenRecording(),  // 🎥 screen recording (for tooling/tests)
   stopRecord: stopScreenRecording,
@@ -7360,7 +7505,7 @@ document.getElementById('savelog').addEventListener('click',
   e => downloadActionLog(e.shiftKey ? 'json' : 'txt'));
 document.getElementById('replay').addEventListener('click', e => {
   if (_replaying) { replayCancel(); return; }          // click again = stop
-  if (e.shiftKey) { replayLog(oplog.slice()); return; } // replay live session
+  if (e.shiftKey) { replayLog(fullTimeline()); return; } // replay live session
   document.getElementById('replayfile').click();        // else load a saved .json
 });
 document.getElementById('replayfile').addEventListener('change', async ev => {
@@ -7376,10 +7521,13 @@ document.getElementById('replayfile').addEventListener('change', async ev => {
 });
 document.getElementById('record').addEventListener('click', async e => {
   if (_rec) { stopScreenRecording(); return; }           // click again = stop
-  const wantReplay = e.shiftKey && oplog.length;
+  // Shift = auto-record a replay -- but only when one isn't already running,
+  // else replayLog() would return immediately (re-entrancy guard) and we'd
+  // stop the capture at once, saving an empty video
+  const wantReplay = e.shiftKey && !_replaying && (oplog.length || camlog.length);
   const started = await startScreenRecording();          // asks to share the tab
   if (started && wantReplay) {                            // Shift = record a replay
-    await replayLog(oplog.slice());
+    await replayLog(fullTimeline());
     stopScreenRecording();
   }
 });

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -595,6 +595,11 @@
       <button id="savelog" data-i18n-title="t.savelog"
               title="操作ログをダウンロード。クリック: .txt ・ Shift+クリック: .json">⤓
       </button>
+      <button id="replay" class="toggle" data-i18n-title="t.replay"
+              title="記録を再生。クリック: .json を読み込んで再生 ・ Shift+クリック: 現在のセッションを再生">▷
+      </button>
+      <input id="replayfile" type="file" accept=".json,application/json"
+             style="display:none">
     </div>
     <div id="autorow">
       <button id="autolimits" style="width:100%" data-i18n="ui.autolimits"
@@ -1405,6 +1410,12 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     't.savelog': { en: 'download the action log (what you did). Click: readable .txt · Shift+click: raw .json (for replay).',
                    ja: '操作ログ（何をしたか）をダウンロード。クリック: 読みやすい .txt ・ Shift+クリック: 生 .json（再生用）。' },
     'log.saved': { en: a => `⤓ saved ${a.file} (${a.n} actions)`, ja: a => `⤓ ${a.file} を保存しました（${a.n} 操作）` },
+    't.replay': { en: 'replay a recorded session. Click: load a saved .json and play it back · Shift+click: replay the current session. Click again to stop.',
+                  ja: '記録したセッションを再生。クリック: 保存した .json を読み込んで再生 ・ Shift+クリック: 現在のセッションを再生。もう一度クリックで停止。' },
+    'replay.empty': { en: 'replay: nothing to play', ja: '再生: 再生する操作がありません' },
+    'replay.done': { en: a => `▷ replay done (${a.done} played, ${a.skipped} skipped)`, ja: a => `▷ 再生完了（${a.done} 実行 / ${a.skipped} スキップ）` },
+    'replay.stepFail': { en: a => `▷ replay: ${a.op} failed: ${a.e}`, ja: a => `▷ 再生: ${a.op} 失敗: ${a.e}` },
+    'replay.badFile': { en: a => `▷ replay: could not read file: ${a.e}`, ja: a => `▷ 再生: ファイルを読めませんでした: ${a.e}` },
     't.autolimits': { en: 'sweep each rotary joint over ±2π(±360°) to the self-collision angle (coarse scan + binary search) and auto-set lower/upper. Joints free over the full ±2π become continuous. Ctrl+Z to undo.',
                       ja: '各回転関節を ±2π(±360°)の範囲で自己干渉が起きる角度まで掃引(粗スキャン+二分探索)して lower/upper を自動設定。±2π まで自由に回る関節は continuous に。Ctrl+Zで戻せます' },
     'ui.autolimits': { en: '🛠 auto joint limits (self-collision, ±2π)', ja: '🛠 自動関節リミット (自己干渉, ±2π)' },
@@ -1870,10 +1881,15 @@ let massOnlyLinks = new Set(); // links flagged mass-only (weight kept, no mesh)
 const oplog = [];
 const opSubs = [];               // live subscribers (keycast overlay, future recorders)
 function onOp(fn) { opSubs.push(fn); }   // subscribe to the semantic action stream
+let _replaying = false;          // true while replayLog() re-performs a session
 function op(name, args = {}) {
   const entry = { t: Math.round(performance.now()), op: name, ...args };
-  oplog.push(entry);
-  if (oplog.length > 400) { oplog.splice(0, 100); }
+  // while replaying we still light up the overlay, but we must NOT append the
+  // re-performed actions back into the log we're reading from.
+  if (!_replaying) {
+    oplog.push(entry);
+    if (oplog.length > 400) { oplog.splice(0, 100); }
+  }
   // notify live listeners; a bad subscriber must never break the action itself
   for (const fn of opSubs) { try { fn(entry); } catch { /* ignore */ } }
 }
@@ -1940,6 +1956,63 @@ function downloadActionLog(kind = 'txt') {
   document.body.appendChild(a); a.click(); a.remove();   // in-DOM click for Firefox
   URL.revokeObjectURL(url);
   log(t('log.saved', { file: a.download, n: oplog.length }), 'ok');
+}
+
+// ---- replay (②): re-perform a recorded op() stream, with the original
+// inter-action timing, driving the viewer -- so a recording plays itself back
+// (joints move, links select) for a demo video.  Only a SAFE, non-destructive
+// subset is replayable; anything else (rename/exclude/add_port/... which mutate
+// server state) is skipped with a log line.  Add an entry here to grow it. ----
+const REPLAY = {
+  select:    e => selectLink(e.link),
+  setJoint:  e => withJointOpSuppressed(() => {   // debounce off; we know the value
+    viewer.setJointValue(e.joint, e.value);
+    op('setJoint', { joint: e.joint, value: e.value });   // announce (not logged)
+  }),
+  resetPose: () => resetPose(),
+  eye:       e => {
+    if (hiddenLinks.has(e.link) === !!e.hide) { return; }   // already in target state
+    toggleLinkVisible(e.link, jointRecForLink(e.link)?.row);  // pass the row so its UI updates
+    if (e.link === selectedLink) {                           // keep the selbar eye in sync too
+      document.getElementById('seleye').classList.toggle('off', hiddenLinks.has(e.link));
+    }
+  },
+  boxSelect: e => {                                // reproduce the recorded set (not select-all)
+    clearBoxSelection();                           // (the recorded select(null) handles deselect)
+    for (const n of e.names ?? []) {
+      if (viewer.robot?.links?.[n]) { boxSelected.add(n); _tintLink(n, 'sel'); }
+    }
+    refreshBulkbar();
+  },
+  boxToggle: e => toggleBoxLink(e.name),
+  undo:      () => doHistory('undo'),
+  redo:      () => doHistory('redo'),
+};
+function replayCancel() { _replaying = false; }
+async function replayLog(entries, { speed = 1, maxGap = 1500 } = {}) {
+  if (_replaying) { return; }                   // no re-entrancy
+  if (!Array.isArray(entries) || !entries.length) {
+    log(t('replay.empty'), 'wrn'); return;
+  }
+  _replaying = true;
+  document.getElementById('replay')?.classList.add('active');
+  let done = 0, skipped = 0, prev = entries[0].t ?? 0;
+  try {
+    for (const e of entries) {
+      const wait = Math.min(maxGap, Math.max(0, (e.t ?? prev) - prev)) / speed;
+      prev = e.t ?? prev;
+      if (wait) { await new Promise(r => setTimeout(r, wait)); }
+      if (!_replaying) { break; }                // cancelled mid-run
+      const fn = REPLAY[e.op];
+      if (!fn) { skipped += 1; continue; }
+      try { fn(e); done += 1; }
+      catch (err) { log(t('replay.stepFail', { op: e.op, e: err.message ?? err }), 'wrn'); }
+    }
+  } finally {
+    _replaying = false;
+    document.getElementById('replay')?.classList.remove('active');
+  }
+  log(t('replay.done', { done, skipped }), 'ok');
 }
 
 async function refreshCompMeta() {
@@ -5964,7 +6037,7 @@ function selectLinksInBox(rect) {
     }
   }
   for (const n of boxSelected) { _tintLink(n, 'sel'); }
-  op('boxSelect', { n: boxSelected.size });
+  op('boxSelect', { n: boxSelected.size, names: [...boxSelected] });
   refreshBulkbar();
   log(boxSelected.size ? t('bulk.boxSelected', { n: boxSelected.size })
                        : t('bulk.boxNone'), boxSelected.size ? undefined : 'wrn');
@@ -7191,6 +7264,9 @@ window.sw2robot = {
   select: n => selectLink(n),
   actionLogText,                         // ③ readable log (for tests / tooling)
   exportLog: kind => downloadActionLog(kind),
+  oplog: () => oplog.slice(),            // ② a copy of the raw action stream
+  replay: (entries, opts) => replayLog(entries ?? oplog.slice(), opts),
+  cancelReplay: replayCancel,
   axisGlyphs: () => [...axisGlyphs.entries()].map(([name, g]) => ({
     name, visible: g.visible, children: g.children.length,
     inScene: !!g.parent })),
@@ -7215,6 +7291,22 @@ document.getElementById('bug').addEventListener('click',
   () => window.sw2robot.report());
 document.getElementById('savelog').addEventListener('click',
   e => downloadActionLog(e.shiftKey ? 'json' : 'txt'));
+document.getElementById('replay').addEventListener('click', e => {
+  if (_replaying) { replayCancel(); return; }          // click again = stop
+  if (e.shiftKey) { replayLog(oplog.slice()); return; } // replay live session
+  document.getElementById('replayfile').click();        // else load a saved .json
+});
+document.getElementById('replayfile').addEventListener('change', async ev => {
+  const file = ev.target.files?.[0];
+  ev.target.value = '';                                 // allow re-picking same file
+  if (!file) { return; }
+  try {
+    const entries = JSON.parse(await file.text());
+    replayLog(entries);
+  } catch (e) {
+    log(t('replay.badFile', { e: e.message ?? e }), 'err');
+  }
+});
 
 // re-render the dynamic (JS-built) UI in the new language when toggled.
 // data-i18n static chrome is handled by applyStaticI18n in the loader script.

--- a/tests/e2e/verify_jointrec.mjs
+++ b/tests/e2e/verify_jointrec.mjs
@@ -1,0 +1,86 @@
+// Focused check for step-2 joint-edit recording (drives the real slider DOM):
+//  - a user joint move emits exactly ONE op('setJoint') per settle (debounced)
+//  - the settled value is carried
+//  - the screencast overlay shows a "Joint … → …" keycap
+//  - reset-pose logs ONE op('resetPose'), not N stray setJoint ops
+//  - no page errors throughout
+import puppeteer from 'puppeteer-core';
+
+const BASE = process.argv[2] ?? 'http://localhost:8090';
+const URL = BASE + (BASE.includes('?') ? '&' : '?') + 'lang=ja';
+const CHROME = process.env.CHROME_PATH
+  ?? 'C:/Program Files/Google/Chrome/Application/chrome.exe';
+const EXTRA = (process.env.CHROME_ARGS ?? '').split(',').map(s => s.trim()).filter(Boolean);
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+let failures = 0;
+const check = (n, ok, d = '') => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${n}${d ? '  -- ' + d : ''}`);
+  if (!ok) failures++;
+};
+const countOp = (page, name) => page.evaluate(
+  n => window.sw2robot.dump().oplog.filter(o => o.op === n).length, name);
+
+const browser = await puppeteer.launch({
+  executablePath: CHROME, headless: 'new', args: ['--disable-gpu', ...EXTRA] });
+const page = await browser.newPage();
+const errs = [];
+page.on('pageerror', e => errs.push(e.message.split('\n')[0]));
+
+await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+await page.waitForFunction(() => window.sw2robot, { timeout: 60000 });
+await sleep(1500);
+
+// screencast overlay ON (exercise the op -> overlay path too)
+await page.click('#keycast');
+// move mode builds a slider per movable joint
+await page.click('#playmode');
+await sleep(300);
+const hasSlider = await page.evaluate(
+  () => !!document.querySelector('#playrows .prow input[type=range]'));
+check('setup: a movable-joint slider exists', hasSlider);
+
+// simulate a drag: many rapid 'input' events, then let it settle past debounce
+const before = await countOp(page, 'setJoint');
+await page.evaluate(() => {
+  const s = document.querySelector('#playrows .prow input[type=range]');
+  const hi = parseFloat(s.max), lo = parseFloat(s.min);
+  const target = lo + (hi - lo) * 0.7;
+  for (let i = 1; i <= 20; i++) {
+    s.value = String(lo + (target - lo) * i / 20);
+    s.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+  // the range input snaps to its step, so read the value it actually settled on
+  window.__settled = parseFloat(s.value);
+});
+await sleep(600);   // > 350 ms debounce
+
+const r = await page.evaluate(before1 => {
+  const sj = window.sw2robot.dump().oplog.filter(o => o.op === 'setJoint');
+  const caps = [...document.querySelectorAll('#keyoverlay .keycap')]
+    .map(c => c.firstChild.textContent);
+  return { delta: sj.length - before1, last: sj[sj.length - 1],
+           settled: window.__settled, caps };
+}, before);
+check('drag: exactly ONE setJoint op (debounced)', r.delta === 1, `delta=${r.delta}`);
+check('drag: settled value carried',
+      r.last && Math.abs(r.last.value - r.settled) < 1e-4,
+      `value=${r.last?.value} settled=${r.settled}`);
+check('drag: overlay shows a Joint keycap',
+      r.caps.some(c => /Joint .*→/.test(c)), JSON.stringify(r.caps));
+
+// reset-pose = ONE op('resetPose'), no stray programmatic setJoint ops
+const bReset = await countOp(page, 'resetPose');
+const bSet = await countOp(page, 'setJoint');
+await page.evaluate(() => document.getElementById('reset').click());
+await sleep(600);
+const aReset = await countOp(page, 'resetPose');
+const aSet = await countOp(page, 'setJoint');
+check('reset: one resetPose op', aReset - bReset === 1, `delta=${aReset - bReset}`);
+check('reset: no stray setJoint from the programmatic move',
+      aSet - bSet === 0, `delta=${aSet - bSet}`);
+
+check('no page errors', errs.length === 0, errs.join(' | '));
+
+await browser.close();
+console.log(failures ? `\n${failures} FAILURE(S)` : '\nALL PASS');
+process.exit(failures ? 1 : 0);

--- a/tests/e2e/verify_logexport.mjs
+++ b/tests/e2e/verify_logexport.mjs
@@ -1,0 +1,75 @@
+// Step-3 check: the action log exports as readable text and as raw JSON.
+//  - actionLogText() renders "+<sec>s  <label>" lines from the op() stream
+//  - a real action (select) shows up with its readable label
+//  - the ⤓ button downloads a .txt (click) and a .json (shift+click)
+//  - no page errors
+import puppeteer from 'puppeteer-core';
+
+const BASE = process.argv[2] ?? 'http://localhost:8090';
+const URL = BASE + (BASE.includes('?') ? '&' : '?') + 'lang=ja';
+const CHROME = process.env.CHROME_PATH
+  ?? 'C:/Program Files/Google/Chrome/Application/chrome.exe';
+const EXTRA = (process.env.CHROME_ARGS ?? '').split(',').map(s => s.trim()).filter(Boolean);
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+import os from 'node:os';
+import fs from 'node:fs';
+import path from 'node:path';
+let failures = 0;
+const check = (n, ok, d = '') => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${n}${d ? '  -- ' + d : ''}`);
+  if (!ok) failures++;
+};
+
+const browser = await puppeteer.launch({
+  executablePath: CHROME, headless: 'new', args: ['--disable-gpu', ...EXTRA] });
+const page = await browser.newPage();
+const errs = [];
+page.on('pageerror', e => errs.push(e.message.split('\n')[0]));
+
+// route downloads to a temp dir so we can assert the files land
+const dlDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sw2log-'));
+const client = await page.target().createCDPSession();
+await client.send('Page.setDownloadBehavior', { behavior: 'allow', downloadPath: dlDir });
+
+await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+await page.waitForFunction(() => window.sw2robot, { timeout: 60000 });
+await sleep(1500);
+
+// do a real, labelled action
+const link = await page.evaluate(() => {
+  const n = Object.keys(window.viewer.robot.links)[0];
+  window.sw2robot.select(n);
+  return n;
+});
+
+const txt = await page.evaluate(() => window.sw2robot.actionLogText());
+check('actionLogText: renders "+<sec>s  <label>" lines',
+      /\+\d+\.\d+s\s+\S/.test(txt), JSON.stringify(txt.split('\n')[0]));
+check('actionLogText: includes the select action with its label',
+      txt.includes('Select: ' + link), `link=${link}`);
+
+// ⤓ click -> .txt, shift+click -> .json
+await page.click('#savelog');
+await sleep(400);
+await page.keyboard.down('Shift');
+await page.click('#savelog');
+await page.keyboard.up('Shift');
+await sleep(400);
+const files = fs.readdirSync(dlDir).filter(f => !f.endsWith('.crdownload'));
+check('download: a .txt file landed', files.some(f => f.endsWith('-actions.txt')),
+      files.join(', '));
+check('download: a .json file landed', files.some(f => f.endsWith('-actions.json')),
+      files.join(', '));
+const jf = files.find(f => f.endsWith('.json'));
+if (jf) {
+  const parsed = JSON.parse(fs.readFileSync(path.join(dlDir, jf), 'utf8'));
+  check('download: .json is the raw oplog array', Array.isArray(parsed)
+        && parsed.some(o => o.op === 'select'), `entries=${parsed.length}`);
+}
+
+check('no page errors', errs.length === 0, errs.join(' | '));
+
+await browser.close();
+fs.rmSync(dlDir, { recursive: true, force: true });
+console.log(failures ? `\n${failures} FAILURE(S)` : '\nALL PASS');
+process.exit(failures ? 1 : 0);

--- a/tests/e2e/verify_record.mjs
+++ b/tests/e2e/verify_record.mjs
@@ -1,0 +1,113 @@
+// Video-recording check. getDisplayMedia is unavailable in headless Chrome, so
+// we stub it to return a canvas.captureStream(), exercising the real
+// MediaRecorder -> Blob path. We assert on the produced video Blob (via a
+// URL.createObjectURL hook) rather than the downloaded file, because Chrome
+// blocks *multiple* automatic downloads -- only the first would ever land on
+// disk. In real use each stop is a user click, so every download is allowed.
+//  - start -> isRecording() true, ⏺ button goes active
+//  - stop  -> a non-empty video/webm blob is produced
+//  - Shift+click auto-records a replay and stops itself, producing a 2nd blob
+//  - no page errors
+import puppeteer from 'puppeteer-core';
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+const BASE = process.argv[2] ?? 'http://localhost:8090';
+const URL = BASE + (BASE.includes('?') ? '&' : '?') + 'lang=ja';
+const CHROME = process.env.CHROME_PATH
+  ?? 'C:/Program Files/Google/Chrome/Application/chrome.exe';
+const EXTRA = (process.env.CHROME_ARGS ?? '').split(',').map(s => s.trim()).filter(Boolean);
+let failures = 0;
+const check = (n, ok, d = '') => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${n}${d ? '  -- ' + d : ''}`);
+  if (!ok) failures++;
+};
+// video blobs the page produced (size + type), captured via createObjectURL
+const videoBlobs = () => page.evaluate(() =>
+  (window.__blobs || []).filter(b => b.type.startsWith('video/')));
+
+const browser = await puppeteer.launch({
+  executablePath: CHROME, headless: 'new', args: ['--disable-gpu', ...EXTRA] });
+const page = await browser.newPage();
+const errs = [];
+page.on('pageerror', e => errs.push(e.message.split('\n')[0]));
+
+await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+await page.waitForFunction(() => window.sw2robot, { timeout: 60000 });
+await sleep(1500);
+
+// capture every Blob handed to createObjectURL (the .webm the recorder makes)
+await page.evaluate(() => {
+  window.__blobs = [];
+  const orig = URL.createObjectURL.bind(URL);
+  URL.createObjectURL = b => {
+    if (b instanceof Blob) { window.__blobs.push({ size: b.size, type: b.type }); }
+    return orig(b);
+  };
+});
+
+// stub getDisplayMedia. Each call gets its OWN freshly-animated canvas so a
+// second recording is not starved by the first stopping its capture track
+// (real getDisplayMedia always returns a fresh live stream; only the stub needs
+// this). The animation guarantees the MediaRecorder receives real frames.
+await page.evaluate(() => {
+  Object.defineProperty(navigator.mediaDevices, 'getDisplayMedia', {
+    configurable: true, writable: true,
+    value: async () => {
+      const cv = document.createElement('canvas');
+      cv.width = 320; cv.height = 240;
+      const ctx = cv.getContext('2d');
+      let f = 0;
+      cv.__on = true;
+      const draw = () => {
+        ctx.fillStyle = `hsl(${(f++ * 7) % 360},70%,50%)`;
+        ctx.fillRect(0, 0, 320, 240);
+        if (cv.__on) { requestAnimationFrame(draw); }
+      };
+      draw();
+      const stream = cv.captureStream(30);
+      stream.getVideoTracks()[0].addEventListener('ended', () => { cv.__on = false; });
+      return stream;
+    },
+  });
+});
+
+// ---- manual start / stop ---------------------------------------------------
+await page.click('#record');
+await sleep(300);
+const recActive = await page.evaluate(() => ({
+  rec: window.sw2robot.isRecording(),
+  active: document.getElementById('record').classList.contains('active'),
+}));
+check('record: start -> isRecording() true', recActive.rec);
+check('record: ⏺ button shows active state', recActive.active);
+
+// keep the canvas producing frames, then stop
+await sleep(700);
+await page.click('#record');
+await sleep(800);   // let onstop fire + the blob get built
+
+const v1 = await videoBlobs();
+check('record: a non-empty video/webm blob was produced',
+      v1.length === 1 && v1[0].size > 0, JSON.stringify(v1));
+check('record: isRecording() false after stop',
+      !(await page.evaluate(() => window.sw2robot.isRecording())));
+
+// ---- Shift+click = auto-record a replay (starts, replays, stops itself) -----
+await page.evaluate(() => { const n = Object.keys(window.viewer.robot.links)[0];
+  window.sw2robot.select(n); });                 // put one action in the log
+await page.keyboard.down('Shift');
+await page.click('#record');
+await page.keyboard.up('Shift');
+// replay clamps the load->select gap to maxGap (1500ms), then stops itself
+await sleep(3500);
+const v2 = await videoBlobs();
+check('record: Shift+click auto-records a replay and self-stops',
+      v2.length === 2 && v2[1].size > 0
+      && !(await page.evaluate(() => window.sw2robot.isRecording())),
+      `blobs=${v2.length} recording=${await page.evaluate(() => window.sw2robot.isRecording())}`);
+
+check('no page errors', errs.length === 0, errs.join(' | '));
+
+await browser.close();
+console.log(failures ? `\n${failures} FAILURE(S)` : '\nALL PASS');
+process.exit(failures ? 1 : 0);

--- a/tests/e2e/verify_replay.mjs
+++ b/tests/e2e/verify_replay.mjs
@@ -37,29 +37,40 @@ const plan = await page.evaluate(() => {
 check('setup: have a link and a movable joint', !!plan.link && !!plan.joint,
       JSON.stringify(plan));
 
-// craft a recorded stream with realistic timestamps + one unknown op
+// craft a recorded stream with realistic timestamps + one unknown op.
+// setJoint now EASES to its value over ~500ms, so leave a wide gap before
+// resetPose and sample on the plateau after the ease completes.
 const entries = [
-  { t: 0,   op: 'select',    link: plan.link },
-  { t: 120, op: 'setJoint',  joint: plan.joint, value: 0.3 },
-  { t: 240, op: 'rename',    kind: 'link', old: 'x', new: 'y' },  // destructive -> skip
-  { t: 360, op: 'resetPose', n: 1 },
+  { t: 0,    op: 'select',    link: plan.link },
+  { t: 60,   op: 'camera',    pos: [1.25, 2.5, 3.75], tgt: [0, 0, 0] },
+  { t: 120,  op: 'setJoint',  joint: plan.joint, value: 0.3 },
+  { t: 300,  op: 'rename',    kind: 'link', old: 'x', new: 'y' },  // destructive -> skip
+  { t: 1400, op: 'resetPose', n: 1 },
 ];
 
 // snapshot the log length; replay must not grow it
 const before = await page.evaluate(() => window.sw2robot.oplog().length);
 
-// replay at real speed; sample between setJoint (120ms) and resetPose (360ms)
+// replay at real speed; sample on the setJoint plateau (~800ms: after the
+// 120ms start + 500ms ease, before resetPose at 1400ms)
 // NB: block body so evaluate does not auto-await the replay promise
 await page.evaluate(e => { window.__rp = window.sw2robot.replay(e, { speed: 1 }); }, entries);
-await sleep(220);
+await sleep(820);
 const mid = await page.evaluate(j => ({
   selected: window.sw2robot.dump().selected,
   angle: Number(window.viewer.robot.joints[j].angle),
+  cam: window.viewer.camera.position.toArray(),
+  cursor: getComputedStyle(document.getElementById('replaycursor')).display,
 }), plan.joint);
 check('replay: select was dispatched', mid.selected === plan.link,
       `selected=${mid.selected}`);
-check('replay: setJoint drove the joint to 0.3', Math.abs(mid.angle - 0.3) < 1e-6,
+check('replay: setJoint eased the joint to 0.3', Math.abs(mid.angle - 0.3) < 1e-3,
       `angle=${mid.angle}`);
+check('replay: camera moved to the keyframe',
+      Math.hypot(mid.cam[0] - 1.25, mid.cam[1] - 2.5, mid.cam[2] - 3.75) < 1e-3,
+      `cam=${mid.cam.map(n => n.toFixed(2))}`);
+check('replay: synthetic cursor is visible while replaying', mid.cursor === 'block',
+      `display=${mid.cursor}`);
 
 await page.evaluate(() => window.__rp);   // wait for the run to finish
 await sleep(200);
@@ -73,6 +84,92 @@ check('replay: did NOT append to oplog', after.len === before,
       `before=${before} after=${after.len}`);
 check('replay: resetPose ran last (joint back to 0)', Math.abs(after.angle) < 1e-6,
       `angle=${after.angle}`);
+check('replay: synthetic cursor hidden after replay ends',
+      (await page.evaluate(() => getComputedStyle(
+        document.getElementById('replaycursor')).display)) === 'none');
+
+// ---- camera RECORDING: orbiting the view populates a camera track that
+// fullTimeline() interleaves with the actions (throttled ~10/s) ---------------
+const camRec = await page.evaluate(async () => {
+  const sleep = ms => new Promise(r => setTimeout(r, ms));
+  const before = window.sw2robot.timeline().filter(e => e.op === 'camera').length;
+  for (let i = 1; i <= 4; i++) {                 // move + fire 'change', spaced past throttle
+    window.viewer.camera.position.set(i, i, i);
+    window.viewer.controls.dispatchEvent({ type: 'change' });
+    await sleep(130);
+  }
+  const tl = window.sw2robot.timeline();
+  return { added: tl.filter(e => e.op === 'camera').length - before,
+           ordered: tl.every((e, i) => i === 0 || (e.t ?? 0) >= (tl[i - 1].t ?? 0)),
+           sample: tl.find(e => e.op === 'camera') };
+});
+check('camera-record: orbiting adds camera keyframes', camRec.added >= 3,
+      `added=${camRec.added}`);
+check('camera-record: keyframe has pos+tgt',
+      Array.isArray(camRec.sample?.pos) && Array.isArray(camRec.sample?.tgt));
+check('camera-record: timeline stays time-ordered', camRec.ordered);
+
+// ---- fix #1 + #1b: a replay ENDING on a setJoint reaches its target, AND the
+// promise only resolves once the ease has settled -- so a caller that stops a
+// recording on `await replayLog()` captures the full glide (no truncation) ----
+await page.evaluate(j => { window.viewer.setJointValue(j, 0); }, plan.joint);
+const atResolve = await page.evaluate(async j => {
+  await window.sw2robot.replay([{ t: 0, op: 'setJoint', joint: j, value: 0.6 }], { speed: 1 });
+  return Number(window.viewer.robot.joints[j].angle);   // sampled the instant the await returns
+}, plan.joint);
+check('fix#1b: replayLog resolves only after the ease settles (video not truncated)',
+      Math.abs(atResolve - 0.6) < 1e-3, `angleAtResolve=${atResolve}`);
+
+// ---- fix #2: boxSelect replays the RECORDED subset, not "everything on screen"
+const box = await page.evaluate(() => {
+  const links = Object.keys(window.viewer.robot.links);
+  const subset = links.slice(0, 1);              // pretend the user box-picked just one
+  window.__boxentry = { t: 0, op: 'boxSelect', n: subset.length, names: subset };
+  return { total: links.length, subset };
+});
+await page.evaluate(() => window.sw2robot.replay([window.__boxentry], { speed: 1 }));
+await sleep(200);
+const boxSel = await page.evaluate(() => window.sw2robot.boxSelected());
+check('fix#2: boxSelect replays the recorded subset, not select-all',
+      boxSel.length === box.subset.length && boxSel[0] === box.subset[0],
+      `selected=${JSON.stringify(boxSel)} (of ${box.total})`);
+
+// ---- fix #4: a skipped (non-replayable) op must NOT fire a cursor click-pulse
+const phantom = await page.evaluate(async () => {
+  const sleep = ms => new Promise(r => setTimeout(r, ms));
+  const link = Object.keys(window.viewer.robot.links)[0];
+  let pulsed = false;
+  document.getElementById('replaycursor').classList.remove('click');  // clear stale pulse
+  // reRoot is in CLICK_OPS but NOT in REPLAY -> should be skipped with no pulse
+  window.sw2robot.replay([{ t: 0, op: 'reRoot', link }], { speed: 1 });
+  for (let i = 0; i < 8; i++) {
+    if (document.getElementById('replaycursor').classList.contains('click')) { pulsed = true; }
+    await sleep(40);
+  }
+  return pulsed;
+});
+check('fix#4: skipped op does not show a phantom cursor click', phantom === false);
+
+// ---- fix #8: a non-replayable op makes replay report a PARTIAL run by name
+const partialLog = await page.evaluate(async () => {
+  const sleep = ms => new Promise(r => setTimeout(r, ms));
+  const link = Object.keys(window.viewer.robot.links)[0];
+  window.sw2robot.replay([{ t: 0, op: 'select', link },
+                          { t: 50, op: 'exclude', body: 'x' }], { speed: 1 });   // exclude not replayable
+  await sleep(300);
+  return [...document.querySelectorAll('#log div')].map(d => d.textContent).join('\n');
+});
+check('fix#8: partial replay is reported with the skipped op name',
+      /部分的|partial/.test(partialLog) && /exclude/.test(partialLog));
+
+// ---- fix #5: clearing the viewer (fresh session) drops the action + camera logs
+const beforeClear = await page.evaluate(() => window.sw2robot.timeline().length);
+const afterClear = await page.evaluate(() => {
+  document.getElementById('clearview').click();     // empties the viewer
+  return window.sw2robot.timeline().length;
+});
+check('fix#5: clearing the viewer resets the session logs',
+      beforeClear > 0 && afterClear === 0, `before=${beforeClear} after=${afterClear}`);
 
 check('no page errors', errs.length === 0, errs.join(' | '));
 

--- a/tests/e2e/verify_replay.mjs
+++ b/tests/e2e/verify_replay.mjs
@@ -1,0 +1,81 @@
+// Step-2 check: replay re-performs a recorded op() stream on the viewer.
+//  - select + setJoint + resetPose dispatch and actually change viewer state
+//  - replay does NOT append the re-performed actions back into oplog
+//  - an unknown/destructive op is skipped, not fatal
+//  - no page errors
+import puppeteer from 'puppeteer-core';
+
+const BASE = process.argv[2] ?? 'http://localhost:8090';
+const URL = BASE + (BASE.includes('?') ? '&' : '?') + 'lang=ja';
+const CHROME = process.env.CHROME_PATH
+  ?? 'C:/Program Files/Google/Chrome/Application/chrome.exe';
+const EXTRA = (process.env.CHROME_ARGS ?? '').split(',').map(s => s.trim()).filter(Boolean);
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+let failures = 0;
+const check = (n, ok, d = '') => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${n}${d ? '  -- ' + d : ''}`);
+  if (!ok) failures++;
+};
+
+const browser = await puppeteer.launch({
+  executablePath: CHROME, headless: 'new', args: ['--disable-gpu', ...EXTRA] });
+const page = await browser.newPage();
+const errs = [];
+page.on('pageerror', e => errs.push(e.message.split('\n')[0]));
+
+await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+await page.waitForFunction(() => window.sw2robot, { timeout: 60000 });
+await sleep(1500);
+
+// pick a link (not the current selection) and a movable joint + target angle
+const plan = await page.evaluate(() => {
+  const links = Object.keys(window.viewer.robot.links);
+  const j = Object.values(window.viewer.robot.joints)
+    .find(x => x.jointType !== 'fixed' && !x.mimicJoint);
+  return { link: links[links.length - 1], joint: j?.name ?? null };
+});
+check('setup: have a link and a movable joint', !!plan.link && !!plan.joint,
+      JSON.stringify(plan));
+
+// craft a recorded stream with realistic timestamps + one unknown op
+const entries = [
+  { t: 0,   op: 'select',    link: plan.link },
+  { t: 120, op: 'setJoint',  joint: plan.joint, value: 0.3 },
+  { t: 240, op: 'rename',    kind: 'link', old: 'x', new: 'y' },  // destructive -> skip
+  { t: 360, op: 'resetPose', n: 1 },
+];
+
+// snapshot the log length; replay must not grow it
+const before = await page.evaluate(() => window.sw2robot.oplog().length);
+
+// replay at real speed; sample between setJoint (120ms) and resetPose (360ms)
+// NB: block body so evaluate does not auto-await the replay promise
+await page.evaluate(e => { window.__rp = window.sw2robot.replay(e, { speed: 1 }); }, entries);
+await sleep(220);
+const mid = await page.evaluate(j => ({
+  selected: window.sw2robot.dump().selected,
+  angle: Number(window.viewer.robot.joints[j].angle),
+}), plan.joint);
+check('replay: select was dispatched', mid.selected === plan.link,
+      `selected=${mid.selected}`);
+check('replay: setJoint drove the joint to 0.3', Math.abs(mid.angle - 0.3) < 1e-6,
+      `angle=${mid.angle}`);
+
+await page.evaluate(() => window.__rp);   // wait for the run to finish
+await sleep(200);
+const after = await page.evaluate(() => ({
+  len: window.sw2robot.oplog().length,
+  angle: Number(window.viewer.robot.joints[
+    Object.values(window.viewer.robot.joints)
+      .find(x => x.jointType !== 'fixed' && !x.mimicJoint).name].angle),
+}));
+check('replay: did NOT append to oplog', after.len === before,
+      `before=${before} after=${after.len}`);
+check('replay: resetPose ran last (joint back to 0)', Math.abs(after.angle) < 1e-6,
+      `angle=${after.angle}`);
+
+check('no page errors', errs.length === 0, errs.join(' | '));
+
+await browser.close();
+console.log(failures ? `\n${failures} FAILURE(S)` : '\nALL PASS');
+process.exit(failures ? 1 : 0);


### PR DESCRIPTION
## Summary

Adds a self-contained action recorder to the web editor, built on the existing semantic `op()` action stream, so an editing session can be shown on screen, exported, replayed, and recorded to video — handy for demos, tutorials, and bug reports.


https://github.com/user-attachments/assets/ae5ea7f3-2da9-417b-bc2d-fe1c32f1e170



Five pieces, all layered on one shared vocabulary:

- **Keycast overlay** now reads the semantic `op()` action stream instead of raw `mousedown`/`wheel` events. View navigation (orbit / pan / zoom, right-click) no longer clutters it — navigation never calls `op()`, so it can't appear — while real actions show a readable label (`Select: base_link`, `Make root: …`). Keyboard is still shown raw, since a keypress is almost always intentional. Joint drags are recorded as a single `op('setJoint')` per settle (debounced on `angle-change`); programmatic moves (pose restore on reload, snap-to-rest on a type flip, reset-pose) are suppressed so they don't log as hand edits.
- **Action-log export** (`⤓` button): a human-readable `.txt` (`+12.3s  Select: base_link`) on click, or the raw `.json` on Shift+click (which replay reads back).
- **Session replay** (`▷` button): re-performs the recorded stream with its original inter-action timing, driving the viewer — joints move, links select, the view pans — so a recording plays itself back. Click loads a saved `.json`; Shift+click replays the current session; clicking again stops. A safe, non-destructive subset is replayable; anything that mutates server state (rename / exclude / add-port / …) is skipped, and the skipped actions are named so a partial replay isn't silent.
- **One-click screen recording** (`⏺` button): captures the whole tab (all UI + the keycast overlay) to a `.webm` via `getDisplayMedia` + `MediaRecorder`. The browser asks to share the tab once; after that it is hands-off. Shift+click auto-records a replay of the current session end to end (start → replay → stop → save), so a demo video falls out of a saved session with no manual narration.
- **Hand-operated replay**: eased joint tweens (glide to target instead of snapping), a separate throttled camera track (recorded and replayed so the view moves the way it moved during recording), and a synthetic cursor that glides to each action's on-screen spot and pulses on clicks — so an automated replay reads as someone operating the tool rather than things happening by themselves.

## Design notes

- Everything routes through one label vocabulary (`OP_LABEL`) and one dispatch table (`REPLAY`), so a newly instrumented action shows up in the overlay and log for free.
- The camera track is stored separately from the action log, so it never adds overlay noise; the two are merged by timestamp only for replay/export.
- Loading a different package (or clearing the viewer) resets the session logs, so a replay/export can't reference a robot that no longer exists.
- Screen recording uses the browser's native tab capture (Chrome/Chromium); a clear message is shown if `getDisplayMedia`/`MediaRecorder` is unavailable.

## Testing

New headless (puppeteer) end-to-end coverage under `tests/e2e/`:

- `verify_jointrec.mjs` — a drag records exactly one debounced `setJoint` carrying the settled value; overlay label; reset-pose collapses to a single op.
- `verify_logexport.mjs` — readable `.txt` and raw `.json` both download; JSON is the raw stream.
- `verify_replay.mjs` — select / setJoint / camera / cursor dispatch and change viewer state; the eased final pose is reached and the replay promise only resolves once the ease settles; replay doesn't grow the log; clearing the viewer resets the session; a non-replayable op reports a partial run by name.
- `verify_record.mjs` — start/stop produces a non-empty `video/webm` blob; Shift+click auto-records a replay and self-stops.

All pass; the existing smoke suite is unaffected.
