### PR TITLE
Export a single .SLDPRT as a 1-link URDF, filter the browser by file type

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,21 @@ report "not available" until it is installed.
 python -m sw2robot.exporter.export path/to/assembly.sldasm -o output
 ```
 
+**Or a single `.sldprt` -> URDF.** Point the exact same command (or the editor's
+🗄 file browser / 📋 path bar) at a lone part instead of an assembly:
+
+```bash
+python -m sw2robot.exporter.export path/to/part.sldprt -o output
+```
+
+A single part has no mates to infer a kinematic tree from, so this yields a
+trivial **1-link, 0-joint URDF** — one rigid body with the part's mesh and its
+**SolidWorks-native mass / centre-of-mass / inertia tensor** (exact CAD geometry
++ material, not a mesh estimate). Handy for a static prop, an environment
+object, or a single end-effector/sensor body you want in a simulator with an
+accurate inertial. It will not turn a multibody part into a jointed robot — that
+needs an assembly with mates.
+
 **Open the browser editor** on an already-extracted package (no SolidWorks
 needed — a sample is included):
 

--- a/sw2robot/editor/core.py
+++ b/sw2robot/editor/core.py
@@ -263,10 +263,11 @@ def sw_session_status() -> dict:
 
 
 def sw_recent_assemblies(limit: int = 10) -> list:
-    """Best-effort list of recently-opened ``.sldasm`` paths from the SolidWorks
-    MRU registry key, newest first -- used only to pre-fill the import path
-    field (an approximation of "the assembly you have open").  Returns ``[]`` on
-    any failure (non-Windows, no SolidWorks, key absent)."""
+    """Best-effort list of recently-opened ``.sldasm``/``.sldprt`` paths from the
+    SolidWorks MRU registry key, newest first -- used only to pre-fill / suggest
+    an import path (an approximation of "the CAD file you have open").  Single
+    parts are included because a lone ``.SLDPRT`` exports as a 1-link URDF too.
+    Returns ``[]`` on any failure (non-Windows, no SolidWorks, key absent)."""
     try:
         import winreg
     except ImportError:
@@ -289,8 +290,8 @@ def sw_recent_assemblies(limit: int = 10) -> list:
         return []
     # Newest SolidWorks version first (e.g. "SOLIDWORKS 2025" > "2024").  The MRU
     # lives under "<ver>\Recent File List" as values File1, File2, ... (full
-    # paths, parts AND assemblies mixed); keep the .sldasm ones in File-number
-    # order so File1 (most-recently-opened) is first.
+    # paths, parts AND assemblies mixed); keep the .sldasm/.sldprt ones in
+    # File-number order so File1 (most-recently-opened) is first.
     for ver in sorted(versions, reverse=True):
         sub = rf"{base}\{ver}\Recent File List"
         items = []
@@ -303,7 +304,8 @@ def sw_recent_assemblies(limit: int = 10) -> list:
                     except OSError:
                         break
                     j += 1
-                    if isinstance(val, str) and val.lower().endswith(".sldasm"):
+                    if isinstance(val, str) and val.lower().endswith(
+                            (".sldasm", ".sldprt")):
                         items.append((vname, val))
         except OSError:
             continue

--- a/sw2robot/editor/ui.py
+++ b/sw2robot/editor/ui.py
@@ -949,8 +949,8 @@ def _pick_sldasm(initial=""):
             if os.path.isfile(initial):
                 kw["initialfile"] = os.path.basename(initial)
         path = filedialog.askopenfilename(
-            title="Select a SolidWorks assembly",
-            filetypes=[("SolidWorks assembly", "*.sldasm"),
+            title="Select a SolidWorks assembly or part",
+            filetypes=[("SolidWorks assembly / part", "*.sldasm *.sldprt"),
                        ("All files", "*.*")], **kw)
         root.destroy()
         return path or ""

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -499,6 +499,21 @@
              style="font-size:11px;color:#cdd;background:#0e1216;
              border:1px solid #345;border-radius:4px;padding:4px 6px;
              margin-bottom:6px">
+      <div style="display:flex;gap:14px;align-items:center;margin-bottom:6px;
+                  font-size:11px;color:#9ab;user-select:none">
+        <label style="display:flex;gap:3px;align-items:center;cursor:pointer">
+          <input type="checkbox" id="fstype-sldasm" checked>
+          <span data-fsicon="sldasm" style="display:inline-flex"></span>
+          <span data-i18n="t.fsTypeAsm">.sldasm (assembly)</span></label>
+        <label style="display:flex;gap:3px;align-items:center;cursor:pointer">
+          <input type="checkbox" id="fstype-sldprt">
+          <span data-fsicon="sldprt" style="display:inline-flex"></span>
+          <span data-i18n="t.fsTypePrt">.sldprt (part)</span></label>
+        <label style="display:flex;gap:3px;align-items:center;cursor:pointer">
+          <input type="checkbox" id="fstype-urdf" checked>
+          <span data-fsicon="urdf" style="display:inline-flex"></span>
+          <span data-i18n="t.fsTypeUrdf">.urdf</span></label>
+      </div>
       <div id="fslist" style="overflow-y:auto;font-size:12.5px"></div>
     </div>
     <div id="loadbackdrop" style="position:absolute;inset:0;z-index:6;
@@ -1422,6 +1437,9 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     't.fspathPh': { en: 'paste / edit a full path, then Enter', ja: 'フルパスを貼り付け / 編集して Enter' },
     't.fsgo': { en: 'open / go to this path', ja: 'このパスを開く / 移動' },
     't.fsfilterPh': { en: 'filter this folder…', ja: 'このフォルダ内を絞り込み…' },
+    't.fsTypeAsm': { en: '.sldasm (assembly)', ja: '.sldasm（アセンブリ）' },
+    't.fsTypePrt': { en: '.sldprt (part)', ja: '.sldprt（単一パーツ）' },
+    't.fsTypeUrdf': { en: '.urdf', ja: '.urdf' },
     'ui.reset': { en: 'Reset pose (0)', ja: '姿勢リセット (0)' },
     'ui.resetview': { en: '↺ Reset view', ja: '↺ リセット' },
     't.resetview': { en: 'back to the just-loaded state: neutral pose, default camera, nothing selected, all tools closed (c)',
@@ -7223,7 +7241,9 @@ async function extractFlow(p) {
 }
 
 function openAny(p) {
-  if (p.toLowerCase().endsWith('.sldasm')) { extractFlow(p); }
+  // a .SLDASM assembly OR a single .SLDPRT part goes through SolidWorks extract
+  // (a lone part becomes a 1-link URDF); a package/.urdf just loads
+  if (/\.(sldasm|sldprt)$/i.test(p)) { extractFlow(p); }
   else { openServerPath(p); }
 }
 // ---- 📁 server-side file browser (the OS dialog can't give us a path) ---
@@ -7231,6 +7251,38 @@ const fsmodal = document.getElementById('fsmodal');
 let fsCur = '';
 
 const FS_LAST_DIR_KEY = 'sw2robot.fsdir';
+
+// File-type marks for the browser rows + the filter checkboxes.  These are our
+// OWN inline SVG glyphs -- NOT Dassault's proprietary SolidWorks icons -- that
+// borrow only the familiar colour coding (green = part, red = assembly) so a
+// row's type reads at a glance.  Inline (no external request) => CSP-safe.
+const FS_ICON = {
+  // a green isometric cube = a single part
+  sldprt: '<svg width="13" height="13" viewBox="0 0 24 25" aria-hidden="true" '
+        + 'style="vertical-align:-2px;flex:none">'
+        + '<polygon points="12,2 21,7 12,12 3,7" fill="#8ccf8c"/>'
+        + '<polygon points="3,7 3,17 12,22 12,12" fill="#4ea24e"/>'
+        + '<polygon points="21,7 21,17 12,22 12,12" fill="#3c7d3c"/></svg>',
+  // two red cubes = an assembly of parts
+  sldasm: '<svg width="14" height="14" viewBox="0 0 26 27" aria-hidden="true" '
+        + 'style="vertical-align:-2px;flex:none">'
+        + '<polygon points="16,2 23,6 16,10 9,6" fill="#eba49c"/>'
+        + '<polygon points="9,6 9,14 16,18 16,10" fill="#c9564b"/>'
+        + '<polygon points="23,6 23,14 16,18 16,10" fill="#aa4238"/>'
+        + '<polygon points="9,9 16,13 9,17 2,13" fill="#f2b0a8"/>'
+        + '<polygon points="2,13 2,21 9,25 9,17" fill="#d75f53"/>'
+        + '<polygon points="16,13 16,21 9,25 9,17" fill="#b8493f"/></svg>',
+  // a blue robot head = a URDF (robot definition); blue is the natural third
+  // colour next to the green part / red assembly (and SolidWorks' drawing hue)
+  urdf: '<svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true" '
+      + 'style="vertical-align:-2px;flex:none">'
+      + '<circle cx="12" cy="2.7" r="1.5" fill="#8fb0e8"/>'
+      + '<rect x="11.3" y="3.4" width="1.4" height="3" fill="#8fb0e8"/>'
+      + '<rect x="3.5" y="6" width="17" height="13.5" rx="3.2" fill="#4f7fd0"/>'
+      + '<rect x="7" y="10.4" width="3.3" height="3.3" rx="1" fill="#eaf1ff"/>'
+      + '<rect x="13.7" y="10.4" width="3.3" height="3.3" rx="1" fill="#eaf1ff"/>'
+      + '<rect x="8.5" y="15.6" width="7" height="1.6" rx="0.8" fill="#bcd2f5"/></svg>',
+};
 
 async function fsShow(path) {
   const r = await (await fetch(
@@ -7246,7 +7298,13 @@ async function fsShow(path) {
   list.innerHTML = '';
   const row = (icon, name, cb, hint) => {
     const d = document.createElement('div');
-    d.textContent = `${icon} ${name}${hint ? '   ' + hint : ''}`;
+    // icon is one of OUR constants (emoji or inline SVG) -> innerHTML is safe;
+    // the file NAME is untrusted, so it goes in as a text node (never HTML)
+    const ic = document.createElement('span');
+    ic.style.cssText = 'display:inline-block;margin-right:4px';
+    ic.innerHTML = icon;
+    d.append(ic, document.createTextNode(
+      `${name}${hint ? '   ' + hint : ''}`));
     d.dataset.fsname = String(name).toLowerCase();
     d.style.cssText = 'padding:3px 6px;border-radius:3px;cursor:pointer;' +
                       'white-space:nowrap;overflow:hidden;' +
@@ -7255,6 +7313,14 @@ async function fsShow(path) {
     d.addEventListener('mouseleave', () => d.style.background = '');
     d.addEventListener('click', cb);
     list.appendChild(d);
+    return d;
+  };
+  // tag an input file row with its type so the .sldasm/.sldprt/.urdf checkboxes
+  // can filter it (untagged rows -- folders, packages -- stay always shown)
+  const tagCad = (d, name) => {
+    const m = /\.(sldasm|sldprt|urdf)$/i.exec(name);
+    if (m) { d.dataset.fstype = m[1].toLowerCase(); }
+    return d;
   };
   if (!r.path) {           // root view: recent SolidWorks files + built packages
     const [recent, pkgs] = await Promise.all([
@@ -7262,8 +7328,8 @@ async function fsShow(path) {
       fetch('/api/list').then(x => x.json()).catch(() => [])]);
     for (const p of (recent || []).slice(0, 10)) {
       const nm = p.split(/[\\/]/).pop();
-      row('⭐', nm, () => { fsmodal.style.display = 'none'; openAny(p); },
-          t('fs.recentHint'));
+      tagCad(row('⭐', nm, () => { fsmodal.style.display = 'none'; openAny(p); },
+                 t('fs.recentHint')), nm);
     }
     for (const pk of (pkgs || []).slice(0, 10)) {
       row('⭐📦', pk.name, () => { fsmodal.style.display = 'none';
@@ -7281,30 +7347,46 @@ async function fsShow(path) {
     }
   }
   for (const f of r.files) {
-    row(f.name.toLowerCase().endsWith('.sldasm') ? '🔧' : '🤖', f.name,
-        () => { fsmodal.style.display = 'none'; openAny(f.path); });
+    const lc = f.name.toLowerCase();
+    const icon = lc.endsWith('.sldasm') ? FS_ICON.sldasm
+               : lc.endsWith('.sldprt') ? FS_ICON.sldprt : FS_ICON.urdf;
+    tagCad(row(icon, f.name,
+               () => { fsmodal.style.display = 'none'; openAny(f.path); }),
+           f.name);
   }
   if (!r.dirs.length && !r.files.length) {
     row('·', t('fs.empty'), () => {});
   }
+  fsFilter();              // apply the .sldasm/.sldprt checkboxes (sldprt off by default)
   fsmodal.style.display = 'flex';
 }
 
-// type-to-narrow the current listing (hide non-matching rows)
+// narrow the current listing: the text box AND the .sldasm/.sldprt/.urdf
+// checkboxes.  Rows with no fstype (folders, packages) are never hidden by the
+// checkboxes; only input file rows are.
 function fsFilter() {
   const q = document.getElementById('fsfilter').value.trim().toLowerCase();
+  const showAsm = document.getElementById('fstype-sldasm').checked;
+  const showPrt = document.getElementById('fstype-sldprt').checked;
+  const showUrdf = document.getElementById('fstype-urdf').checked;
   for (const d of document.querySelectorAll('#fslist > div')) {
-    d.style.display = (!q || (d.dataset.fsname || '').includes(q)) ? '' : 'none';
+    const ty = d.dataset.fstype;
+    const typeOk = ty === 'sldasm' ? showAsm
+                 : ty === 'sldprt' ? showPrt
+                 : ty === 'urdf' ? showUrdf : true;
+    const textOk = !q || (d.dataset.fsname || '').includes(q);
+    d.style.display = (typeOk && textOk) ? '' : 'none';
   }
 }
 
-// the path bar IS the old 📋: paste/edit a full path + Enter -> a .sldasm/.urdf
-// is opened/extracted, anything else is treated as a directory to navigate to.
+// the path bar IS the old 📋: paste/edit a full path + Enter -> a
+// .sldasm/.sldprt/.urdf is opened/extracted, anything else is treated as a
+// directory to navigate to.
 // Windows "Copy as path" wraps the path in quotes -- strip them.
 function fsGo() {
   const p = document.getElementById('fspath').value.trim().replace(/^"+|"+$/g, '');
   if (!p) { return; }
-  if (/\.(sldasm|urdf)$/i.test(p)) { fsmodal.style.display = 'none'; openAny(p); }
+  if (/\.(sldasm|sldprt|urdf)$/i.test(p)) { fsmodal.style.display = 'none'; openAny(p); }
   else { fsShow(p); }
 }
 
@@ -7355,6 +7437,40 @@ document.getElementById('fsclose').addEventListener('click',
   () => { fsmodal.style.display = 'none'; });
 document.getElementById('fsup').addEventListener('click', ev =>
   fsShow(ev.target.dataset.parent || ''));
+
+// .sldasm / .sldprt / .urdf type filter: .sldprt is OFF by default (its HTML
+// checkbox is unchecked), the other two ON; a user's choice persists across
+// sessions in localStorage.
+(function () {
+  // paint the checkbox marks from the same SVG constants the rows use
+  for (const el of document.querySelectorAll('#fsmodal [data-fsicon]')) {
+    el.innerHTML = FS_ICON[el.dataset.fsicon] || '';
+  }
+  const asm = document.getElementById('fstype-sldasm');
+  const prt = document.getElementById('fstype-sldprt');
+  const urdf = document.getElementById('fstype-urdf');
+  const K_ASM = 'sw2robot.fs.showSldasm', K_PRT = 'sw2robot.fs.showSldprt',
+        K_URDF = 'sw2robot.fs.showUrdf';
+  try {
+    const a = localStorage.getItem(K_ASM);
+    const p = localStorage.getItem(K_PRT);
+    const u = localStorage.getItem(K_URDF);
+    if (a !== null) { asm.checked = a === '1'; }
+    if (p !== null) { prt.checked = p === '1'; }
+    if (u !== null) { urdf.checked = u === '1'; }
+  } catch { /**/ }
+  const onChange = () => {
+    try {
+      localStorage.setItem(K_ASM, asm.checked ? '1' : '0');
+      localStorage.setItem(K_PRT, prt.checked ? '1' : '0');
+      localStorage.setItem(K_URDF, urdf.checked ? '1' : '0');
+    } catch { /**/ }
+    fsFilter();
+  };
+  asm.addEventListener('change', onChange);
+  prt.addEventListener('change', onChange);
+  urdf.addEventListener('change', onChange);
+})();
 
 // ---- resizable right panel (link names get long; let the user widen it) ---
 (function () {

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -2367,7 +2367,7 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                             pkg = os.path.isdir(os.path.join(full, "urdf"))
                             dirs.append({"name": e, "path": full,
                                          "package": pkg})
-                        elif e.lower().endswith((".sldasm", ".urdf")):
+                        elif e.lower().endswith((".sldasm", ".sldprt", ".urdf")):
                             files.append({"name": e, "path": full})
                 except OSError as e:
                     return self._send_json({"error": str(e)}, 400)
@@ -2523,9 +2523,9 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 target = os.path.abspath(os.path.expanduser(
                     target.strip().strip('"')))
                 if not (os.path.isfile(target)
-                        and target.lower().endswith(".sldasm")):
+                        and target.lower().endswith((".sldasm", ".sldprt"))):
                     return self._send_json(
-                        {"error": f"not a .sldasm file: {target}"}, 400)
+                        {"error": f"not a .sldasm/.sldprt file: {target}"}, 400)
                 if not _prog_start("extract", _EXTRACT_STAGES):
                     return self._send_json(
                         {"error": "a job is already running"}, 409)

--- a/sw2robot/exporter/export.py
+++ b/sw2robot/exporter/export.py
@@ -1,4 +1,4 @@
-"""SolidWorks assembly -> URDF/ROS package, split into two phases.
+"""SolidWorks assembly (or single part) -> URDF/ROS package, split into two phases.
 
   extract  (SLOW, needs SolidWorks): open a throwaway copy, pull the CAD graph
            + per-link coloured 3DXML meshes, write ``graph.json``.  Run once.
@@ -10,6 +10,11 @@
     uv run python -m sw2robot.exporter.export  <assembly.sldasm> [-o OUT] [-n NAME]
     uv run python -m sw2robot.exporter.extract <assembly.sldasm> [-o OUT] [-n NAME]
     uv run python -m sw2robot.exporter.build   <pkg_dir> [--config c.yaml] [--base ..] [--exclude ..]
+
+A single ``.SLDPRT`` is also accepted anywhere a ``.SLDASM`` is: a lone part has
+no mates to infer a kinematic tree from, so it yields a trivial 1-link, 0-joint
+URDF carrying the part's SolidWorks-native mass/COM/inertia -- handy for a static
+prop / environment object / single rigid body in a simulator.
 """
 
 from __future__ import annotations
@@ -19,18 +24,24 @@ import os
 import sys
 
 from . import jointcfg
-from .mesh import _SAVE_OPTS, export_meshes, export_subgraph_meshes
+from .mesh import (
+    _SAVE_OPTS,
+    export_meshes,
+    export_part_mesh,
+    export_subgraph_meshes,
+)
 from .model import (
     build_model,
     capture_deep_worlds,
     extract_graph,
     extract_limit_joints,
+    extract_part_graph,
     extract_subgraphs,
     safe_name,
     to_graph_state,
 )
 from .state import GraphState
-from .swcom import SolidWorks, as_iface
+from .swcom import SW_DOC_PART, SolidWorks, as_iface, doc_type_for
 from .urdf_writer import write_ros_package, write_urdf
 
 GRAPH_FILE = "graph.json"
@@ -58,10 +69,36 @@ def _pkg_paths(assembly_path, out_dir, robot_name):
 
 
 # ---------------------------------------------------------------- extract
+def _extract_part_into(sw, part_path, pkg_dir, meshes_dir, robot_name, _say):
+    """Extraction body for a single ``.SLDPRT``: one link, no joints.
+
+    A lone part carries no assembly structure, so there is nothing to infer a
+    kinematic tree from -- we emit a trivial one-link robot with the part's
+    SolidWorks-native mass/COM/inertia and its mesh.  See
+    :func:`sw2robot.exporter.model.extract_part_graph`."""
+    _say(f"opening copy of {os.path.basename(part_path)} (loading the part) ...")
+    doc = sw.open_copy(part_path)
+
+    _say("reading part mass properties ...")
+    comps, adjacency, ground = extract_part_graph(doc, robot_name, part_path)
+
+    _say("exporting part mesh ...")
+    export_part_mesh(doc, comps[0], meshes_dir)
+
+    _say("saving graph.json ...")
+    graph = to_graph_state(comps, adjacency, ground, robot_name, part_path)
+    graph.save(os.path.join(pkg_dir, GRAPH_FILE))
+    sw.close_doc(doc)
+    return pkg_dir
+
+
 def _extract_into(sw, assembly_path, pkg_dir, meshes_dir, robot_name, _say,
                   _part=None):
     """Extraction body against an already-running SolidWorks session.  ``_part``
     (optional) reports the part currently being read, for the load indicator."""
+    if doc_type_for(assembly_path) == SW_DOC_PART:
+        return _extract_part_into(sw, assembly_path, pkg_dir, meshes_dir,
+                                  robot_name, _say)
     _say(f"opening copy of {os.path.basename(assembly_path)} "
          f"(loading the assembly) ...")
     doc = sw.open_copy(assembly_path)
@@ -309,7 +346,9 @@ def _exclude_list(s):
 
 def main():
     ap = argparse.ArgumentParser(description="extract + build (full export)")
-    ap.add_argument("assembly")
+    ap.add_argument("assembly",
+                    help="path to a .SLDASM assembly, or a single .SLDPRT part "
+                         "(a lone part exports as a 1-link, 0-joint URDF)")
     ap.add_argument("-o", "--out", default=None)
     ap.add_argument("-n", "--name", default=None)
     ap.add_argument("--visible", action="store_true")

--- a/sw2robot/exporter/mesh.py
+++ b/sw2robot/exporter/mesh.py
@@ -192,6 +192,33 @@ def export_meshes(app, doc, comps, meshes_dir, progress=None, by_path=None):
     return n
 
 
+def export_part_mesh(md, comp, meshes_dir):
+    """Export a single PART doc's geometry to ``meshes/<link>.3dxml`` and set
+    ``comp.mesh_file``; return 1 on success, 0 otherwise.
+
+    ``md`` is the already-open ``IModelDoc2`` of the ``.SLDPRT`` (part-local
+    frame, the same frame its inertial is in), so no re-open is needed.  A fresh
+    cache of real geometry is reused when present (see :func:`_cache_is_fresh`)."""
+    os.makedirs(meshes_dir, exist_ok=True)
+    out = os.path.join(meshes_dir, comp.link_name + ".3dxml")
+    if _cache_is_fresh(out, comp.part_path):
+        comp.mesh_file = os.path.join("meshes", os.path.basename(out))
+        return 1
+    ok = False
+    try:
+        ok = _save_3dxml(md, out)
+    except Exception as e:
+        print(f"  part mesh in-session export failed ({e!r})")
+    if ok:
+        comp.mesh_file = os.path.join("meshes", os.path.basename(out))
+        print(f"  mesh: {comp.link_name} <- {os.path.basename(comp.part_path)} "
+              f"({os.path.getsize(out)} B)")
+        return 1
+    print(f"  FAILED part mesh for {comp.name} "
+          f"({os.path.basename(comp.part_path)})")
+    return 0
+
+
 def export_subgraph_meshes(app, subgraphs, meshes_dir, by_path=None):
     """Meshes for every sub-assembly-internal component, so a build-time
     expansion has per-child visuals.  ``subgraphs`` is

--- a/sw2robot/exporter/model.py
+++ b/sw2robot/exporter/model.py
@@ -164,6 +164,43 @@ def _sw_mass_props(mp):
     return mass, [float(x) for x in com], inertia6
 
 
+def _read_part_props(md):
+    """``(material, density, sw_dict|None)`` read straight from a PART's model doc.
+
+    ``md`` is an ``IModelDoc2`` of a ``.SLDPRT`` (either a component's
+    ``GetModelDoc2`` or a standalone part opened on its own).  ``sw_dict`` is
+    ``{"mass","com","inertia"}`` in the part-local frame (SI) or None when the
+    SolidWorks-native mass properties are unavailable.  All lookups are
+    best-effort: any failure just leaves that field None."""
+    material = density = None
+    sw = None
+    try:
+        pd = as_iface(md, "IPartDoc")
+        res = pd.GetMaterialPropertyName2("", "")
+        if isinstance(res, (tuple, list)):
+            res = next((x for x in res if x), None)
+        material = str(res) if res else None
+    except Exception:
+        pass
+    try:
+        mdoc = as_iface(md, "IModelDoc2")
+        ext = as_iface(mdoc.Extension, "IModelDocExtension")
+        mp = ext.CreateMassProperty
+        if callable(mp):
+            mp = mp()
+        d = getattr(mp, "Density", None)
+        if d and d > 1.0:               # kg/m^3
+            density = float(d)
+        # SolidWorks-native mass/COM/inertia (exact CAD geometry +
+        # material/override) -- preferred over the mesh estimate
+        mass, com, inertia6 = _sw_mass_props(mp)
+        if mass is not None:
+            sw = {"mass": mass, "com": com, "inertia": inertia6}
+    except Exception:
+        pass
+    return material, density, sw
+
+
 @dataclass
 class Component:
     name: str
@@ -385,39 +422,15 @@ def extract_components(doc, exclude=None, progress=None):
         key = path.lower()
         if key in matcache:
             return matcache[key]
-        material = density = None
-        sw = None
+        props = (None, None, None)
         try:
             md = safe_call(ct, "GetModelDoc2")
             if md is not None:
-                try:
-                    pd = as_iface(md, "IPartDoc")
-                    res = pd.GetMaterialPropertyName2("", "")
-                    if isinstance(res, (tuple, list)):
-                        res = next((x for x in res if x), None)
-                    material = str(res) if res else None
-                except Exception:
-                    pass
-                try:
-                    mdoc = as_iface(md, "IModelDoc2")
-                    ext = as_iface(mdoc.Extension, "IModelDocExtension")
-                    mp = ext.CreateMassProperty
-                    if callable(mp):
-                        mp = mp()
-                    d = getattr(mp, "Density", None)
-                    if d and d > 1.0:           # kg/m^3
-                        density = float(d)
-                    # SolidWorks-native mass/COM/inertia (exact CAD geometry +
-                    # material/override) -- preferred over the mesh estimate
-                    mass, com, inertia6 = _sw_mass_props(mp)
-                    if mass is not None:
-                        sw = {"mass": mass, "com": com, "inertia": inertia6}
-                except Exception:
-                    pass
+                props = _read_part_props(md)
         except Exception:
             pass
-        matcache[key] = (material, density, sw)
-        return material, density, sw
+        matcache[key] = props
+        return props
     for c in raw:
         ct = as_iface(c, "IComponent2")
         name = safe_prop(ct, "Name2")
@@ -2399,6 +2412,31 @@ def extract_graph(doc, robot_name, source_assembly, progress=None):
                   f"(check for suppressed/lightweight mates)")
     _warn_unsolved_mates(comps, adjacency)
     return comps, adjacency, ground
+
+
+def extract_part_graph(doc, robot_name, part_path):
+    """A single ``.SLDPRT`` -> the same ``(comps, adjacency, ground)`` triple
+    ``extract_graph`` returns, but with exactly ONE component and no mates.
+
+    A lone part has no assembly structure to infer a kinematic tree from, so the
+    result is a trivial one-link robot: the part itself, at the identity pose in
+    its own frame, carrying its SolidWorks-native mass/COM/inertia.  The build
+    then emits a 1-link, 0-joint URDF -- useful for a static prop / environment
+    object / single rigid body you want in a simulator with an accurate inertial.
+    ``adjacency`` is empty and the sole component is its own ground (the base)."""
+    # _read_part_props guards every COM call in try/except, so pass the raw doc
+    # straight in -- an unguarded as_iface() here would import win32com and blow
+    # up the cross-platform unit test on macOS/Linux (there is no SolidWorks).
+    material, density, sw = _read_part_props(doc)
+    sw = sw or {}
+    ln = safe_name(os.path.splitext(os.path.basename(part_path))[0])
+    comp = Component(
+        name=ln, link_name=ln, part_path=part_path,
+        is_subassembly=False, world=np.eye(4), fixed=True, dof=0,
+        material=material, density=density,
+        sw_mass=sw.get("mass"), sw_com=sw.get("com"),
+        sw_inertia=sw.get("inertia"))
+    return [comp], {}, [comp.name]
 
 
 def _warn_unsolved_mates(comps, adjacency):

--- a/tests/e2e/run.mjs
+++ b/tests/e2e/run.mjs
@@ -502,6 +502,82 @@ const paste = await page.evaluate(() => ({
 check('server-browser: pasting a .sldasm path into the bar starts extraction',
       /SolidWorks|抽出/.test(paste.text), JSON.stringify(paste));
 
+// ---- 11b. 🗄 server browser: .sldasm/.sldprt/.urdf type checkboxes ----------
+// A folder with one of each input type: .sldprt is OFF by default, so its row
+// starts hidden while .sldasm/.urdf show; the checkboxes toggle rows live and
+// the choice persists.  Rows are tagged via dataset.fstype (see tagCad).
+await page.evaluate(() => {
+  const of = window.fetch.bind(window);
+  window.fetch = async (u, opts) => {
+    const url = typeof u === 'string' ? u : u?.url;
+    const J = o => new Response(JSON.stringify(o),
+      { headers: { 'Content-Type': 'application/json' } });
+    if (url && url.includes('/api/recent')) { return J([]); }
+    if (url && url.includes('/api/list')) { return J([]); }
+    if (url && url.includes('/api/fs')) {
+      return J({ path: 'C:/cad', parent: 'C:/', dirs: [], files: [
+        { name: 'arm.SLDASM', path: 'C:/cad/arm.SLDASM' },
+        { name: 'bracket.SLDPRT', path: 'C:/cad/bracket.SLDPRT' },
+        { name: 'robot.urdf', path: 'C:/cad/robot.urdf' }] });
+    }
+    return of(u, opts);
+  };
+  // start from the documented defaults regardless of any persisted choice
+  for (const k of ['sw2robot.fs.showSldasm', 'sw2robot.fs.showSldprt',
+                   'sw2robot.fs.showUrdf']) { localStorage.removeItem(k); }
+  document.getElementById('fstype-sldasm').checked = true;
+  document.getElementById('fstype-sldprt').checked = false;
+  document.getElementById('fstype-urdf').checked = true;
+});
+await page.evaluate(() => document.getElementById('fsbrowse').click());
+await sleep(400);
+// shown-state of each input row, keyed by its dataset.fstype
+const rowsByType = () => page.evaluate(() => {
+  const out = {};
+  for (const d of document.querySelectorAll('#fslist > div')) {
+    if (d.dataset.fstype) { out[d.dataset.fstype] = d.style.display !== 'none'; }
+  }
+  return out;
+});
+const tfDefault = await rowsByType();
+check('type-filter: .sldprt hidden by default, .sldasm/.urdf shown',
+      tfDefault.sldasm === true && tfDefault.urdf === true
+      && tfDefault.sldprt === false, JSON.stringify(tfDefault));
+// enabling .sldprt reveals the part row
+await page.evaluate(() => {
+  const c = document.getElementById('fstype-sldprt');
+  c.checked = true; c.dispatchEvent(new Event('change'));
+});
+await sleep(120);
+const tfWithPrt = await rowsByType();
+check('type-filter: enabling .sldprt reveals the part row',
+      tfWithPrt.sldprt === true, JSON.stringify(tfWithPrt));
+// disabling .sldasm hides the assembly row; .urdf/.sldprt stay
+await page.evaluate(() => {
+  const c = document.getElementById('fstype-sldasm');
+  c.checked = false; c.dispatchEvent(new Event('change'));
+});
+await sleep(120);
+const tfNoAsm = await rowsByType();
+check('type-filter: disabling .sldasm hides only the assembly row',
+      tfNoAsm.sldasm === false && tfNoAsm.urdf === true
+      && tfNoAsm.sldprt === true, JSON.stringify(tfNoAsm));
+// the choice persists to localStorage
+const tfPersist = await page.evaluate(() => ({
+  asm: localStorage.getItem('sw2robot.fs.showSldasm'),
+  prt: localStorage.getItem('sw2robot.fs.showSldprt') }));
+check('type-filter: choice persists to localStorage',
+      tfPersist.asm === '0' && tfPersist.prt === '1', JSON.stringify(tfPersist));
+// restore defaults so the suite stays idempotent for a re-run
+await page.evaluate(() => {
+  for (const k of ['sw2robot.fs.showSldasm', 'sw2robot.fs.showSldprt',
+                   'sw2robot.fs.showUrdf']) { localStorage.removeItem(k); }
+  document.getElementById('fstype-sldasm').checked = true;
+  document.getElementById('fstype-sldprt').checked = false;
+  document.getElementById('fstype-urdf').checked = true;
+  document.getElementById('fsclose').click();
+});
+
 check('suite: no page errors at end', pageErrors.length === 0,
       pageErrors.join(' | '));
 await browser.close();

--- a/tests/test_single_part.py
+++ b/tests/test_single_part.py
@@ -1,0 +1,67 @@
+"""A single .SLDPRT exports as a trivial 1-link, 0-joint URDF.
+
+A lone part has no mates to infer a kinematic tree from, so ``extract_part_graph``
+yields exactly one component (the part, at identity, in its own frame) and the
+build emits a one-link robot carrying the part's SolidWorks-native inertial.
+The SolidWorks reads inside ``extract_part_graph`` are fully guarded, so a plain
+object with no COM methods exercises the whole structure headlessly.
+"""
+import os
+import xml.etree.ElementTree as ET
+
+import numpy as np
+
+
+class _NoComDoc:
+    """Stands in for an IModelDoc2; every property lookup fails -> None props."""
+
+
+def test_extract_part_graph_single_component():
+    from sw2robot.exporter.model import extract_part_graph
+
+    # os.path.join so the separator is native on every OS -- a hard-coded
+    # backslash path would leave basename() unstripped on macOS/Linux CI
+    part = os.path.join("cad", "Base Plate.SLDPRT")
+    comps, adjacency, ground = extract_part_graph(_NoComDoc(), "robot", part)
+
+    assert len(comps) == 1
+    assert adjacency == {}
+    c = comps[0]
+    assert ground == [c.name]              # the sole part is its own base
+    assert c.link_name == "Base_Plate"     # sanitized file stem
+    assert c.part_path.endswith("Base Plate.SLDPRT")
+    assert c.fixed is True and c.dof == 0
+    assert np.allclose(c.world, np.eye(4))
+    assert c.is_subassembly is False
+
+
+def test_single_part_builds_one_link_zero_joint_urdf(tmp_path):
+    """The full graph.json -> build path for a lone part: one link, no joints,
+    SolidWorks inertial + the part mesh as visual/collision."""
+    from sw2robot.exporter import build as buildmod
+    from sw2robot.exporter.model import Component, to_graph_state
+
+    pkg = tmp_path
+    (pkg / "meshes").mkdir()
+    comp = Component(
+        name="widget", link_name="widget", part_path=r"C:\cad\widget.SLDPRT",
+        is_subassembly=False, world=np.eye(4), fixed=True, dof=0,
+        material="ABS", density=1020.0,
+        sw_mass=0.35, sw_com=[0.01, 0.0, 0.02],
+        sw_inertia=[1e-4, 0.0, 0.0, 1.2e-4, 0.0, 1.1e-4])
+    comp.mesh_file = "meshes/widget.3dxml"
+    graph = to_graph_state([comp], {}, [comp.name], "widget", comp.part_path)
+    graph.save(str(pkg / "graph.json"))
+
+    urdf_path = buildmod.build(str(pkg))
+    root = ET.parse(urdf_path).getroot()
+
+    links = root.findall("link")
+    assert len(links) == 1
+    assert root.findall("joint") == []
+    link = links[0]
+    assert link.get("name") == "base_link"          # root is renamed
+    # SolidWorks-native inertial passes through
+    assert float(link.find("inertial/mass").get("value")) == 0.35
+    assert link.find("visual/geometry/mesh").get("filename").endswith(
+        "widget.3dxml")


### PR DESCRIPTION
## Summary

Two related changes around opening CAD input:

1. **Single `.SLDPRT` → URDF.** Point `extract` at a lone part (CLI, the
   `/api/extract` endpoint, the 🗄 file browser, or a pasted path) and it
   yields a trivial one-link, zero-joint URDF: the part at identity in its
   own frame, carrying its SolidWorks-native mass / centre-of-mass /
   inertia tensor and mesh. A single part has no mates to infer a
   kinematic tree from, so a 1-link result is by design -- handy for a
   static prop, environment object, or single rigid body in a simulator.
   It does not turn a multibody part into a jointed robot (that needs an
   assembly with mates).

2. **File-browser type filter.** The 🗄 browser gains three type
   checkboxes -- `.sldasm` / `.sldprt` / `.urdf`. `.sldprt` is off by
   default (its rows start hidden); the choice persists in localStorage.
   Folders and packages are never filtered. Each input type gets its own
   inline-SVG mark shared between the rows and the checkbox labels: a green
   cube (part), two red cubes (assembly), a blue robot head (URDF). These
   are original glyphs that only borrow SolidWorks' colour coding, not its
   proprietary icons.

## Implementation notes

- `extract_part_graph` / `export_part_mesh`: one-component graph + mesh,
  reusing the part material/mass-property read with the assembly path.
- Everything downstream (build, URDF/ROS export, editor) is unchanged --
  a one-component graph flows through the existing pipeline.

## Testing

- `pytest`: full suite green except two pre-existing failures that need
  the optional `python-fcl` (collision tests), unrelated to this change.
- New `tests/test_single_part.py` covers the one-link graph + build.
- `ruff`: clean.
- New e2e checks in `tests/e2e/run.mjs` cover the default-hidden `.sldprt`
  and the live checkbox toggles (run against a live editor + Chrome).
