### PR TITLE
Extraction robustness: resolve moved refs, cache parts, survive hangs

### DIFF
--- a/sw2robot/exporter/export.py
+++ b/sw2robot/exporter/export.py
@@ -77,7 +77,7 @@ def _extract_part_into(sw, part_path, pkg_dir, meshes_dir, robot_name, _say):
     SolidWorks-native mass/COM/inertia and its mesh.  See
     :func:`sw2robot.exporter.model.extract_part_graph`."""
     _say(f"opening copy of {os.path.basename(part_path)} (loading the part) ...")
-    doc = sw.open_copy(part_path)
+    doc = sw.open_copy(part_path, progress=_say)
 
     _say("reading part mass properties ...")
     comps, adjacency, ground = extract_part_graph(doc, robot_name, part_path)
@@ -101,7 +101,8 @@ def _extract_into(sw, assembly_path, pkg_dir, meshes_dir, robot_name, _say,
                                   robot_name, _say)
     _say(f"opening copy of {os.path.basename(assembly_path)} "
          f"(loading the assembly) ...")
-    doc = sw.open_copy(assembly_path)
+    # progress=_say -> heartbeat during the (possibly long) reference download
+    doc = sw.open_copy(assembly_path, progress=_say)
 
     _say("reading components + mates ...")
     comps, adjacency, ground = extract_graph(doc, robot_name, assembly_path,

--- a/sw2robot/exporter/mesh.py
+++ b/sw2robot/exporter/mesh.py
@@ -159,6 +159,7 @@ def export_meshes(app, doc, comps, meshes_dir, progress=None, by_path=None):
         if reused:
             continue
         ok = False
+        why = None                       # specific reason, surfaced on failure
         ct = live.get(comp.name)
         md = safe_call(ct, "GetModelDoc2") if ct else None
         if md is not None:
@@ -167,11 +168,20 @@ def export_meshes(app, doc, comps, meshes_dir, progress=None, by_path=None):
             # a standalone OpenDoc6 of the same file comes up hollow
             try:
                 ok = _save_3dxml(md, out)
+                if not ok:
+                    why = "in-session 3DXML export was empty"
             except Exception as e:
+                why = f"in-session export raised {e!r}"
                 print(f"  {comp.name}: in-session export failed ({e!r}); "
                       f"opening file")
         if not ok:
-            ok = _export_by_opening(app, path, out)
+            if not os.path.exists(path):
+                why = "referenced part file not found on disk (unresolved reference)"
+            else:
+                ok = _export_by_opening(app, path, out)
+                if not ok:
+                    why = ("opened but produced no geometry -- no solid bodies "
+                           "(an imported STEP / graphics body?) or it would not open")
         if not ok and comp.is_subassembly:
             # 3DXML of a sub-assembly doc reliably comes out EMPTY however it
             # is opened; compose the mesh from its child PARTS instead (parts
@@ -180,6 +190,8 @@ def export_meshes(app, doc, comps, meshes_dir, progress=None, by_path=None):
             print(f"  composing {comp.link_name}.glb from child parts ...")
             ok = _compose_from_parts(app, md, path, out,
                                      meshes_dir=meshes_dir, by_path=by_path)
+            if not ok:
+                why = "sub-assembly mesh could not be composed from its child parts"
         if ok:
             rel = os.path.join("meshes", os.path.basename(out))
             by_path[path] = rel
@@ -188,7 +200,10 @@ def export_meshes(app, doc, comps, meshes_dir, progress=None, by_path=None):
             print(f"  mesh: {comp.link_name} <- {os.path.basename(path)} "
                   f"({os.path.getsize(out)} B)")
         else:
-            print(f"  FAILED mesh for {comp.name} ({os.path.basename(path)})")
+            # surface WHY instead of a bare "FAILED mesh": distinguishes an
+            # unresolved reference from a bodiless / STEP part from a compose miss
+            print(f"  FAILED mesh for {comp.name} "
+                  f"({os.path.basename(path)}): {why or 'unknown reason'}")
     return n
 
 

--- a/sw2robot/exporter/swcom.py
+++ b/sw2robot/exporter/swcom.py
@@ -17,6 +17,7 @@ KEY FACTS about this machine (discovered empirically):
 
 from __future__ import annotations
 
+import hashlib
 import os
 import shutil
 import sys
@@ -441,9 +442,70 @@ class SolidWorks:
             return True
         return safe_call(self.app, "RevisionNumber") not in (None, "")
 
+    # -- part cache -------------------------------------------------------
+    def _cache_dir(self):
+        """Persistent local cache of CAD files pulled from the source drive.
+        Override the location with ``SW2ROBOT_PART_CACHE``."""
+        d = getattr(self, "_part_cache", None)
+        if d is None:
+            d = (os.environ.get("SW2ROBOT_PART_CACHE")
+                 or os.path.join(os.environ.get("LOCALAPPDATA")
+                                 or os.path.expanduser("~"),
+                                 "sw2robot", "partcache"))
+            self._part_cache = d
+        return d
+
+    def _place(self, src, dst):
+        """Put a copy of ``src`` at ``dst``, sourcing the bytes from a persistent
+        local cache keyed by (path, mtime, size).
+
+        The slow part of opening an assembly off Google Drive is streaming its
+        referenced parts DOWN from the drive; the same shared part (a servo, a
+        bearing) is referenced by many assemblies, so without a cache it is
+        re-downloaded once per assembly.  With the cache each (file, version) is
+        pulled ONCE and every later use is a fast local copy.  Falls back to a
+        direct copy if the cache cannot be used."""
+        try:
+            st = os.stat(src)
+        except OSError:
+            return False
+        h = hashlib.sha1(
+            os.path.normcase(os.path.abspath(src)).encode("utf-8")).hexdigest()
+        tag = f"{int(st.st_mtime)}_{st.st_size}"
+        cdir = os.path.join(self._cache_dir(), h[:2])
+        cname = f"{h}__{tag}__{os.path.basename(src)}"
+        cpath = os.path.join(cdir, cname)
+        try:
+            if not os.path.exists(cpath):
+                os.makedirs(cdir, exist_ok=True)
+                # keep ONE version per file: drop older-mtime entries so the
+                # cache tracks the current drive contents, not every past edit
+                for fn in os.listdir(cdir):
+                    if fn.startswith(h + "__") and fn != cname:
+                        try:
+                            os.remove(os.path.join(cdir, fn))
+                        except OSError:
+                            pass
+                tmp = cpath + f".{os.getpid()}.part"
+                shutil.copy2(src, tmp)          # the drive download -- once
+                os.replace(tmp, cpath)
+            shutil.copy2(cpath, dst)            # fast local copy into the temp dir
+            return True
+        except OSError:
+            try:
+                shutil.copy2(src, dst)          # cache unusable -> straight copy
+                return True
+            except OSError:
+                return False
+
     # -- document handling ------------------------------------------------
-    def open_copy(self, path):
+    def open_copy(self, path, progress=None):
         """Copy ``path`` to a temp dir and open the COPY full (read-write).
+
+        ``progress(msg)`` -- if given -- is pinged as each referenced file is
+        fetched, so a caller's stall watchdog sees a heartbeat during a long
+        co-location download (many parts streamed off a shared drive) and does
+        not mistake it for a hang.
 
         We never open or modify the user's original file.  Crucially we do NOT
         use the read-only open flag: opening an assembly read-only makes
@@ -507,7 +569,7 @@ class SolidWorks:
             stem, ext = os.path.splitext(os.path.basename(path))
             tmp = os.path.join(tmpdir, f"{stem}_{os.path.basename(tmpdir)}{ext}")
             if not os.path.exists(tmp):
-                shutil.copy2(path, tmp)
+                self._place(path, tmp)
             # Co-locate the source folder's sibling CAD files in the SAME temp dir
             # so SolidWorks' "same folder as the assembly" rule resolves them by
             # name -- ONCE per folder (the folder's other sub-assemblies reuse
@@ -529,11 +591,10 @@ class SolidWorks:
                     s = os.path.join(src_dir, fn)
                     d = os.path.join(tmpdir, fn)
                     if os.path.isfile(s) and not os.path.exists(d):
-                        try:
-                            shutil.copy2(s, d)
+                        if progress:
+                            progress(f"fetching {fn}")   # stall-watchdog heartbeat
+                        if self._place(s, d):
                             n_sib += 1
-                        except OSError:
-                            pass
                 if n_sib:
                     print(f"      co-located {n_sib} sibling CAD file(s) for "
                           f"reference resolution")
@@ -547,11 +608,10 @@ class SolidWorks:
             for s in dep_files:
                 d = os.path.join(tmpdir, os.path.basename(s))
                 if os.path.isfile(s) and not os.path.exists(d):
-                    try:
-                        shutil.copy2(s, d)
+                    if progress:
+                        progress(f"fetching {os.path.basename(s)}")  # heartbeat
+                    if self._place(s, d):
                         n_dep += 1
-                    except OSError:
-                        pass
             if n_dep:
                 print(f"      co-located {n_dep} referenced file(s) from their "
                       f"resolved locations")

--- a/sw2robot/exporter/swcom.py
+++ b/sw2robot/exporter/swcom.py
@@ -660,35 +660,42 @@ class SolidWorks:
               f"{t4 - t3:.1f}s")
         return doc
 
-    def _dependency_files(self, src_path):
-        """Every file this assembly references, resolved to its CURRENT location
-        via ``GetDocumentDependencies2`` (from the file, no open required).
-
-        SearchSubfolders is ON, which is what recovers a MOVED or relocated part:
-        an assembly saved on another machine bakes in a stale absolute path (a
-        different Drive letter, a ``\\.shortcut-targets-by-id\\`` id, an old
-        folder), so the recorded path no longer exists here.  With the flag on,
-        SolidWorks searches and returns the part's real, current location.  We use
-        these both to seed the reference search paths AND to co-locate the parts
-        beside the throw-away assembly copy (a distant SHARED library -- e.g.
-        ``.../common_parts/servo/...`` while the assembly is under
-        ``.../beetle/asm/subasm`` -- is otherwise never reached, and the assembly
-        opens with every component unresolved: "no usable components")."""
-        files = []
+    def _deps(self, src_path, search_subfolders):
+        """``GetDocumentDependencies2`` -> list of referenced file paths (from the
+        file, no open required).  ``[name, path, name, path, ...]`` -> the paths."""
         try:
-            # (document, Traverseflag=whole tree, SearchSubfolders=ON, AddReadOnlyInfo=off)
-            deps = self.app.GetDocumentDependencies2(src_path, True, True, False)
+            deps = self.app.GetDocumentDependencies2(
+                src_path, True, bool(search_subfolders), False)
         except Exception as e:
             print(f"      WARN: GetDocumentDependencies2 failed ({e!r}); "
                   f"distant/relocated part references may not resolve")
-            return files
-        if not deps:
-            return files
-        # flat [name, path, name, path, ...]; keep the existing resolved files
-        seen = set()
-        for p in list(deps)[1::2]:
+            return None
+        return [str(p) for p in list(deps or [])[1::2]]
+
+    def _dependency_files(self, src_path):
+        """Every file this assembly references, resolved to its CURRENT location.
+
+        Fast path first: ``GetDocumentDependencies2`` with SearchSubfolders OFF
+        just reads the recorded paths and returns instantly.  Only if some of
+        those paths are STALE (a part was moved -- saved on another machine, a
+        different Drive letter, a ``\\.shortcut-targets-by-id\\`` id) do we pay
+        the SLOW subfolder search (ON), which walks the drive to find the part's
+        current location.  Turning the flag ON unconditionally made SolidWorks
+        scan the whole subtree for every assembly -- minutes over a shared drive,
+        long enough to look like a hang on a big reference tree (e.g. tiger_8link)."""
+        recorded = self._deps(src_path, False)
+        if recorded is None:
+            return []
+        paths = recorded
+        if any(not os.path.isfile(os.path.abspath(p)) for p in recorded):
+            # a recorded path points nowhere here -> resolve via the slow search
+            resolved = self._deps(src_path, True)
+            if resolved:
+                paths = resolved
+        files, seen = [], set()
+        for p in paths:
             try:
-                ap = os.path.abspath(str(p))
+                ap = os.path.abspath(p)
             except Exception:
                 continue
             key = os.path.normcase(ap)

--- a/sw2robot/exporter/swcom.py
+++ b/sw2robot/exporter/swcom.py
@@ -482,7 +482,12 @@ class SolidWorks:
             # stale then open with almost everything unresolved (home_drone came
             # up as a single component).  Register the original's folder family
             # as document search paths so rule (2) replaces rule (4).
-            self._register_search_folders(path)
+            # resolve the assembly's references to their CURRENT locations (also
+            # recovers a part that was MOVED so the stored path is stale), then
+            # both register those folders and co-locate the parts beside the copy
+            dep_files = (self._dependency_files(path)
+                         if doc_type_for(path) == SW_DOC_ASSEMBLY else [])
+            self._register_search_folders(path, dep_files)
             # Reuse ONE temp dir per source folder: assemblies that share a folder
             # (the common case -- a module's sub-assemblies all sit beside it)
             # then co-locate their sibling CAD files ONCE instead of re-copying
@@ -532,6 +537,24 @@ class SolidWorks:
                 if n_sib:
                     print(f"      co-located {n_sib} sibling CAD file(s) for "
                           f"reference resolution")
+            # Also co-locate this assembly's OWN referenced files, resolved to
+            # their current locations, beside the copy.  This is what recovers a
+            # DISTANT shared library or a MOVED part whose stored path is stale:
+            # a temp copy does not re-resolve an unresolvable stored path through
+            # the search paths (those components then come up suppressed), but the
+            # "same folder as the assembly" rule resolves a co-located part by name.
+            n_dep = 0
+            for s in dep_files:
+                d = os.path.join(tmpdir, os.path.basename(s))
+                if os.path.isfile(s) and not os.path.exists(d):
+                    try:
+                        shutil.copy2(s, d)
+                        n_dep += 1
+                    except OSError:
+                        pass
+            if n_dep:
+                print(f"      co-located {n_dep} referenced file(s) from their "
+                      f"resolved locations")
             t1 = _time.time()
             doc, ecode, wcode = open_doc6(self.app, tmp, doc_type_for(tmp))
             if doc is None:
@@ -577,47 +600,48 @@ class SolidWorks:
               f"{t4 - t3:.1f}s")
         return doc
 
-    def _reference_dirs(self, src_path):
-        """Every folder that actually holds a file this assembly references,
-        read from SolidWorks' own dependency records (``GetDocumentDependencies2``
-        -- from the file, no open required).
+    def _dependency_files(self, src_path):
+        """Every file this assembly references, resolved to its CURRENT location
+        via ``GetDocumentDependencies2`` (from the file, no open required).
 
-        The parent + parent's-subfolders scan below only reaches parts that sit
-        near the .SLDASM.  Assemblies that reference a SHARED library in a distant
-        folder (e.g. ``.../common_parts/servo/Dynamixel/XL430`` while the assembly
-        is under ``.../beetle/asm/subasm``) then open with every component
-        unresolved -- the "no usable components" / widespread "FAILED mesh"
-        failures on the hand and aerial trees.  Feeding those real folders into
-        the search paths lets SolidWorks resolve them by name."""
-        dirs = []
+        SearchSubfolders is ON, which is what recovers a MOVED or relocated part:
+        an assembly saved on another machine bakes in a stale absolute path (a
+        different Drive letter, a ``\\.shortcut-targets-by-id\\`` id, an old
+        folder), so the recorded path no longer exists here.  With the flag on,
+        SolidWorks searches and returns the part's real, current location.  We use
+        these both to seed the reference search paths AND to co-locate the parts
+        beside the throw-away assembly copy (a distant SHARED library -- e.g.
+        ``.../common_parts/servo/...`` while the assembly is under
+        ``.../beetle/asm/subasm`` -- is otherwise never reached, and the assembly
+        opens with every component unresolved: "no usable components")."""
+        files = []
         try:
-            # (document, Traverseflag=whole tree, SearchSubfolders=off, AddReadOnlyInfo=off)
-            deps = self.app.GetDocumentDependencies2(src_path, True, False, False)
+            # (document, Traverseflag=whole tree, SearchSubfolders=ON, AddReadOnlyInfo=off)
+            deps = self.app.GetDocumentDependencies2(src_path, True, True, False)
         except Exception as e:
             print(f"      WARN: GetDocumentDependencies2 failed ({e!r}); "
-                  f"distant part references may not resolve")
-            return dirs
+                  f"distant/relocated part references may not resolve")
+            return files
         if not deps:
-            return dirs
-        # returns a flat [name, path, name, path, ...] sequence
-        seq = list(deps)
+            return files
+        # flat [name, path, name, path, ...]; keep the existing resolved files
         seen = set()
-        for p in seq[1::2]:
+        for p in list(deps)[1::2]:
             try:
-                d = os.path.dirname(os.path.abspath(str(p)))
+                ap = os.path.abspath(str(p))
             except Exception:
                 continue
-            key = os.path.normcase(d)
-            if d and key not in seen and os.path.isdir(d):
+            key = os.path.normcase(ap)
+            if key not in seen and os.path.isfile(ap):
                 seen.add(key)
-                dirs.append(d)
-        return dirs
+                files.append(ap)
+        return files
 
-    def _register_search_folders(self, src_path):
+    def _register_search_folders(self, src_path, dep_files=()):
         """Add the source assembly's folder, its parent, the parent's sub-folders
         (parts/, commercial/, ...) AND every folder that actually holds a
-        referenced part (from the assembly's dependency records) to the reference
-        search paths of this SolidWorks session.
+        referenced part (from ``dep_files``) to the reference search paths of this
+        SolidWorks session.
 
         The previous user settings are captured ONCE and restored in
         shutdown() -- SolidWorks persists these preferences to the registry
@@ -647,10 +671,12 @@ class SolidWorks:
             # the real folders of every referenced part, wherever they live --
             # this is what lets a DISTANT shared library resolve (parent-subfolder
             # scan above only reaches parts near the .SLDASM)
-            ref_dirs = self._reference_dirs(src_path)
-            for d in ref_dirs:
-                if d not in cand:
-                    cand.append(d)
+            ref_dirs = []
+            for f in dep_files:
+                d = os.path.dirname(f)
+                if d and d not in cand and d not in ref_dirs:
+                    ref_dirs.append(d)
+            cand.extend(ref_dirs)
             # KEEP the user's existing referenced-document search paths and only
             # ADD ours -- SolidWorks resolves this assembly's parts through those
             # configured paths interactively, so replacing them (the old


### PR DESCRIPTION
Follow-up to #130.

## Problem

Some assemblies (e.g. `beetle` hand modules) reference parts that were **moved** since the assembly was saved. The stored reference then points at a location that does not exist here — a different Drive letter, a `\.shortcut-targets-by-id\<id>\` shortcut, an old folder. #130 called `GetDocumentDependencies2` with `SearchSubfolders` **off**, so it returned those dead paths, no valid folder was found, and the components stayed unresolved (suppressed) → *"no usable components"*.

Concretely, `hand6_pulley_leaning_13.SLDASM` records its parts at `H:\.shortcut-targets-by-id\...\hand6_pulley_roller.SLDPRT` (doesn't exist), while the part actually lives at `G:\...\beetle\Beatle_hand\parts\PLA\hand 6\pulley\hand6_pulley_roller.SLDPRT`.

## Fix

- Turn `SearchSubfolders` **on** in `GetDocumentDependencies2` so SolidWorks resolves each reference to its **current** location, and **co-locate those resolved files** beside the throw-away assembly copy. A temp copy does not re-resolve a dead stored path through the search paths (the components come up suppressed), but the *"same folder as the assembly"* rule resolves a co-located part by name. The dependency list is computed once and used for both the search folders and the co-location.
- **Surface why a mesh failed** instead of a bare `FAILED mesh for X`: distinguishes an unresolved reference from a bodiless / imported-STEP part from a sub-assembly compose miss.

## Verification

`beetle` `hand6` / `hand7` / `hand8` finger + `Beetle_Hyper/module_ver1` (2-, 3-, 18-, **352**-link) — previously **4/4 failed** — now **4/4 build with geometry (78/78 models, 0 empty)**.

The nine hand assemblies from #130 still build **41/41 with meshes (no regression)**.

## Note

Co-locating the full resolved dependency tree copies more files per open (e.g. ~104 for `module_ver1`) — more temp I/O in exchange for recovering references a search folder alone can't. Basename collisions across folders keep first-copied (same as the existing sibling co-location).

---

## Added (extraction robustness)

- **Part cache** — co-location routed through a persistent local cache keyed by (path, mtime, size), so a shared part streamed off Google Drive is downloaded once, not once per referencing assembly. Overridable via `SW2ROBOT_PART_CACHE`.
- **Download heartbeat** — `open_copy` pings a progress callback per fetched file, so a caller's stall watchdog can tell a slow-but-progressing download from a genuine hang.

Verified: kondo-original-kxr-parts 110/117 assemblies, 185/185 models with geometry (before an unrelated transient SolidWorks hang, which motivated the watchdog on the caller side).