### PR TITLE
Feat/mass editor

### DIFF
--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -85,6 +85,12 @@
   #linkinfo .sw { display: inline-block; width: 10px; height: 10px;
                   border-radius: 2px; vertical-align: -1px;
                   border: 1px solid #555; }
+  /* link-info header (the folded-in selection bar): one tidy row of
+     equal-width, equal-height buttons so the icons and "make root" match */
+  #selbar #selname { color: #55d6ff; font-size: 12px; padding: 1px 0; }
+  #selbar button { flex: 1 1 0; min-width: 0; height: 24px; padding: 0 6px;
+    font-size: 12px; line-height: 1; display: inline-flex;
+    align-items: center; justify-content: center; white-space: nowrap; }
   .jtype { font-size: 10px; padding: 0 4px; border-radius: 3px;
            background: #444; color: #ccc; }
   .joint.dirty { background: #2c2a1e; outline: 1px solid #6b5d2a; }

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -2651,14 +2651,23 @@ function attachInlineRename(el, kind, getOld) {
   });
 }
 
+// dock a floating list panel (#renamelist / #masslist) just below the viewer's
+// button row (#views), which may wrap to several rows, instead of overlapping it
+function dockPanelBelowViews(ov) {
+  const v = document.getElementById('views');
+  if (v) { ov.style.top = (v.offsetTop + v.offsetHeight + 6) + 'px'; }
+}
+
 // the ≣ 改名 list: every joint with its (editable) joint name + child link name
 function openRenameList() {
   if (!viewer.robot) { log(t('common.openFirst'), 'wrn'); return; }
+  document.getElementById('masslist')?.remove();   // the two panels are exclusive
   document.getElementById('renamelist')?.remove();
   const linkOf = (j, tag) => [...(j.urdfNode?.children ?? [])]
     .find(e => e.tagName === tag)?.getAttribute('link') ?? '';
   const ov = document.createElement('div');
   ov.id = 'renamelist';
+  dockPanelBelowViews(ov);          // sit under the viewer's button row
   const card = document.createElement('div');
   card.className = 'card';
   const ttl = t('rename.emptyResetTitle');
@@ -2774,6 +2783,7 @@ async function openMassList() {
 }
 
 function _renderMassList(data) {
+  document.getElementById('renamelist')?.remove();  // the two panels are exclusive
   document.getElementById('masslist')?.remove();
   // link order: base link(s) first (no parent joint), then the rest, matching
   // the tree feel of the rename panel; parent_joint gates mass-only (fixed only)
@@ -2788,6 +2798,7 @@ function _renderMassList(data) {
 
   const ov = document.createElement('div');
   ov.id = 'masslist';
+  dockPanelBelowViews(ov);          // sit under the viewer's button row
   const card = document.createElement('div');
   card.className = 'card';
   const esc = s => String(s).replace(/"/g, '&quot;');

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -88,9 +88,9 @@
   /* link-info header (the folded-in selection bar): one tidy row of
      equal-width, equal-height buttons so the icons and "make root" match */
   #selbar #selname { color: #55d6ff; font-size: 12px; padding: 1px 0; }
-  #selbar button { flex: 1 1 0; min-width: 0; height: 24px; padding: 0 6px;
-    font-size: 12px; line-height: 1; display: inline-flex;
-    align-items: center; justify-content: center; white-space: nowrap; }
+  #selbar button { height: 24px; padding: 0 8px; font-size: 12px;
+    line-height: 1; display: inline-flex; align-items: center;
+    justify-content: center; white-space: nowrap; }
   .jtype { font-size: 10px; padding: 0 4px; border-radius: 3px;
            background: #444; color: #ccc; }
   .joint.dirty { background: #2c2a1e; outline: 1px solid #6b5d2a; }

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -4702,7 +4702,14 @@ function fillLinkInfo(name) {
   // listeners since the element was only moved, never recreated)
   if (selbar) {
     Object.assign(selbar.style, { position: 'static', border: 'none',
-      background: 'none', padding: '0', margin: '0 0 6px', width: 'auto' });
+      background: 'none', padding: '0', margin: '0 0 6px', width: 'auto',
+      flexWrap: 'wrap' });                 // let the buttons drop to a 2nd row
+    // name takes the whole first row (truncated); the action buttons wrap below
+    const nm = document.getElementById('selname');
+    if (nm) {
+      Object.assign(nm.style, { flexBasis: '100%', minWidth: '0',
+        overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' });
+    }
     el.insertBefore(selbar, el.firstChild);
   }
   if (j) { wireJointPanel(el, j); }

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -2875,7 +2875,9 @@ function _renderMassList(data) {
     // computed mass (user then edits it); uncheck -> clear it, back to material
     tr.querySelector('.bm')?.addEventListener('change', e => {
       if (e.target.checked) {
-        const seed = data.links[ln]?.current_mass ?? 0.1;
+        // `||` (not `??`): a 0 / missing current mass falls to 0.1 so the seed
+        // POST is never rejected by the positive-mass check
+        const seed = data.links[ln]?.current_mass || 0.1;
         apply(post('/api/set_masses', { link: ln, mass: seed }),
               { rebuild: true, okMsg: t('mass.setMassOk', { name: ln, m: seed }) });
       } else {
@@ -4699,7 +4701,9 @@ function fillLinkInfo(name) {
     } catch (err) { log(t('mass.fail', { e: err.message ?? err }), 'err'); }
   };
   el.querySelector('#li_bm')?.addEventListener('change', e => {
-    setMass(e.target.checked ? (meta?.current_mass ?? 0.1) : null);
+    // `||` (not `??`): a 0 / missing current mass falls to 0.1 so the seed
+    // POST is never rejected by the positive-mass check
+    setMass(e.target.checked ? (meta?.current_mass || 0.1) : null);
   });
   const sel = el.querySelector('.li_mat');    // matSelectHtml emits a class (density mode only)
   sel?.addEventListener('change', async () => {

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -220,6 +220,27 @@
   .rn-input { background: #15171a; color: #cfe3ff; border: 1px solid #3a4750;
     border-radius: 3px; font: inherit; padding: 1px 4px; width: 15em; }
   .rn-input:focus { border-color: #6cf; outline: none; }
+  /* mass editor: shares #renamelist's docked-card + .rntable styling */
+  #masslist { position: absolute; top: 8px; right: 8px; bottom: 8px;
+    z-index: 12; display: flex; align-items: flex-start;
+    pointer-events: none; }
+  #masslist .card { pointer-events: auto; background: #1c2228f2;
+    border: 1px solid #456; border-radius: 8px; padding: 14px 16px;
+    max-height: 100%; max-width: 92vw; overflow: auto; color: #dde;
+    box-shadow: 0 8px 30px #000a; }
+  .mass-num { width: 6.5em; text-align: right; }
+  /* truncate long link names so the panel stays narrow (full name on hover) */
+  #masslist td.mlink { max-width: 10em; overflow: hidden;
+    text-overflow: ellipsis; }
+  /* clearly show a disabled material picker (mutually exclusive with a mass) */
+  #masslist select:disabled, #linkinfo select:disabled {
+    opacity: .4; cursor: not-allowed; text-decoration: line-through; }
+  tr.mass-warn td { background: #3a2c17; }        /* default (unset) SW mass */
+  .mass-flag { color: #e8b84b; }                  /* ⚠ marker */
+  .mass-note { color: #7a8494; font-size: 10px; }
+  .mass-summary { font-size: 11px; margin: 2px 0 8px; }
+  .mass-summary.warn { color: #e8b84b; }
+  .mass-summary.ok { color: #7bd88f; }
   .joint .mimictag { font-size: 10px; padding: 0 4px; border-radius: 3px;
                      background: #3d3556; color: #c5b3ff; }
   .joint .motag { font-size: 10px; padding: 0 4px; border-radius: 3px;
@@ -613,6 +634,9 @@
       <button id="renamelistbtn" data-i18n="ui.renamelist"
               data-i18n-title="t.renamelist"
               title="関節名・リンク名を一覧で改名">≣ 改名</button>
+      <button id="masslistbtn" data-i18n="ui.masslist"
+              data-i18n-title="t.masslist"
+              title="質量を一覧で編集">⚖ 質量</button>
       <button id="bug" data-i18n-title="t.bug"
               title="壊れたらこれ: 操作ログ+状態をサーバーに送る">🐞
       </button>
@@ -988,6 +1012,39 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     'rename.resetAllBtn': { en: '↺ reset all to defaults', ja: '↺ 全デフォルト名に戻す' },
     'rename.resetAllBtnTitle': { en: 'revert every joint/link name to its original',
                                  ja: 'すべての joint 名・link 名を元の名前に戻す' },
+    // mass editor (bulk mass / density / mass-only + default-mass guard)
+    'mass.listTitle': { en: 'mass editor', ja: '質量エディタ' },
+    'mass.listHelp': { en: 'set a target mass (kg) OR a density (kg/m³) per link — one clears the other. ⚠ links use a SolidWorks default mass (no material assigned); set a value or acknowledge them before export.',
+                       ja: 'リンクごとに目標質量(kg)または密度(kg/m³)を設定（片方を設定すると他方は解除）。⚠はSW既定の質量（材質未設定）。エクスポート前に値を設定するか確認してください。' },
+    'mass.thLink': { en: 'link', ja: 'link' },
+    'mass.thMaterial': { en: 'material', ja: '材質' },
+    'mass.thMass': { en: 'mass', ja: '質量' },
+    'mass.thDensity': { en: 'density (kg/m³)', ja: '密度 (kg/m³)' },
+    'mass.thTarget': { en: 'target (kg)', ja: '目標 (kg)' },
+    'mass.thMassOnly': { en: 'mass-only', ja: '質量のみ' },
+    'mass.thReview': { en: 'reviewed', ja: '確認済' },
+    'mass.needReview': { en: a => `⚠ ${a.n} link(s) use a default SolidWorks mass — review before export`,
+                         ja: a => `⚠ ${a.n} 個のリンクがSW既定の質量です — エクスポート前に確認してください` },
+    'mass.allGood': { en: 'all link masses are set or reviewed ✓', ja: 'すべてのリンク質量は設定または確認済み ✓' },
+    'mass.ackAll': { en: '✓ acknowledge all flagged', ja: '✓ 全ての⚠を確認済みに' },
+    'mass.massOnlyFixedOnly': { en: 'mass-only is valid only on a fixed link', ja: '質量のみは固定リンクでのみ有効' },
+    'mass.setMassOk': { en: a => `mass of ${a.name} → ${a.m} kg ✓ (inertia rescaled)`,
+                        ja: a => `${a.name} の質量 → ${a.m} kg ✓（慣性を再計算）` },
+    'mass.setOk': { en: 'updated ✓ (mass/inertia rebuilt)', ja: '更新しました ✓（質量・慣性を再計算）' },
+    'mass.fail': { en: a => `mass edit failed: ${a.e}`, ja: a => `質量編集に失敗: ${a.e}` },
+    'mass.swOverride': { en: 'set in SW', ja: 'SWで設定済' },
+    'mass.thByMass': { en: 'by mass?', ja: '質量指定?' },
+    'mass.thValue': { en: 'material / mass', ja: '材質 / 質量' },
+    'mass.byMass': { en: 'set by target mass', ja: '目標質量で指定' },
+    'mass.byMassTitle': { en: 'tick to set an exact target mass; untick to drive mass from a material / density',
+                          ja: 'チェックで目標質量を指定、外すと材質・密度から質量を算出' },
+    'mass.exportBlockedTitle': { en: a => `${a.n} link(s) still use a default SolidWorks mass:`,
+                                 ja: a => `${a.n} 個のリンクがSW既定の質量のままです：` },
+    'mass.exportAnyway': { en: 'Export anyway? (Cancel opens the mass editor to fix them.)',
+                           ja: 'このままエクスポートしますか？（キャンセルで質量エディタを開きます）' },
+    't.masslist': { en: 'edit per-link mass / density; flags default SolidWorks masses',
+                    ja: 'リンクごとの質量・密度を編集。SW既定の質量を警告' },
+    'ui.masslist': { en: '⚖ mass', ja: '⚖ 質量' },
     // joint rows / tree
     'row.jnameTitle': { en: a => `joint: ${a.name}\n${a.parent} → ${a.child}`,
                         ja: a => `関節: ${a.name}\n${a.parent} → ${a.child}` },
@@ -1124,7 +1181,7 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     'li.swUnset': { en: '(unset in SW)', ja: '(SWで未設定)' },
     'li.reextract': { en: '(re-extract to get)', ja: '(再抽出で取得)' },
     'li.setMaterial': { en: 'set material', ja: 'set 材質' },
-    'li.densityPlaceholder': { en: '— override density —', ja: '— 密度を上書き —' },
+    'li.densityPlaceholder': { en: '— set material —', ja: '— 材質を設定 —' },
     'li.densityReset': { en: 'back to SW value (clear override)', ja: 'SW値に戻す (上書き解除)' },
     'li.densityPrompt': { en: 'density (kg/m³):', ja: '密度 (kg/m³):' },
     'li.swValue': { en: '(SW value)', ja: '(SW値)' },
@@ -2232,6 +2289,9 @@ async function refreshCompMeta() {
       chip.style.display = excludedList.length ? '' : 'none';
       chip.textContent = t('excl.chip', { n: excludedList.length });
       chip.title = excludedList.join('\n') + '\n' + t('excl.restoreAll');
+      // keep an open mass-editor popup in sync with mass-only / material edits
+      // made from the main panel (both read the same /api/components data)
+      if (document.getElementById('masslist')) { openMassList(); }
     }
   } catch { /* no package yet */ }
 }
@@ -2650,6 +2710,227 @@ function openRenameList() {
 }
 document.getElementById('renamelistbtn')
   .addEventListener('click', openRenameList);
+
+// shared material/density presets (label -> density kg/m³; 'custom' = prompt),
+// used by both the mass editor and the per-link select popup
+const MAT_PRESETS = [['PLA', '1240'], ['ABS', '1040'], ['PETG', '1270'],
+  ['Nylon', '1140'], ['POM', '1410'], ['FR4', '1850'], ['Aluminum', '2700'],
+  ['Iron/Steel', '7850'], ['Titanium', '4500'], ['custom', 'custom']];
+
+// a material picker <select>: reset + presets + custom.  `disabled` greys it out
+// (used when a target mass is set -- mass and material are mutually exclusive).
+function matSelectHtml(cls, { disabled = false, style = '', selected = null } = {}) {
+  // pre-select the preset matching the current density so the picker shows the
+  // active material instead of resetting to the placeholder; if the density is
+  // a non-preset (custom) value, fall through to the placeholder
+  const sel = selected != null ? String(Math.round(Number(selected))) : null;
+  const known = sel != null && MAT_PRESETS.some(([, v]) => v === sel);
+  return `<select class="${cls}"${disabled ? ' disabled' : ''} style="${style}`
+    + `background:#15171a;color:#ddd;border:1px solid #444;border-radius:3px;`
+    + `font-size:11px">`
+    + `<option value=""${known ? '' : ' selected'}>${t('li.densityPlaceholder')}</option>`
+    + `<option value="__reset__">${t('li.densityReset')}</option>`
+    + MAT_PRESETS.map(([l, v]) =>
+        `<option value="${v}"${v === sel ? ' selected' : ''}>`
+        + `${v === 'custom' ? l : l + ' ' + v}</option>`).join('')
+    + `</select>`;
+}
+
+// map a material <select> value to a density: a number, null (reset to SW), or
+// undefined (placeholder / cancelled custom prompt -> caller should no-op)
+function matPickDensity(val) {
+  if (val === '__reset__') { return null; }
+  if (val === 'custom') {
+    const d = prompt(t('li.densityPrompt'));
+    return d ? Number(d) : undefined;
+  }
+  return val ? Number(val) : undefined;
+}
+
+// the ⚖ 質量 list: per-link mass / density / mass-only, with default-mass ⚠
+const _fmtMass = m => (m == null) ? '—'
+  : (m >= 0.1 ? `${m.toFixed(3)} kg` : `${(m * 1000).toFixed(1)} g`);
+
+async function openMassList() {
+  // Fully data-driven (keyed by the server's final link names): do NOT depend
+  // on viewer.robot, so reopening right after an edit -- while the robot is
+  // still reloading -- always repaints with the freshly-stored values instead
+  // of leaving the stale panel up.
+  let data;
+  try {
+    data = await (await fetch('/api/components')).json();
+  } catch { log(t('common.openFirst'), 'wrn'); return; }
+  if (data.error || !data.links || !Object.keys(data.links).length) {
+    log(t('common.openFirst'), 'wrn'); return;
+  }
+  try {
+    _renderMassList(data);
+  } catch (e) {
+    // never let a render error wedge the panel: drop any half-built one so the
+    // button can always bring a fresh one back up
+    document.getElementById('masslist')?.remove();
+    log(t('mass.fail', { e: e.message ?? e }), 'err');
+  }
+}
+
+function _renderMassList(data) {
+  document.getElementById('masslist')?.remove();
+  // link order: base link(s) first (no parent joint), then the rest, matching
+  // the tree feel of the rename panel; parent_joint gates mass-only (fixed only)
+  const links = data.links;
+  const order = [...Object.keys(links)].sort((a, b) => {
+    const ra = links[a].parent_joint ? 1 : 0, rb = links[b].parent_joint ? 1 : 0;
+    return ra - rb || a.localeCompare(b);
+  });
+  const urdfMasses = data.urdf_masses ?? {};
+  const massOnly = new Set(data.mass_only ?? []);
+  const flaggedN = (data.default_mass_links ?? []).length;
+
+  const ov = document.createElement('div');
+  ov.id = 'masslist';
+  const card = document.createElement('div');
+  card.className = 'card';
+  const esc = s => String(s).replace(/"/g, '&quot;');
+  const rows = order.map(ln => {
+    const m = data.links[ln] ?? {};
+    const resolved = m.name != null;        // maps to a graph component
+    const warn = m.default_mass && !m.reviewed;
+    const matTxt = m.mass_overridden_in_sw ? t('mass.swOverride')
+      : m.material ? m.material
+      : resolved ? `<span class="mass-flag">${t('li.swUnset')}</span>`
+      : '<span class="mass-note">—</span>';
+    const cur = m.current_mass ?? urdfMasses[ln];
+    const fixed = m.parent_joint === 'fixed' || massOnly.has(ln);
+    // per-link source: a target mass OR a material/density -- a checkbox picks
+    // which, and the value cell shows only that control (no disabled elements)
+    const byMass = m.mass != null;
+    const valueCell = byMass
+      ? `<input class="rn-input mass-num mt" type="number" step="any" min="0" `
+        + `placeholder="${cur != null ? cur.toFixed(3) : ''}" `
+        + `value="${m.mass ?? ''}"> kg`
+      : matSelectHtml('md', { style: 'width:9em;', selected: m.override ?? m.density })
+        + (m.override ? `<div class="mass-note">${m.override.toFixed(0)} kg/m³ `
+          + `${t('li.override')}</div>` : '');
+    return `<tr class="${warn ? 'mass-warn' : ''}" data-link="${esc(ln)}">` +
+      `<td class="mlink" title="${esc(ln)}">` +
+      `${warn ? '<span class="mass-flag">⚠ </span>' : ''}${ln}</td>` +
+      `<td class="mass-note">${matTxt}</td>` +
+      `<td>${_fmtMass(cur)}</td>` +
+      `<td style="text-align:center"><input type="checkbox" class="bm" ` +
+      `${byMass ? 'checked' : ''} title="${t('mass.byMassTitle')}"></td>` +
+      `<td>${valueCell}</td>` +
+      `<td style="text-align:center">${fixed
+        ? `<input type="checkbox" class="mo" ${massOnly.has(ln) ? 'checked' : ''}>`
+        : `<span class="mass-note" title="${t('mass.massOnlyFixedOnly')}">—</span>`
+      }</td>` +
+      `<td style="text-align:center">${m.default_mass || m.reviewed
+        ? `<input type="checkbox" class="rv" ${m.reviewed ? 'checked' : ''}>`
+        : ''}</td>` +
+      `</tr>`;
+  }).join('');
+  const summary = flaggedN
+    ? `<div class="mass-summary warn">${t('mass.needReview', { n: flaggedN })}</div>`
+    : `<div class="mass-summary ok">${t('mass.allGood')}</div>`;
+  card.innerHTML =
+    '<div style="font-size:14px;margin-bottom:2px;color:#9fe0a8">' +
+    t('mass.listTitle') + '</div>' +
+    // cap the help width so this long sentence wraps instead of stretching the
+    // shrink-to-fit card wider than the table (which pushed columns off-screen)
+    '<div style="font-size:11px;color:#8a93a3;margin-bottom:8px;max-width:640px">' +
+    t('mass.listHelp') + '</div>' + summary +
+    '<table class="rntable"><thead><tr>' +
+    `<th>${t('mass.thLink')}</th><th>${t('mass.thMaterial')}</th>` +
+    `<th>${t('mass.thMass')}</th><th>${t('mass.thByMass')}</th>` +
+    `<th>${t('mass.thValue')}</th><th>${t('mass.thMassOnly')}</th>` +
+    `<th>${t('mass.thReview')}</th>` +
+    '</tr></thead><tbody>' + rows + '</tbody></table>';
+
+  // one edit -> POST -> (optionally) rebuild the robot -> refresh + reopen
+  const apply = async (fetchArgs, { rebuild, okMsg } = {}) => {
+    try {
+      const resp = await fetch(...fetchArgs);
+      const r = await resp.json();
+      if (!resp.ok || r.error) { throw new Error(r.error ?? resp.status); }
+      log(okMsg ?? t('mass.setOk'), 'ok');
+      if (rebuild) {
+        loadRobot(currentInfo, { keepPose: true });
+        refreshHistory();
+      }
+      await refreshCompMeta();      // repaints this popup (see refreshCompMeta)
+      // sync the main tree so a mass-only toggle shows there too, not just here
+      if (viewer.robot) { buildJointRows(viewer.robot); }
+      return true;
+    } catch (e) {
+      log(t('mass.fail', { e: e.message ?? e }), 'err');
+      return false;
+    }
+  };
+  const post = (path, body) => [path, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body) }];
+
+  card.querySelectorAll('tr[data-link]').forEach(tr => {
+    const ln = tr.dataset.link;
+    // the source toggle: check -> pin an explicit target mass at the current
+    // computed mass (user then edits it); uncheck -> clear it, back to material
+    tr.querySelector('.bm')?.addEventListener('change', e => {
+      if (e.target.checked) {
+        const seed = data.links[ln]?.current_mass ?? 0.1;
+        apply(post('/api/set_masses', { link: ln, mass: seed }),
+              { rebuild: true, okMsg: t('mass.setMassOk', { name: ln, m: seed }) });
+      } else {
+        apply(post('/api/set_masses', { link: ln, mass: null }), { rebuild: true });
+      }
+    });
+    tr.querySelector('.md')?.addEventListener('change', e => {
+      const d = matPickDensity(e.target.value);
+      if (d === undefined) { e.target.value = ''; return; }   // placeholder / cancelled
+      apply(post('/api/set_material', { link: ln, density: d }), { rebuild: true });
+    });
+    tr.querySelector('.mt')?.addEventListener('change', e => {
+      const v = e.target.value.trim();
+      apply(post('/api/set_masses', { link: ln, mass: v ? Number(v) : null }),
+            { rebuild: true,
+              okMsg: v ? t('mass.setMassOk', { name: ln, m: v }) : undefined });
+    });
+    tr.querySelector('.mo')?.addEventListener('change', e => {
+      apply(post('/api/set_mass_only', { link: ln, on: e.target.checked }),
+            { rebuild: true });
+    });
+    tr.querySelector('.rv')?.addEventListener('change', e => {
+      apply(post('/api/set_mass_reviewed', { link: ln, reviewed: e.target.checked }),
+            { rebuild: false });      // acknowledgement changes no geometry
+    });
+  });
+
+  const bar = document.createElement('div');
+  bar.style.cssText = 'display:flex;gap:8px;margin-top:10px';
+  if (flaggedN) {
+    const ackAll = document.createElement('button');
+    ackAll.textContent = t('mass.ackAll');
+    ackAll.addEventListener('click', async () => {
+      for (const ln of (data.default_mass_links ?? [])) {
+        await fetch(...post('/api/set_mass_reviewed', { link: ln, reviewed: true }));
+      }
+      log(t('mass.setOk'), 'ok');
+      await refreshCompMeta();      // repaints this popup (see refreshCompMeta)
+    });
+    bar.appendChild(ackAll);
+  }
+  const close = document.createElement('button');
+  close.textContent = t('common.close');
+  close.addEventListener('click', () => ov.remove());
+  bar.appendChild(close);
+  card.appendChild(bar);
+  ov.appendChild(card);
+  (document.getElementById('viewer').parentElement || document.body)
+    .appendChild(ov);
+}
+document.getElementById('masslistbtn').addEventListener('click', () => {
+  // toggle: the button always responds -- close an open panel, else (re)open it
+  const p = document.getElementById('masslist');
+  if (p) { p.remove(); } else { openMassList(); }
+});
 
 function buildJointRows(robot) {
   jointsEl.innerHTML = '';
@@ -4369,51 +4650,82 @@ function fillLinkInfo(name) {
       : meta ? t('li.swUnset') : t('li.reextract');
   add(t('li.material'), matTxt);
   add(t('li.mesh'), `${meshFile} · ${Math.round(tris)} tris`);
-  // value 'custom' triggers the prompt; everything else is a density number
-  const matChoices = [['PLA', '1240'], ['ABS', '1040'], ['PETG', '1270'],
-    [t('li.matNylon'), '1140'], ['POM', '1410'], [t('li.matFR4'), '1850'],
-    [t('li.matAlu'), '2700'], [t('li.matSteel'), '7850'],
-    [t('li.matTitanium'), '4500'], [t('li.matCustom'), 'custom']];
-  rowsHtml.push(
-    `<tr><td>${t('li.setMaterial')}</td><td><select id="li_mat" style="width:100%;` +
-    `background:#15171a;color:#ddd;border:1px solid #444;` +
-    `border-radius:3px;font-size:11px">` +
-    `<option value="">${t('li.densityPlaceholder')}</option>` +
-    `<option value="">${t('li.densityReset')}</option>` +
-    matChoices.map(([label, val]) =>
-      `<option value="${val}">${val === 'custom' ? label : label + ' ' + val}` +
-      `</option>`).join('') +
-    `</select></td></tr>`);
+  // mass source: a checkbox picks target-mass vs material/density, then only
+  // the relevant control is shown (no disabled fields).  CAD mode only -- a
+  // URDF-input link edits its inertial through the block above.
+  const byMass = meta?.mass != null;
+  if (!urdfMode) {
+    rowsHtml.push(
+      `<tr><td>${t('mass.thByMass')}</td><td>` +
+      `<input type="checkbox" id="li_bm" ${byMass ? 'checked' : ''} ` +
+      `title="${t('mass.byMassTitle')}"> ${t('mass.byMass')}</td></tr>`);
+  }
+  if (byMass && !urdfMode) {
+    rowsHtml.push(
+      `<tr><td>${t('mass.thTarget')}</td><td>` +
+      `<input id="li_masst" type="number" step="any" min="0" ` +
+      `placeholder="${meta?.current_mass != null ? meta.current_mass.toFixed(3) : ''}" ` +
+      `value="${meta?.mass ?? ''}" style="width:80px;background:#15171a;color:#ddd;` +
+      `border:1px solid #444;border-radius:3px;font-size:11px"> kg</td></tr>`);
+  } else {
+    rowsHtml.push(
+      `<tr><td>${t('li.setMaterial')}</td><td>` +
+      matSelectHtml('li_mat', { style: 'width:100%;',
+        selected: meta?.override ?? meta?.density }) +
+      (meta?.override ? `<div class="mass-note">${meta.override.toFixed(0)} kg/m³ `
+        + `${t('li.override')}</div>` : '') +
+      `</td></tr>`);
+  }
   const jointHtml = j ? jointPanelHtml(j, jParentLink, name) : '';
   el.innerHTML = jointHtml +
     `<h2>🔎 ${name}</h2><table>${rowsHtml.join('')}</table>`;
   if (j) { wireJointPanel(el, j); }
-  const sel = el.querySelector('#li_mat');
-  sel.addEventListener('change', async () => {
-    let d = sel.value;
-    if (sel.selectedIndex === 1) { d = null; }            // remove override
-    else if (d === 'custom') {
-      d = prompt(t('li.densityPrompt'));
-      if (!d) { sel.selectedIndex = 0; return; }
-    } else if (!d) { return; }
+  // source toggle: check -> pin an explicit target mass at the current mass;
+  // uncheck -> clear it, back to material / density
+  const setMass = async (mass) => {
+    try {
+      const resp = await fetch('/api/set_masses', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ link: name, mass }) });
+      const r = await resp.json();
+      if (!resp.ok || r.error) { throw new Error(r.error ?? resp.status); }
+      log(mass != null ? t('mass.setMassOk', { name, m: mass }) : t('mass.setOk'), 'ok');
+      // refresh compMeta FIRST so the reselect below re-renders the popup in the
+      // new state (checkbox / override), not the stale pre-edit one
+      await refreshCompMeta();
+      reselectAfterLoad = name;   // reopen this popup when the reload completes
+      loadRobot(currentInfo, { keepPose: true });
+      refreshHistory();
+    } catch (err) { log(t('mass.fail', { e: err.message ?? err }), 'err'); }
+  };
+  el.querySelector('#li_bm')?.addEventListener('change', e => {
+    setMass(e.target.checked ? (meta?.current_mass ?? 0.1) : null);
+  });
+  const sel = el.querySelector('.li_mat');    // matSelectHtml emits a class (density mode only)
+  sel?.addEventListener('change', async () => {
+    const d = matPickDensity(sel.value);      // number, null (reset), or undefined
+    if (d === undefined) { sel.selectedIndex = 0; return; }
     op('setMaterial', { link: name, density: d });
     log(t('li.settingDensity', { name, d: d ?? t('li.swValue') }));
     try {
       const resp = await fetch('/api/set_material', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ link: name,
-                               density: d ? Number(d) : null }) });
+        body: JSON.stringify({ link: name, density: d }) });
       const r = await resp.json();
       if (!resp.ok || r.error) { throw new Error(r.error ?? resp.status); }
       log(t('li.densityOk'), 'ok');
+      await refreshCompMeta();    // fresh meta so the reselect shows the override
+      reselectAfterLoad = name;   // reopen this popup when the reload completes
       loadRobot(currentInfo, { keepPose: true });
       refreshHistory();
-      const reselect = name;
-      setTimeout(() => selectLink(reselect), 1500);
     } catch (e) {
       log(t('li.densityFail', { e: e.message ?? e }), 'err');
     }
+  });
+  el.querySelector('#li_masst')?.addEventListener('change', (e) => {
+    const v = e.target.value.trim();
+    setMass(v ? Number(v) : null);
   });
   const colInp = el.querySelector('#li_color');
   if (colInp) {
@@ -5352,7 +5664,16 @@ expLinks.forEach(a => a.addEventListener('click', async ev => {
   try {
     // ASYNC export: start the build (reports into _prog), watch the unified
     // progress panel live, then download the finished bytes
-    const r0 = await (await fetch('/api/export/zip/start?' + query)).json();
+    let r0 = await (await fetch('/api/export/zip/start?' + query)).json();
+    // default-mass gate: some links still use a guessed SolidWorks mass. Let the
+    // user fix them in the mass editor, or knowingly export anyway (&ack=1).
+    if (r0.default_mass_links && r0.default_mass_links.length) {
+      const links = r0.default_mass_links;
+      const msg = t('mass.exportBlockedTitle', { n: links.length })
+        + '\n\n' + links.join('\n') + '\n\n' + t('mass.exportAnyway');
+      if (!confirm(msg)) { openMassList(); return; }
+      r0 = await (await fetch('/api/export/zip/start?' + query + '&ack=1')).json();
+    }
     if (r0.error) { throw new Error(r0.error); }
     setProgressStop(() => {                     // ■ stop -> cooperative cancel
       log(t('export.cancelling'), 'wrn');
@@ -6546,6 +6867,13 @@ bulkMatSel?.addEventListener('change', () => {
   bulkSetDensity(Number(v));
 });
 window.addEventListener('keydown', ev => {
+  // Esc closes the rename / mass-list overlays first -- even when focus is in
+  // one of their fields (which would otherwise swallow the key below)
+  if (ev.key === 'Escape') {
+    const ov = document.getElementById('masslist')
+            || document.getElementById('renamelist');
+    if (ov) { ev.preventDefault(); ev.stopPropagation(); ov.remove(); return; }
+  }
   const ae = document.activeElement;
   const inField = /INPUT|SELECT|TEXTAREA/.test(ae?.tagName)
       || ae?.isContentEditable;

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -4548,6 +4548,13 @@ function fillLinkInfo(name) {
   const el = document.getElementById('linkinfo');
   const link = viewer.robot?.links?.[name];
   if (!link) { el.style.display = 'none'; return; }
+  // the selection bar (name + 👁/🗑/⌂/✕) is folded in as this panel's header so
+  // it is ONE panel, not two overlapping ones.  Park it outside #linkinfo before
+  // the innerHTML rebuild below so the element (and its listeners) survives.
+  const selbar = document.getElementById('selbar');
+  if (selbar && selbar.parentElement === el) {
+    document.getElementById('viewwrap').appendChild(selbar);
+  }
   const j = link.parent?.isURDFJoint ? link.parent : null;
   const box = ownLinkBox(link, new THREE.Box3());
   const size = box.isEmpty() ? null : box.getSize(new THREE.Vector3());
@@ -4690,8 +4697,14 @@ function fillLinkInfo(name) {
       `</td></tr>`);
   }
   const jointHtml = j ? jointPanelHtml(j, jParentLink, name) : '';
-  el.innerHTML = jointHtml +
-    `<h2>🔎 ${name}</h2><table>${rowsHtml.join('')}</table>`;
+  el.innerHTML = jointHtml + `<table>${rowsHtml.join('')}</table>`;
+  // re-insert the selection bar as the panel header (its buttons keep their
+  // listeners since the element was only moved, never recreated)
+  if (selbar) {
+    Object.assign(selbar.style, { position: 'static', border: 'none',
+      background: 'none', padding: '0', margin: '0 0 6px', width: 'auto' });
+    el.insertBefore(selbar, el.firstChild);
+  }
   if (j) { wireJointPanel(el, j); }
   // source toggle: check -> pin an explicit target mass at the current mass;
   // uncheck -> clear it, back to material / density
@@ -4789,6 +4802,7 @@ function fillLinkInfo(name) {
       }
     });
   }
+  dockPanelBelowViews(el);      // sit under the viewer's button row (was 76px)
   el.style.display = 'block';   // '' would fall back to the stylesheet's
                                 // display:none and never show
 }
@@ -4806,7 +4820,7 @@ function selectLink(linkName) {
   if (linkName) {
     _tintLink(linkName, _colorTint(linkName));   // red survives selection
     statusEl.textContent = t('sel.status', { name: linkName });
-    document.getElementById('selname').textContent = linkName;
+    document.getElementById('selname').textContent = '🔎 ' + linkName;
     document.getElementById('seleye').classList.toggle(
       'off', hiddenLinks.has(linkName));
     bar.style.display = 'flex';

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -739,6 +739,26 @@ def _parse_export_query(cls, query):
     }, None
 
 
+def _export_gate(cls, query):
+    """Block export while CAD-mode links still carry an unreviewed default
+    SolidWorks mass, so a guessed weight never silently reaches the URDF.
+
+    Bypassed with ``?ack=1`` (the client's "export anyway" after showing the
+    list, and the launch_it.sh one-liner).  Returns ``(payload, code)`` to send
+    back, or None to let the export proceed."""
+    if (query.get("ack") or ["0"])[0] == "1":
+        return None
+    if not _cad_mode(cls.pkg_dir):
+        return None
+    flagged = _default_mass_links(cls.pkg_dir, cls.urdf_rel)
+    if not flagged:
+        return None
+    return ({"error": f"{len(flagged)} link(s) still have a default SolidWorks "
+                       "mass (no material / unset). Set a mass or density, or "
+                       "acknowledge them, before export.",
+             "default_mass_links": sorted(flagged)}, 409)
+
+
 def _export_fname(robot_name, pkg, params):
     return (f"{robot_name}_glb.zip"
             if params["visual_fmt"] == "glb" and params["collision_fmt"] == "glb"
@@ -874,6 +894,131 @@ def _read_colors(pkg_dir, urdf_rel):
         return {}
     colors = cfg.get("colors")
     return colors if isinstance(colors, dict) else {}
+
+
+# SolidWorks uses this density (kg/m^3) when a part has no material assigned, so
+# a mass computed from it is a silent guess -- see _default_mass_links.
+_DEFAULT_SW_DENSITY = 1000.0
+
+
+def _default_mass_links(pkg_dir, urdf_rel):
+    """Link names whose mass looks like an unreviewed SolidWorks *default*.
+
+    A part with no material assigned still gets a mass from SolidWorks' default
+    density (~1000 kg/m^3), which then flows into the URDF labelled as an exact
+    value -- a silent error.  A link is flagged when its material is unset OR its
+    density is the SW default, UNLESS the user has resolved it: a per-link mass
+    (`masses:`) or density (`densities:`) override, a manual SolidWorks mass
+    override (``sw_mass_overridden``), or an explicit acknowledgement
+    (`mass_reviewed:`).  Returns an empty set for a non-CAD / missing package."""
+    if not pkg_dir or not urdf_rel:
+        return set()
+    gj = os.path.join(pkg_dir, "graph.json")
+    if not os.path.exists(gj):
+        return set()
+    from sw2robot.exporter.state import GraphState
+    try:
+        gs = GraphState.load(gj)
+    except Exception:
+        return set()
+    name = os.path.splitext(os.path.basename(urdf_rel))[0]
+    yml = os.path.join(pkg_dir, name + ".joints.yaml")
+    cfg = {}
+    if os.path.exists(yml):
+        import yaml as _yaml
+        try:
+            cfg = _yaml.safe_load(open(yml, encoding="utf-8").read()) or {}
+        except Exception:
+            cfg = {}
+    densities = cfg.get("densities") if isinstance(cfg.get("densities"), dict) else {}
+    masses = cfg.get("masses") if isinstance(cfg.get("masses"), dict) else {}
+    reviewed = set(cfg.get("mass_reviewed") or [])
+
+    def _resolved(c):
+        # override / acknowledgement keys may be the link name OR the SW name
+        for k in (c.link_name, c.name):
+            if k in densities or k in masses or k in reviewed:
+                return True
+        return bool(getattr(c, "sw_mass_overridden", False))
+
+    flagged = set()
+    for c in gs.components:
+        if _resolved(c):
+            continue
+        material_unset = not c.material
+        density_default = (c.density is not None
+                           and abs(c.density - _DEFAULT_SW_DENSITY) < 1.0)
+        if material_unset or density_default:
+            flagged.add(c.link_name)
+    return flagged
+
+
+def _urdf_link_masses(pkg_dir, urdf_rel):
+    """``{link name -> mass (kg)}`` parsed from the built URDF's ``<inertial>``.
+
+    This is the *actual* mass each link carries in the output (after SW-native /
+    density / target-mass resolution), so the editor can show the true value
+    rather than the raw CAD estimate.  Empty on any parse failure."""
+    if not pkg_dir or not urdf_rel:
+        return {}
+    path = os.path.join(pkg_dir, urdf_rel)
+    if not os.path.exists(path):
+        return {}
+    import xml.etree.ElementTree as ET
+    out = {}
+    try:
+        root = ET.parse(path).getroot()
+    except Exception:
+        return {}
+    for ln in root.findall("link"):
+        mass = ln.find("inertial/mass")
+        if mass is None:
+            continue
+        try:
+            out[ln.get("name")] = float(mass.get("value"))
+        except (TypeError, ValueError):
+            pass
+    return out
+
+
+def _urdf_child_joint_types(pkg_dir, urdf_rel):
+    """``{child link name -> parent joint type}`` from the built URDF, so the
+    mass editor can offer mass-only only on a fixed child without needing the
+    client's live robot.  Empty on any parse failure."""
+    if not pkg_dir or not urdf_rel:
+        return {}
+    path = os.path.join(pkg_dir, urdf_rel)
+    if not os.path.exists(path):
+        return {}
+    import xml.etree.ElementTree as ET
+    out = {}
+    try:
+        root = ET.parse(path).getroot()
+    except Exception:
+        return {}
+    for j in root.findall("joint"):
+        child = j.find("child")
+        if child is not None and child.get("link"):
+            out[child.get("link")] = j.get("type")
+    return out
+
+
+def _set_number_override(txt, mapkey, key, value):
+    """Add / replace / remove ``key: value`` in a numeric ``mapkey:`` block of
+    joints.yaml text (the shape ``densities:`` and ``masses:`` share).
+
+    ``value`` None (or falsy) removes the entry; the block is dropped entirely
+    once empty.  A freshly created block is prepended.  Returns the new text."""
+    m = re.search(r"(?m)^" + re.escape(mapkey) + r":\n((?:[ \t]+\S+:.*\n)*)", txt)
+    block = m.group(1) if m else ""
+    block = re.sub(r"(?m)^[ \t]+" + re.escape(key) + r":.*\n?", "", block)
+    if value:
+        block += f"  {key}: {float(value):g}\n"
+    if m:
+        return txt[:m.start()] \
+            + (f"{mapkey}:\n{block}" if block else "") \
+            + txt[m.end():]
+    return (f"{mapkey}:\n{block}" + txt) if block else txt
 
 
 def _upsert_yaml_map(txt, mapkey, key, value):
@@ -2297,6 +2442,7 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 name = os.path.splitext(os.path.basename(cls.urdf_rel))[0]
                 yml = os.path.join(cls.pkg_dir, name + ".joints.yaml")
                 overrides = {}
+                mass_overrides = {}
                 if os.path.exists(yml):
                     txt = open(yml, encoding="utf-8").read()
                     m = re.search(r"(?m)^densities:\n((?:[ \t]+\S+:.*\n)*)",
@@ -2308,14 +2454,58 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                                 overrides[k] = float(v)
                             except ValueError:
                                 pass
+                    m = re.search(r"(?m)^masses:\n((?:[ \t]+\S+:.*\n)*)", txt)
+                    if m:
+                        for ln in m.group(1).splitlines():
+                            k, _, v = ln.strip().partition(":")
+                            try:
+                                mass_overrides[k] = float(v)
+                            except ValueError:
+                                pass
+                reviewed = set()
+                if os.path.exists(yml):
+                    _, reviewed_list = _set_yaml_list_block(
+                        open(yml, encoding="utf-8").read(), "mass_reviewed")
+                    reviewed = set(reviewed_list)
                 colors = _read_colors(cls.pkg_dir, cls.urdf_rel)
+                # the actual per-link mass in the built URDF (after density /
+                # target-mass resolution) + which links still need review
+                urdf_masses = _urdf_link_masses(cls.pkg_dir, cls.urdf_rel)
+                joint_types = _urdf_child_joint_types(cls.pkg_dir, cls.urdf_rel)
+                default_links = _default_mass_links(cls.pkg_dir, cls.urdf_rel)
+                # Key by the FINAL display link name (what the viewer/URDF uses),
+                # and cover EVERY built link -- composed sub-assembly children and
+                # renamed links included -- so the mass editor lists them all, not
+                # just top-level graph components.  Resolve each display name back
+                # through the rename map to its graph component for material etc.
+                yml_txt = (open(yml, encoding="utf-8").read()
+                           if os.path.exists(yml) else "")
+                inv = _link_names_inverse(yml_txt)     # display name -> component key
+                by_ln = {c.link_name: c for c in gs.components}
+                by_nm = {c.name: c for c in gs.components}
+                names = list(urdf_masses) or [c.link_name for c in gs.components]
                 links = {}
-                for c in gs.components:
-                    links[c.link_name] = {
-                        "material": c.material, "density": c.density,
-                        "name": c.name,
-                        "override": overrides.get(c.link_name),
-                        "color": colors.get(c.link_name)}
+                for dl in names:
+                    key = inv.get(dl, dl)
+                    c = by_ln.get(key) or by_nm.get(key)
+                    cur = urdf_masses.get(dl)
+                    if cur is None and c is not None:
+                        cur = c.sw_mass
+                    links[dl] = {
+                        "material": c.material if c else None,
+                        "density": c.density if c else None,
+                        "name": c.name if c else None,
+                        "override": overrides.get(c.link_name) if c else None,
+                        "color": colors.get(c.link_name) if c else colors.get(dl),
+                        "sw_mass": c.sw_mass if c else None,
+                        "current_mass": cur,
+                        "mass": mass_overrides.get(c.link_name) if c else None,
+                        "mass_overridden_in_sw": bool(
+                            getattr(c, "sw_mass_overridden", False)) if c else False,
+                        "default_mass": (c.link_name in default_links) if c else False,
+                        "reviewed": bool(c and (c.link_name in reviewed
+                                                or c.name in reviewed)),
+                        "parent_joint": joint_types.get(dl)}
                 excluded = []
                 if os.path.exists(yml):
                     m = re.search(r"(?m)^exclude:\n((?:- .*\n)*)",
@@ -2333,6 +2523,12 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 return self._send_json({"links": links,
                                         "excluded": excluded,
                                         "colors": colors,
+                                        "default_mass_links": sorted(default_links),
+                                        # actual mass of EVERY built URDF link
+                                        # (incl. composed/merged sub-links that
+                                        # aren't top-level graph components) so
+                                        # the mass editor can list them all
+                                        "urdf_masses": urdf_masses,
                                         "mass_only": sorted(
                                             _read_mass_only(cls.pkg_dir))})
             if path == "/api/fs":
@@ -2588,6 +2784,9 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 params, err = _parse_export_query(cls, query)
                 if err:
                     return self._send_json({"error": err[0]}, err[1])
+                gate = _export_gate(cls, query)
+                if gate:
+                    return self._send_json(gate[0], gate[1])
                 try:
                     colors = (_read_colors(cls.pkg_dir, cls.urdf_rel)
                               if _cad_mode(cls.pkg_dir)
@@ -2613,6 +2812,9 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 params, err = _parse_export_query(cls, query)
                 if err:
                     return self._send_json({"error": err[0]}, err[1])
+                gate = _export_gate(cls, query)
+                if gate:
+                    return self._send_json(gate[0], gate[1])
                 gen = _prog_start("export", _EXPORT_STAGES)
                 if gen is None:
                     return self._send_json(
@@ -2670,7 +2872,9 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 pkg_name = (query.get("name") or [""])[0].strip() or None
                 pkg = ros_pkg_name(cls.robot_name, pkg_name)
                 host = self.headers.get("Host") or "localhost:8090"
-                zip_q = "ros=2&meshes=dae"
+                # ack=1: the one-liner is fire-and-forget and can't act on the
+                # default-mass gate's 409, so it always bypasses it
+                zip_q = "ros=2&meshes=dae&ack=1"
                 if pkg_name:
                     zip_q += "&name=" + pkg_name
                 zip_url = f"http://{host}/api/export/zip?{zip_q}"
@@ -3340,19 +3544,11 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                     txt = f.read()
                 link = _link_names_inverse(txt).get(link, link)
                 _snapshot(cls.pkg_dir, yml, f"material of {link[:30]}")
-                m = re.search(r"(?m)^densities:\n((?:[ \t]+\S+:.*\n)*)", txt)
-                block = m.group(1) if m else ""
-                pat = re.compile(r"(?m)^[ \t]+" + re.escape(link)
-                                 + r":.*\n?")
-                block = pat.sub("", block)
+                txt = _set_number_override(txt, "densities", link, density)
                 if density:
-                    block += f"  {link}: {float(density):g}\n"
-                if m:
-                    txt = txt[:m.start()] \
-                        + (f"densities:\n{block}" if block else "") \
-                        + txt[m.end():]
-                elif block:
-                    txt = f"densities:\n{block}" + txt
+                    # a density and a target mass are two ways to define the
+                    # same weight -- keep them mutually exclusive per link
+                    txt = _set_number_override(txt, "masses", link, None)
                 with open(yml, "w", encoding="utf-8") as f:
                     f.write(txt)
                 from sw2robot.exporter.export import build
@@ -3363,6 +3559,126 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                         {"error": f"rebuild failed: {e}"}, 500)
                 print(f"[sw2robot.web] set_material: {link} -> {density}")
                 return self._send_json({"link": link, "density": density})
+            if parsed.path == "/api/set_masses":
+                # per-link TARGET mass (kg): rescales the inertial to an exact
+                # weight (issue #29).  Mirrors set_material but writes a `masses:`
+                # block; mutually exclusive with a density override, so setting a
+                # mass clears any `densities:` entry for the link.  None removes it.
+                cls = type(self)
+                n = int(self.headers.get("Content-Length", 0))
+                body = json.loads(self.rfile.read(n) or b"{}")
+                link = body.get("link")
+                mass = body.get("mass")           # None = remove override
+                if not cls.pkg_dir or not link:
+                    return self._send_json({"error": "no package/link"}, 400)
+                if mass is not None:
+                    try:
+                        mass = float(mass)
+                    except (TypeError, ValueError):
+                        return self._send_json(
+                            {"error": f"mass {body.get('mass')!r} is not a number"},
+                            400)
+                    if not (mass > 0):
+                        return self._send_json(
+                            {"error": "mass must be positive"}, 400)
+                if not _cad_mode(cls.pkg_dir):
+                    return self._send_json(
+                        {"error": "target mass is only editable in CAD mode; "
+                                  "use set_inertial in URDF-input mode"}, 400)
+                name = os.path.splitext(os.path.basename(cls.urdf_rel))[0]
+                yml = os.path.join(cls.pkg_dir, name + ".joints.yaml")
+                if not os.path.exists(yml):
+                    return self._send_json(
+                        {"error": "joints.yaml not found"}, 400)
+                with open(yml, encoding="utf-8") as f:
+                    txt = f.read()
+                link = _link_names_inverse(txt).get(link, link)
+                _snapshot(cls.pkg_dir, yml, f"mass of {link[:30]}")
+                txt = _set_number_override(txt, "masses", link, mass)
+                if mass is not None:
+                    txt = _set_number_override(txt, "densities", link, None)
+                with open(yml, "w", encoding="utf-8") as f:
+                    f.write(txt)
+                from sw2robot.exporter.export import build
+                try:
+                    build(cls.pkg_dir, config_path=yml)
+                except Exception as e:
+                    return self._send_json(
+                        {"error": f"rebuild failed: {e}"}, 500)
+                print(f"[sw2robot.web] set_masses: {link} -> {mass}")
+                return self._send_json({"link": link, "mass": mass})
+            if parsed.path == "/api/set_mass_reviewed":
+                # acknowledge (or un-acknowledge) that a link's default SW mass
+                # has been reviewed -- clears the export gate for it WITHOUT
+                # changing any geometry, so no rebuild is needed.  Stored as a
+                # `mass_reviewed:` list block in joints.yaml.
+                cls = type(self)
+                n = int(self.headers.get("Content-Length", 0))
+                body = json.loads(self.rfile.read(n) or b"{}")
+                link = body.get("link")
+                on = bool(body.get("reviewed", True))
+                if not cls.pkg_dir or not link:
+                    return self._send_json({"error": "no package/link"}, 400)
+                if not _cad_mode(cls.pkg_dir):
+                    return self._send_json(
+                        {"error": "mass review is a CAD-mode concept"}, 400)
+                name = os.path.splitext(os.path.basename(cls.urdf_rel))[0]
+                yml = os.path.join(cls.pkg_dir, name + ".joints.yaml")
+                if not os.path.exists(yml):
+                    return self._send_json(
+                        {"error": "joints.yaml not found"}, 400)
+                with open(yml, encoding="utf-8") as f:
+                    txt = f.read()
+                link = _link_names_inverse(txt).get(link, link)
+                _snapshot(cls.pkg_dir, yml, f"review mass of {link[:30]}")
+                txt, reviewed = _set_yaml_list_block(
+                    txt, "mass_reviewed",
+                    add=[link] if on else (), remove=[link])
+                with open(yml, "w", encoding="utf-8") as f:
+                    f.write(txt)
+                print(f"[sw2robot.web] set_mass_reviewed: {link} on={on}")
+                return self._send_json({"link": link, "reviewed": on,
+                                        "mass_reviewed": reviewed})
+            if parsed.path == "/api/set_mass_only":
+                # toggle a link's mass-only flag (keep the weight, drop the
+                # geometry).  Stored in the `mass_only:` list; the build enforces
+                # "fixed child only" and warns otherwise.  Rebuilds.
+                cls = type(self)
+                n = int(self.headers.get("Content-Length", 0))
+                body = json.loads(self.rfile.read(n) or b"{}")
+                link = body.get("link")
+                on = bool(body.get("on", True))
+                if not cls.pkg_dir or not link:
+                    return self._send_json({"error": "no package/link"}, 400)
+                if not _cad_mode(cls.pkg_dir):
+                    return self._send_json(
+                        {"error": "mass-only is edited via set_types in "
+                                  "URDF-input mode"}, 400)
+                name = os.path.splitext(os.path.basename(cls.urdf_rel))[0]
+                yml = os.path.join(cls.pkg_dir, name + ".joints.yaml")
+                if not os.path.exists(yml):
+                    return self._send_json(
+                        {"error": "joints.yaml not found"}, 400)
+                with open(yml, encoding="utf-8") as f:
+                    txt = f.read()
+                link = _link_names_inverse(txt).get(link, link)
+                _snapshot(cls.pkg_dir, yml, f"mass-only {link[:30]}")
+                txt = _set_mass_only_members(
+                    txt, {link} if on else set(), set() if on else {link})
+                with open(yml, "w", encoding="utf-8") as f:
+                    f.write(txt)
+                from sw2robot.exporter.export import build
+                try:
+                    build(cls.pkg_dir, config_path=yml)
+                except Exception as e:
+                    return self._send_json(
+                        {"error": f"rebuild failed: {e}"}, 500)
+                from sw2robot.exporter.ros_export import _read_mass_only
+                applied = link in _read_mass_only(cls.pkg_dir)
+                print(f"[sw2robot.web] set_mass_only: {link} on={on} "
+                      f"applied={applied}")
+                return self._send_json({"link": link, "on": on,
+                                        "applied": applied})
             if parsed.path == "/api/set_color":
                 # per-link visual colour override, stored as a `colors:` block in
                 # joints.yaml ({component name -> '#RRGGBB'}).  The viewer paints

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1013,7 +1013,9 @@ def _set_number_override(txt, mapkey, key, value):
     block = m.group(1) if m else ""
     block = re.sub(r"(?m)^[ \t]+" + re.escape(key) + r":.*\n?", "", block)
     if value:
-        block += f"  {key}: {float(value):g}\n"
+        # .10g keeps up to 10 significant figures (a `:g` default of 6 silently
+        # rounded precise target masses) while avoiding trailing-zero noise
+        block += f"  {key}: {float(value):.10g}\n"
     if m:
         return txt[:m.start()] \
             + (f"{mapkey}:\n{block}" if block else "") \
@@ -2441,12 +2443,14 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                     os.path.join(cls.pkg_dir, "graph.json"))
                 name = os.path.splitext(os.path.basename(cls.urdf_rel))[0]
                 yml = os.path.join(cls.pkg_dir, name + ".joints.yaml")
+                # read joints.yaml once and reuse for every block below
+                yml_txt = (open(yml, encoding="utf-8").read()
+                           if os.path.exists(yml) else "")
                 overrides = {}
                 mass_overrides = {}
-                if os.path.exists(yml):
-                    txt = open(yml, encoding="utf-8").read()
+                if yml_txt:
                     m = re.search(r"(?m)^densities:\n((?:[ \t]+\S+:.*\n)*)",
-                                  txt)
+                                  yml_txt)
                     if m:
                         for ln in m.group(1).splitlines():
                             k, _, v = ln.strip().partition(":")
@@ -2454,7 +2458,7 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                                 overrides[k] = float(v)
                             except ValueError:
                                 pass
-                    m = re.search(r"(?m)^masses:\n((?:[ \t]+\S+:.*\n)*)", txt)
+                    m = re.search(r"(?m)^masses:\n((?:[ \t]+\S+:.*\n)*)", yml_txt)
                     if m:
                         for ln in m.group(1).splitlines():
                             k, _, v = ln.strip().partition(":")
@@ -2463,9 +2467,9 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                             except ValueError:
                                 pass
                 reviewed = set()
-                if os.path.exists(yml):
+                if yml_txt:
                     _, reviewed_list = _set_yaml_list_block(
-                        open(yml, encoding="utf-8").read(), "mass_reviewed")
+                        yml_txt, "mass_reviewed")
                     reviewed = set(reviewed_list)
                 colors = _read_colors(cls.pkg_dir, cls.urdf_rel)
                 # the actual per-link mass in the built URDF (after density /
@@ -2478,8 +2482,6 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 # renamed links included -- so the mass editor lists them all, not
                 # just top-level graph components.  Resolve each display name back
                 # through the rename map to its graph component for material etc.
-                yml_txt = (open(yml, encoding="utf-8").read()
-                           if os.path.exists(yml) else "")
                 inv = _link_names_inverse(yml_txt)     # display name -> component key
                 by_ln = {c.link_name: c for c in gs.components}
                 by_nm = {c.name: c for c in gs.components}
@@ -2507,9 +2509,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                                                 or c.name in reviewed)),
                         "parent_joint": joint_types.get(dl)}
                 excluded = []
-                if os.path.exists(yml):
-                    m = re.search(r"(?m)^exclude:\n((?:- .*\n)*)",
-                                  open(yml, encoding="utf-8").read())
+                if yml_txt:
+                    m = re.search(r"(?m)^exclude:\n((?:- .*\n)*)", yml_txt)
                     if m:
                         excluded = [ln[2:].strip()
                                     for ln in m.group(1).splitlines()]

--- a/sw2robot/exporter/inertia.py
+++ b/sw2robot/exporter/inertia.py
@@ -143,6 +143,38 @@ def link_inertial_from_sw(mass, com_local, inertia6_local,
     }
 
 
+def rescale_to_mass(info, target_mass):
+    """Rescale a computed inertial dict to an exact target mass (kg).
+
+    ``info`` is a dict as returned by :func:`link_inertial` /
+    :func:`link_inertial_from_sw` (``{mass, com, inertia, method}``).  For a
+    rigid body of fixed geometry, changing the (uniform) density scales the
+    mass and the full inertia tensor by the SAME factor, while the centre of
+    mass is unchanged -- so we multiply ``mass`` and all six inertia components
+    by ``target_mass / mass`` and leave ``com`` alone.  ``method`` is annotated
+    with ``"->mass"`` so the provenance report shows the rescale happened.
+
+    Returns a new dict (does not mutate ``info``).  If ``info`` is falsy or its
+    mass is non-positive/non-finite, returns ``info`` unchanged (nothing sane to
+    scale from)."""
+    if not info:
+        return info
+    try:
+        m0 = float(info["mass"])
+        target = float(target_mass)
+    except (TypeError, ValueError, KeyError):
+        return info
+    if not (np.isfinite(m0) and m0 > 0 and np.isfinite(target) and target > 0):
+        return info
+    factor = target / m0
+    return {
+        "mass": target,
+        "com": list(info["com"]),
+        "inertia": tuple(float(x) * factor for x in info["inertia"]),
+        "method": f'{info.get("method", "?")}->mass',
+    }
+
+
 def validate_inertia(mass, inertia6, rel_tol=1e-6):
     """Physics sanity-check one link's inertial; return a list of problem
     strings (empty list == OK).

--- a/sw2robot/exporter/model.py
+++ b/sw2robot/exporter/model.py
@@ -164,6 +164,19 @@ def _sw_mass_props(mp):
     return mass, [float(x) for x in com], inertia6
 
 
+def _sw_mass_overridden(mp):
+    """Did the user manually override mass properties on this part in the
+    SolidWorks "Override Mass Properties" dialog?
+
+    When true, the reported ``Mass`` is a deliberate user value rather than the
+    material/geometry default, so the mass editor must not flag it as unset.
+    The override booleans live on different interface versions under different
+    names, so probe each defensively (``safe_prop`` returns None on a missing
+    attribute); any one being set counts as an override."""
+    return any(bool(safe_prop(mp, a)) for a in (
+        "OverrideMass", "OverrideCenterOfMass", "OverrideMomentsOfInertia"))
+
+
 @dataclass
 class Component:
     name: str
@@ -183,9 +196,17 @@ class Component:
     sw_mass: float | None = None              # kg
     sw_com: list | None = None                # centre of mass [x,y,z] (m)
     sw_inertia: list | None = None            # (ixx,ixy,ixz,iyy,iyz,izz) about COM
+    # True when the user manually overrode mass properties in SolidWorks'
+    # "Override Mass Properties" dialog: the sw_mass is then a deliberate value,
+    # not the material/geometry default -- so the mass editor must not flag it.
+    sw_mass_overridden: bool = False
     # set when a per-link density override (config / web editor) should drive
     # the inertial from the mesh, overriding the SolidWorks-native values
     density_override: bool = False
+    # per-link target mass (kg): the inertial is rescaled to this exact weight
+    # (config `masses:` / the web editor), mutually exclusive with a density
+    # override -- see exporter.inertia.rescale_to_mass
+    mass_target: float | None = None
     # standard hardware (screw/bolt/nut/washer/pin): weld it FIXED to whatever it
     # fastens and never let it be a tree parent -- see is_fastener_part
     is_fastener: bool = False
@@ -412,6 +433,12 @@ def extract_components(doc, exclude=None, progress=None):
                     mass, com, inertia6 = _sw_mass_props(mp)
                     if mass is not None:
                         sw = {"mass": mass, "com": com, "inertia": inertia6}
+                    # a manual SW mass-properties override means the mass is a
+                    # deliberate value, not the material/geometry default -- the
+                    # mass editor must not flag it (see _sw_mass_overridden)
+                    if _sw_mass_overridden(mp):
+                        sw = (sw or {})
+                        sw["overridden"] = True
                 except Exception:
                     pass
         except Exception:
@@ -463,7 +490,8 @@ def extract_components(doc, exclude=None, progress=None):
                                fixed=fixed, dof=dof,
                                material=material, density=density,
                                sw_mass=sw.get("mass"), sw_com=sw.get("com"),
-                               sw_inertia=sw.get("inertia")))
+                               sw_inertia=sw.get("inertia"),
+                               sw_mass_overridden=sw.get("overridden", False)))
     if n_skipped or n_excluded:
         print(f"      (skipped {n_skipped} suppressed/unnamed, "
               f"excluded {n_excluded} components)")
@@ -2518,7 +2546,9 @@ def _component_states(comps):
             world=[float(x) for x in c.world.flatten()],
             fixed=c.fixed, dof=c.dof, mesh_file=c.mesh_file,
             material=c.material, density=c.density,
-            sw_mass=c.sw_mass, sw_com=c.sw_com, sw_inertia=c.sw_inertia)
+            sw_mass=c.sw_mass, sw_com=c.sw_com, sw_inertia=c.sw_inertia,
+            sw_mass_overridden=c.sw_mass_overridden,
+            mass_target=c.mass_target)
             for c in comps]
 
 
@@ -2675,6 +2705,8 @@ def from_graph(graph, exclude=None, expand=None, no_expand=None):
             fixed=cs.fixed, dof=cs.dof, mesh_file=cs.mesh_file,
             material=cs.material, density=cs.density,
             sw_mass=cs.sw_mass, sw_com=cs.sw_com, sw_inertia=cs.sw_inertia,
+            sw_mass_overridden=getattr(cs, "sw_mass_overridden", False),
+            mass_target=getattr(cs, "mass_target", None),
             mass_only=getattr(cs, "mass_only", False)))
     names = {c.name for c in comps}
     adjacency = {}
@@ -2787,7 +2819,9 @@ def _expand_one(inst, sub, comps, adjacency, ground, deep=None, hidden=None):
             is_subassembly=cs.is_subassembly, world=world,
             fixed=False, dof=None, mesh_file=cs.mesh_file,
             material=cs.material, density=cs.density,
-            sw_mass=cs.sw_mass, sw_com=cs.sw_com, sw_inertia=cs.sw_inertia))
+            sw_mass=cs.sw_mass, sw_com=cs.sw_com, sw_inertia=cs.sw_inertia,
+            sw_mass_overridden=getattr(cs, "sw_mass_overridden", False),
+            mass_target=getattr(cs, "mass_target", None)))
         name_map[cs.name] = gname
         local_of[cs.name] = local
         world_of[cs.name] = world
@@ -3026,6 +3060,30 @@ def build_model(graph, robot_name=None, base_hint=None, config=None,
                 c.density_override = True
             else:
                 print(f"      WARN: densities: '{k}' matched no link")
+
+    if config and config.get("masses"):
+        # per-link target mass (kg) -- the web editor's direct-weight setting.
+        # Same name matching as densities.  Mutually exclusive with a density
+        # override: a target mass rescales the inertial to an exact weight, so
+        # clear any density override on the same link (mass wins).  Consumed in
+        # urdf_writer._inertial_xml via exporter.inertia.rescale_to_mass.
+        by_ln = {c.link_name: c for c in comps}
+        by_nm = {c.name: c for c in comps}
+        for k, v in config["masses"].items():
+            c = by_ln.get(str(k)) or by_nm.get(str(k))
+            if c is not None:
+                try:
+                    m = float(v)
+                except (TypeError, ValueError):
+                    print(f"      WARN: masses: '{k}' -> {v!r} is not a number")
+                    continue
+                if not (m > 0):
+                    print(f"      WARN: masses: '{k}' -> {m} is not positive")
+                    continue
+                c.mass_target = m
+                c.density_override = False   # mass wins over any density override
+            else:
+                print(f"      WARN: masses: '{k}' matched no link")
 
     if config and config.get("mass_only"):
         # mass-only links: keep the weight, drop the geometry.  Same name

--- a/sw2robot/exporter/state.py
+++ b/sw2robot/exporter/state.py
@@ -35,6 +35,14 @@ class ComponentState(BaseModel):
     sw_mass: float | None = None              # kg
     sw_com: list[float] | None = None         # centre of mass [x,y,z] (m)
     sw_inertia: list[float] | None = None     # (ixx,ixy,ixz,iyy,iyz,izz) about COM
+    # True when the user manually overrode mass properties in SolidWorks (the
+    # "Override Mass Properties" dialog): sw_mass is then a deliberate value, not
+    # the material/geometry default. False on older extracts.
+    sw_mass_overridden: bool = False
+    # per-link target mass (kg): the inertial is rescaled to this exact weight
+    # (config `masses:` / the web editor). Mutually exclusive with a density
+    # override. None on older extracts / when no target is set.
+    mass_target: float | None = None
     # mass-only: keep the part's weight but drop its visual/collision geometry.
     # Valid only on a fixed child -- its inertial is lumped into the fixed parent
     # on export, so the parent's mass/inertia accounts for it without a mesh.

--- a/sw2robot/exporter/urdf_writer.py
+++ b/sw2robot/exporter/urdf_writer.py
@@ -77,6 +77,10 @@ def _inertial_xml(comp, mesh_dir, density):
        SolidWorks material density winning over the global default.
     3. A small placeholder if neither is usable.
 
+    Finally, if the link carries a per-link target mass (``comp.mass_target``,
+    the ``masses:`` override), whatever inertial the above produced is rescaled
+    to that exact weight (mass + tensor scale together, com unchanged).
+
     Returns ``(xml_lines, method, problems)`` so the caller can report which
     source / approximation each link used and flag any physically invalid
     inertial (``problems`` is a list of sanity-check failures, empty if OK)."""
@@ -102,6 +106,13 @@ def _inertial_xml(comp, mesh_dir, density):
             comp.visual_xyz, comp.visual_rpy, density=d)
     if info is None:
         info = _PLACEHOLDER_INERTIAL
+    # 4. per-link target mass: rescale whatever inertial we derived (SW-native,
+    # mesh, or placeholder) to the exact requested weight -- see the `masses:`
+    # override applied in model.build.  Mass and the full tensor scale together;
+    # the com is unchanged (exporter.inertia.rescale_to_mass).
+    mass_target = getattr(comp, "mass_target", None)
+    if mass_target:
+        info = _inertia.rescale_to_mass(info, mass_target)
     ixx, ixy, ixz, iyy, iyz, izz = info["inertia"]
     lines = [
         "    <inertial>",

--- a/tests/test_cad_mode_webserver.py
+++ b/tests/test_cad_mode_webserver.py
@@ -109,6 +109,32 @@ def _joints_yaml(pkg):
     return (pkg / "fingertip.joints.yaml").read_text(encoding="utf-8")
 
 
+def _link(root, name):
+    return next(l for l in root.findall("link") if l.get("name") == name)
+
+
+# --------------------------------------------------------------- set_mass_only
+def test_set_mass_only_drops_geometry_in_working_urdf(server):
+    """Toggling mass-only on a fixed child strips its visual/collision from the
+    served URDF straight away (weight kept), and clears it back on toggle-off."""
+    base, _pkg = server
+    assert _link(_served_urdf(base), SCREW_LINK).find("visual") is not None
+
+    code, r = _post(base, "/api/set_mass_only", {"link": SCREW_LINK, "on": True})
+    assert code == 200 and r["applied"] is True
+    scr = _link(_served_urdf(base), SCREW_LINK)
+    assert scr.find("visual") is None and scr.find("collision") is None
+    assert scr.find("inertial") is not None            # weight kept
+    # /api/components reports it mass-only + parent_joint fixed (drives the UI)
+    comp = _get_json(base, "/api/components")
+    assert SCREW_LINK in comp["mass_only"]
+    assert comp["links"][SCREW_LINK]["parent_joint"] == "fixed"
+
+    code, r = _post(base, "/api/set_mass_only", {"link": SCREW_LINK, "on": False})
+    assert code == 200 and r["applied"] is False
+    assert _link(_served_urdf(base), SCREW_LINK).find("visual") is not None
+
+
 # --------------------------------------------------------------- set_limits
 def test_set_limits_reflected_without_rebuild(server):
     base, pkg = server

--- a/tests/test_mass_editor_webserver.py
+++ b/tests/test_mass_editor_webserver.py
@@ -1,0 +1,242 @@
+"""CAD-mode mass-editor endpoints (Part C): /api/components mass fields,
+/api/set_masses (target mass, mutually exclusive with density), the
+/api/set_mass_reviewed acknowledgement, /api/set_mass_only toggle, and the
+default-mass export gate.
+
+Drives a real in-process HTTP server against a synthetic CAD package (a
+graph.json with known material/density state + a joints.yaml), so the
+default-mass detection is deterministic without needing SolidWorks."""
+import json
+import threading
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+
+import numpy as np
+import pytest
+import yaml
+
+
+def _eye():
+    return list(np.eye(4).flatten())
+
+
+def _free_port():
+    import socket
+    s = socket.socket()
+    s.bind(("", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def _get(base, path):
+    with urllib.request.urlopen(base + path) as r:
+        return r.read().decode("utf-8")
+
+
+def _get_json(base, path):
+    return json.loads(_get(base, path))
+
+
+def _post(base, path, body):
+    req = urllib.request.Request(
+        base + path, data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"}, method="POST")
+    try:
+        with urllib.request.urlopen(req) as r:
+            return r.status, json.loads(r.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read().decode("utf-8"))
+
+
+def _served_urdf(base):
+    return ET.fromstring(_get(base, _get_json(base, "/api/info")["urdf"]))
+
+
+def _link_mass(base, link):
+    for l in _served_urdf(base).findall("link"):
+        if l.get("name") == link:
+            return float(l.find("inertial/mass").get("value"))
+    raise KeyError(link)
+
+
+@pytest.fixture
+def server(tmp_path):
+    from sw2robot.editor import webserver
+    from sw2robot.exporter.export import build
+    from sw2robot.exporter.state import ComponentState, GraphState
+
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    GraphState(
+        robot_name="demo", source_assembly="x.SLDASM",
+        components=[
+            # material assigned + non-default density -> never flagged
+            ComponentState(name="base", link_name="base", world=_eye(),
+                           fixed=True, material="ABS", density=1040.0,
+                           sw_mass=1.0, sw_com=[0, 0, 0],
+                           sw_inertia=[1, 0, 0, 1, 0, 1]),
+            # no material, SW default ~1000 density -> flagged as default mass
+            ComponentState(name="guess", link_name="guess", world=_eye(),
+                           density=1000.0, sw_mass=0.2, sw_com=[0, 0, 0],
+                           sw_inertia=[2, 0, 0, 2, 0, 2]),
+        ]).save(str(pkg / "graph.json"))
+    cfg = pkg / "demo.joints.yaml"
+    cfg.write_text(yaml.safe_dump({
+        "base": "base",
+        "joints": [{"parent": "base", "child": "guess", "type": "fixed"}]}))
+    build(str(pkg), config_path=str(cfg))
+
+    httpd, port = webserver._bind_free_port(webserver._Handler, _free_port())
+    httpd.daemon_threads = True
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{port}"
+    try:
+        assert _get_json(base, f"/api/open?path={pkg}")["mode"] == "cad"
+        yield base, pkg
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        webserver._um["state"] = None
+
+
+def _yaml(pkg):
+    return yaml.safe_load((pkg / "demo.joints.yaml").read_text()) or {}
+
+
+# --------------------------------------------------------------- /api/components
+
+def test_components_exposes_mass_fields_and_default_flag(server):
+    base, _pkg = server
+    r = _get_json(base, "/api/components")
+    assert r["default_mass_links"] == ["guess"]
+    # links are keyed by the FINAL display name: the root component "base" is
+    # emitted as the URDF root link "base_link"; every built link is present
+    base_l, guess_l = r["links"]["base_link"], r["links"]["guess"]
+    # base: assigned material, has SW mass, not flagged
+    assert base_l["default_mass"] is False
+    assert base_l["material"] == "ABS"
+    assert np.isclose(base_l["current_mass"], 1.0)
+    # guess: default mass, flagged, not yet reviewed
+    assert guess_l["default_mass"] is True
+    assert guess_l["reviewed"] is False
+    assert guess_l["mass"] is None                       # no target override yet
+    assert np.isclose(guess_l["current_mass"], 0.2)      # from the built URDF
+
+
+# --------------------------------------------------------------- /api/set_masses
+
+def test_set_masses_sets_urdf_mass_and_resolves_flag(server):
+    base, pkg = server
+    code, r = _post(base, "/api/set_masses", {"link": "guess", "mass": 0.5})
+    assert code == 200 and np.isclose(r["mass"], 0.5)
+    assert np.isclose(_link_mass(base, "guess"), 0.5)    # rescaled in the URDF
+    assert _yaml(pkg)["masses"]["guess"] == 0.5
+    # setting a mass resolves the default-mass flag
+    assert _get_json(base, "/api/components")["default_mass_links"] == []
+
+
+def test_components_reflects_stored_overrides_for_repopulation(server):
+    """The panel repopulates its inputs from /api/components, so the payload must
+    echo back stored overrides (target mass, density) + parent_joint (which gates
+    the mass-only checkbox)."""
+    base, _pkg = server
+    _post(base, "/api/set_masses", {"link": "guess", "mass": 0.5})
+    _post(base, "/api/set_material", {"link": "base_link", "density": 2700})
+    r = _get_json(base, "/api/components")
+    g, b = r["links"]["guess"], r["links"]["base_link"]
+    assert g["mass"] == 0.5            # target-mass field repopulates
+    assert b["override"] == 2700       # density field repopulates
+    assert g["parent_joint"] == "fixed"   # fixed child -> mass-only enabled
+    assert b["parent_joint"] is None      # root link -> mass-only disabled
+
+
+def test_set_masses_rejects_non_positive(server):
+    base, _pkg = server
+    code, r = _post(base, "/api/set_masses", {"link": "guess", "mass": 0})
+    assert code == 400 and "positive" in r["error"]
+
+
+def test_set_masses_clears_density_and_vice_versa(server):
+    """Mass and density are mutually exclusive per link."""
+    base, pkg = server
+    _post(base, "/api/set_material", {"link": "guess", "density": 1500})
+    assert _yaml(pkg).get("densities", {}).get("guess") == 1500
+    # now set a target mass -> the density entry for the link is dropped
+    _post(base, "/api/set_masses", {"link": "guess", "mass": 0.4})
+    y = _yaml(pkg)
+    assert "guess" not in y.get("densities", {})
+    assert y["masses"]["guess"] == 0.4
+    # and back the other way: setting density drops the mass entry
+    _post(base, "/api/set_material", {"link": "guess", "density": 900})
+    y = _yaml(pkg)
+    assert "guess" not in y.get("masses", {})
+    assert y["densities"]["guess"] == 900
+
+
+# ----------------------------------------------------------- /api/set_mass_reviewed
+
+def test_set_mass_reviewed_clears_flag_without_changing_mass(server):
+    base, pkg = server
+    before = _link_mass(base, "guess")
+    code, r = _post(base, "/api/set_mass_reviewed",
+                    {"link": "guess", "reviewed": True})
+    assert code == 200 and r["reviewed"] is True
+    assert _yaml(pkg)["mass_reviewed"] == ["guess"]
+    comp = _get_json(base, "/api/components")
+    assert comp["default_mass_links"] == []
+    assert comp["links"]["guess"]["reviewed"] is True
+    assert np.isclose(_link_mass(base, "guess"), before)   # mass untouched
+    # un-review restores the flag
+    _post(base, "/api/set_mass_reviewed", {"link": "guess", "reviewed": False})
+    assert _get_json(base, "/api/components")["default_mass_links"] == ["guess"]
+
+
+# --------------------------------------------------------------- /api/set_mass_only
+
+def test_set_mass_only_toggles_on_fixed_child(server):
+    base, pkg = server
+    code, r = _post(base, "/api/set_mass_only", {"link": "guess", "on": True})
+    assert code == 200 and r["applied"] is True
+    assert "guess" in (_yaml(pkg).get("mass_only") or [])
+    code, r = _post(base, "/api/set_mass_only", {"link": "guess", "on": False})
+    assert code == 200 and r["applied"] is False
+
+
+# --------------------------------------------------------------- export gate
+
+def _get_code(base, path):
+    req = urllib.request.Request(base + path)
+    try:
+        with urllib.request.urlopen(req) as r:
+            return r.status, json.loads(r.read().decode())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        try:
+            return e.code, json.loads(body)
+        except json.JSONDecodeError:
+            return e.code, {}
+
+
+def test_export_start_blocked_lists_default_links(server):
+    base, _pkg = server
+    # the export endpoints are GET; an unresolved default-mass link -> 409
+    code, r = _get_code(base, "/api/export/zip/start?ros=2&meshes=dae")
+    assert code == 409
+    assert r["default_mass_links"] == ["guess"]
+    # acknowledging resolves it, so the gate would no longer block
+    _post(base, "/api/set_mass_reviewed", {"link": "guess", "reviewed": True})
+    assert _get_json(base, "/api/components")["default_mass_links"] == []
+
+
+def test_export_gate_helper_blocks_and_ack_bypasses(server):
+    from sw2robot.editor import webserver
+    _base, pkg = server
+
+    class Cls:
+        pkg_dir = str(pkg)
+        urdf_rel = "urdf/demo.urdf"
+
+    assert webserver._export_gate(Cls, {}) is not None        # blocked
+    assert webserver._export_gate(Cls, {"ack": ["1"]}) is None  # bypass

--- a/tests/test_mass_override.py
+++ b/tests/test_mass_override.py
@@ -70,8 +70,8 @@ def test_writer_rescales_solidworks_inertial_to_target_mass(tmp_path):
 def test_writer_rescales_placeholder_when_no_geometry(tmp_path):
     """With no sw values and no mesh the inertial falls to the placeholder; a
     target mass still rescales it, so the URDF carries the requested weight."""
-    from sw2robot.exporter.model import Component, RobotModel
     from sw2robot.exporter import urdf_writer
+    from sw2robot.exporter.model import Component, RobotModel
     c = Component(name="P-1", link_name="base_link", part_path=None,
                   is_subassembly=False, world=np.eye(4), fixed=True, dof=0,
                   mass_target=0.5)

--- a/tests/test_mass_override.py
+++ b/tests/test_mass_override.py
@@ -1,0 +1,253 @@
+"""Per-link target-mass override (issue #29): a `masses:` block (mirroring
+`densities:`) rescales a link's inertial to an exact weight.  Covers the
+inertia.rescale_to_mass helper, the urdf_writer consumption, the build_model
+config parsing + mutual-exclusivity with a density override, and an end-to-end
+build() through joints.yaml."""
+import xml.etree.ElementTree as ET
+
+import numpy as np
+import yaml
+
+
+def _eye():
+    return list(np.eye(4).flatten())
+
+
+# ---------------------------------------------------------------- rescale helper
+
+def test_rescale_to_mass_scales_mass_and_tensor_keeps_com():
+    from sw2robot.exporter.inertia import rescale_to_mass
+    info = {"mass": 2.0, "com": [0.1, -0.2, 0.3],
+            "inertia": (3.0, 0.5, 0.0, 4.0, 0.0, 5.0), "method": "solidworks"}
+    out = rescale_to_mass(info, 6.0)          # factor 3
+    assert out["mass"] == 6.0
+    assert np.allclose(out["com"], [0.1, -0.2, 0.3])          # com unchanged
+    assert np.allclose(out["inertia"], (9.0, 1.5, 0.0, 12.0, 0.0, 15.0))
+    assert out["method"] == "solidworks->mass"
+    # original dict is not mutated
+    assert info["mass"] == 2.0 and info["method"] == "solidworks"
+
+
+def test_rescale_to_mass_noop_on_bad_input():
+    from sw2robot.exporter.inertia import rescale_to_mass
+    assert rescale_to_mass(None, 5.0) is None
+    bad = {"mass": 0.0, "com": [0, 0, 0], "inertia": (1, 0, 0, 1, 0, 1),
+           "method": "x"}
+    assert rescale_to_mass(bad, 5.0) is bad          # zero base mass -> unchanged
+    good = {"mass": 1.0, "com": [0, 0, 0], "inertia": (1, 0, 0, 1, 0, 1),
+            "method": "x"}
+    assert rescale_to_mass(good, 0.0) is good        # non-positive target -> unchanged
+
+
+# ---------------------------------------------------------------- urdf writer
+
+def _model_with_sw(mass_target=None):
+    from sw2robot.exporter.model import Component, RobotModel
+    c = Component(name="Part-1", link_name="base_link", part_path=None,
+                  is_subassembly=False, world=np.eye(4), fixed=True, dof=0,
+                  sw_mass=2.0, sw_com=[0.0, 0.0, 0.1],
+                  sw_inertia=[0.2, 0.0, 0.0, 0.3, 0.0, 0.4],
+                  mass_target=mass_target)
+    return RobotModel(name="demo", components=[c], joints=[],
+                      base_link="base_link")
+
+
+def test_writer_rescales_solidworks_inertial_to_target_mass(tmp_path):
+    from sw2robot.exporter import urdf_writer
+    out = tmp_path / "urdf" / "demo.urdf"
+    urdf_writer.write_urdf(_model_with_sw(mass_target=6.0), str(out))  # factor 3
+    inertial = ET.parse(out).getroot().find("link/inertial")
+    assert np.isclose(float(inertial.find("mass").get("value")), 6.0)
+    # com is unchanged by a mass rescale
+    assert np.allclose(
+        [float(x) for x in inertial.find("origin").get("xyz").split()],
+        [0.0, 0.0, 0.1])
+    inr = inertial.find("inertia")
+    assert np.isclose(float(inr.get("ixx")), 0.6)   # 0.2 * 3
+    assert np.isclose(float(inr.get("izz")), 1.2)   # 0.4 * 3
+
+
+def test_writer_rescales_placeholder_when_no_geometry(tmp_path):
+    """With no sw values and no mesh the inertial falls to the placeholder; a
+    target mass still rescales it, so the URDF carries the requested weight."""
+    from sw2robot.exporter.model import Component, RobotModel
+    from sw2robot.exporter import urdf_writer
+    c = Component(name="P-1", link_name="base_link", part_path=None,
+                  is_subassembly=False, world=np.eye(4), fixed=True, dof=0,
+                  mass_target=0.5)
+    model = RobotModel(name="demo", components=[c], joints=[],
+                       base_link="base_link")
+    out = tmp_path / "urdf" / "demo.urdf"
+    urdf_writer.write_urdf(model, str(out))
+    inertial = ET.parse(out).getroot().find("link/inertial")
+    assert np.isclose(float(inertial.find("mass").get("value")), 0.5)
+
+
+# ---------------------------------------------------------------- build_model
+
+def _graph(comp_states, robot="r"):
+    from sw2robot.exporter.state import GraphState
+    return GraphState(robot_name=robot, source_assembly="x.SLDASM",
+                      components=comp_states)
+
+
+def test_build_model_masses_sets_target_and_wins_over_density():
+    """A `masses:` entry sets mass_target; when the same link ALSO has a
+    `densities:` override, mass wins and density_override is cleared."""
+    from sw2robot.exporter.model import build_model
+    from sw2robot.exporter.state import ComponentState
+    comps = [
+        ComponentState(name="base", link_name="base", world=_eye(), fixed=True,
+                       sw_mass=1.0, sw_com=[0, 0, 0], sw_inertia=[1, 0, 0, 1, 0, 1]),
+        ComponentState(name="pcb", link_name="pcb", world=_eye(),
+                       sw_mass=0.2, sw_com=[0, 0, 0],
+                       sw_inertia=[1, 0, 0, 1, 0, 1]),
+    ]
+    config = {
+        "base": "base",
+        "joints": [{"parent": "base", "child": "pcb", "type": "fixed"}],
+        "densities": {"pcb": 1500.0},
+        "masses": {"pcb": 0.75},
+    }
+    model = build_model(_graph(comps), config=config)
+    pcb = next(c for c in model.components if c.link_name == "pcb")
+    assert pcb.mass_target == 0.75
+    assert pcb.density_override is False     # mass wins over the density override
+
+
+def test_build_model_masses_unmatched_or_invalid_is_ignored():
+    from sw2robot.exporter.model import build_model
+    from sw2robot.exporter.state import ComponentState
+    comps = [ComponentState(name="base", link_name="base", world=_eye(),
+                            fixed=True, sw_mass=1.0, sw_com=[0, 0, 0],
+                            sw_inertia=[1, 0, 0, 1, 0, 1])]
+    model = build_model(_graph(comps), config={
+        "masses": {"nope": 1.0, "base": -3.0}})   # unmatched name + non-positive
+    base = next(c for c in model.components if c.link_name == "base")
+    assert base.mass_target is None
+
+
+# ---------------------------------------------------------------- end-to-end build
+
+def test_build_masses_block_sets_urdf_mass(tmp_path):
+    """Through build(): a joints.yaml `masses:` block yields the exact <mass>
+    in the working URDF (rescaled from the SW-native value)."""
+    from sw2robot.exporter.export import build
+    from sw2robot.exporter.state import ComponentState, GraphState
+
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    graph = GraphState(
+        robot_name="demo", source_assembly="x.SLDASM",
+        components=[
+            ComponentState(name="base", link_name="base", world=_eye(),
+                           fixed=True, sw_mass=1.0, sw_com=[0, 0, 0],
+                           sw_inertia=[1, 0, 0, 1, 0, 1]),
+            ComponentState(name="pcb", link_name="pcb", world=_eye(),
+                           sw_mass=0.2, sw_com=[0, 0, 0],
+                           sw_inertia=[2, 0, 0, 2, 0, 2]),
+        ])
+    graph.save(str(pkg / "graph.json"))
+    cfg = pkg / "demo.joints.yaml"
+    cfg.write_text(yaml.safe_dump({
+        "base": "base",
+        "joints": [{"parent": "base", "child": "pcb", "type": "fixed"}],
+        "masses": {"pcb": 0.8},          # from sw_mass 0.2 -> factor 4
+    }))
+    build(str(pkg), config_path=str(cfg))
+
+    root = ET.parse(pkg / "urdf" / "demo.urdf").getroot()
+    pcb = next(ln for ln in root.findall("link") if ln.get("name") == "pcb")
+    inertial = pcb.find("inertial")
+    assert np.isclose(float(inertial.find("mass").get("value")), 0.8)
+    inr = inertial.find("inertia")
+    assert np.isclose(float(inr.get("ixx")), 8.0)      # 2 * 4
+
+
+# -------------------------------------------- SW mass-override flag (Part B)
+
+def test_sw_mass_overridden_reads_override_flags():
+    from sw2robot.exporter.model import _sw_mass_overridden
+
+    class OverrideMass:
+        OverrideMass = True
+    assert _sw_mass_overridden(OverrideMass()) is True
+
+    class OverrideCom:              # a different interface's flag name
+        OverrideCenterOfMass = True
+    assert _sw_mass_overridden(OverrideCom()) is True
+
+    class NoOverride:
+        OverrideMass = False
+        OverrideCenterOfMass = False
+        OverrideMomentsOfInertia = False
+    assert _sw_mass_overridden(NoOverride()) is False
+
+    class OlderInterface:           # none of the attributes present
+        pass
+    assert _sw_mass_overridden(OlderInterface()) is False
+
+
+# -------------------------------------------- default-mass detection (Part B)
+
+def _write_pkg(tmp_path, comp_states, cfg):
+    from sw2robot.exporter.state import GraphState
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    GraphState(robot_name="demo", source_assembly="x.SLDASM",
+               components=comp_states).save(str(pkg / "graph.json"))
+    if cfg is not None:
+        (pkg / "demo.joints.yaml").write_text(yaml.safe_dump(cfg))
+    return pkg
+
+
+def test_default_mass_links_flags_unset_and_default_density(tmp_path):
+    from sw2robot.editor.webserver import _default_mass_links
+    from sw2robot.exporter.state import ComponentState
+    comps = [
+        # assigned material, non-default density -> OK
+        ComponentState(name="Base", link_name="base", world=_eye(),
+                       material="ABS", density=1040.0),
+        # no material at all -> flagged
+        ComponentState(name="NoMat", link_name="nomat", world=_eye()),
+        # no material name but SW default density ~1000 -> flagged
+        ComponentState(name="Def", link_name="defdens", world=_eye(),
+                       density=1000.0),
+        # a named material that happens to sit at ~1000 -> flagged too (the
+        # "also flag ~1000" rule accepts this false-positive)
+        ComponentState(name="Water", link_name="water", world=_eye(),
+                       material="Water", density=1000.0),
+    ]
+    pkg = _write_pkg(tmp_path, comps, {"base": "base"})
+    flagged = _default_mass_links(str(pkg), "urdf/demo.urdf")
+    assert flagged == {"nomat", "defdens", "water"}
+
+
+def test_default_mass_links_respects_resolutions(tmp_path):
+    """SW mass override, an editor density/mass override, and an explicit
+    acknowledgement each clear the flag."""
+    from sw2robot.editor.webserver import _default_mass_links
+    from sw2robot.exporter.state import ComponentState
+    comps = [
+        ComponentState(name="SwOver", link_name="swover", world=_eye(),
+                       density=1000.0, sw_mass_overridden=True),
+        ComponentState(name="DensOvr", link_name="densovr", world=_eye(),
+                       density=1000.0),
+        ComponentState(name="MassOvr", link_name="massovr", world=_eye()),
+        ComponentState(name="Ack", link_name="ack", world=_eye()),
+        ComponentState(name="Still", link_name="still", world=_eye()),
+    ]
+    cfg = {
+        "densities": {"densovr": 500.0},
+        "masses": {"massovr": 0.3},
+        "mass_reviewed": ["ack"],
+    }
+    pkg = _write_pkg(tmp_path, comps, cfg)
+    flagged = _default_mass_links(str(pkg), "urdf/demo.urdf")
+    assert flagged == {"still"}      # only the untouched, material-less link
+
+
+def test_default_mass_links_empty_without_graph(tmp_path):
+    from sw2robot.editor.webserver import _default_mass_links
+    assert _default_mass_links(str(tmp_path), "urdf/demo.urdf") == set()
+    assert _default_mass_links(None, None) == set()


### PR DESCRIPTION
## Mass editor

Adds a CAD-mode **mass editor** for setting per-link weights and guarding against silent default masses.

<img width="1641" height="1096" alt="image" src="https://github.com/user-attachments/assets/07ce6af1-3a32-4444-979b-8b1f5a8a19f9" />

### What it does

- **Per-link target mass** — a `masses:` config block rescales a link's inertial to an exact weight (mass + full tensor scale together, COM unchanged) via `inertia.rescale_to_mass`. Mutually exclusive with a density override — setting one clears the other.
- **Default-mass export gate** — blocks export (409) when CAD links still carry an unreviewed SolidWorks *default* mass (no material assigned / ~1000 kg/m³ density), so a guessed weight never silently reaches the URDF. Bypassable with `?ack=1` / "export anyway"; the launch one-liner always acks.
- **SW override import** — reads SolidWorks' manual "Override Mass Properties" flag (`sw_mass_overridden`) so deliberately-set masses aren't flagged.
- **UI** — a `⚖ mass` bulk panel + per-link controls: target mass / material-density picker (checkbox toggles which drives the weight), mass-only toggle (fixed children only), and per-link review acknowledgement with an "acknowledge all" action.

### Endpoints
`/api/set_masses`, `/api/set_mass_reviewed`, `/api/set_mass_only`; `/api/components` now returns actual built-URDF masses, review state, and parent joint types.

### Tests
New `test_mass_override.py` (rescale helper, urdf_writer, build_model, E2E build) and `test_mass_editor_webserver.py` (in-process HTTP against a synthetic CAD package: mass fields, mutual exclusivity, review, mass-only, export gate), plus a mass-only case in `test_cad_mode_webserver.py`. Full suite green (142 passed).