### PR TITLE
Add one-line installer published via GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,93 @@
+name: Deploy install scripts to Pages
+
+# Publish the one-line installers on GitHub Pages so users can fetch them from a
+# shorter, canonical URL:
+#
+#   https://jsk-ros-pkg.github.io/solidworks_urdf_exporter2/install.sh
+#   https://jsk-ros-pkg.github.io/solidworks_urdf_exporter2/install.ps1
+#
+# instead of the longer raw.githubusercontent.com/<repo>/main/... path.  The
+# scripts themselves live at the repo root (single source of truth); this job
+# just copies them into the Pages artifact -- editing install.sh redeploys it.
+#
+# The Pages URL path is always <org>.github.io/<repo>/...; the repo name can't be
+# dropped without a custom domain.  To go shorter (e.g. sw2robot.dev/install.sh),
+# add a CNAME (see the commented step below) and point the domain's DNS at Pages.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - install.sh
+      - install.ps1
+      - .github/workflows/pages.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# never run two Pages deploys at once; the newest push wins
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Assemble the Pages site
+        run: |
+          mkdir -p _site
+          cp install.sh install.ps1 _site/
+          # disable Jekyll so the raw scripts are served verbatim (no templating,
+          # and files/dirs starting with '_' or '.' aren't dropped)
+          touch _site/.nojekyll
+          # a tiny landing page at the site root showing the install commands
+          cat > _site/index.html <<'HTML'
+          <!doctype html>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <title>sw2robot — install</title>
+          <style>
+            :root { color-scheme: light dark; }
+            body { font: 16px/1.6 system-ui, sans-serif; max-width: 720px;
+                   margin: 6vh auto; padding: 0 1.2rem; }
+            h1 { font-size: 1.6rem; } code, pre { font-family: ui-monospace, monospace; }
+            pre { background: color-mix(in srgb, currentColor 8%, transparent);
+                  padding: .9rem 1rem; border-radius: 8px; overflow-x: auto; }
+            a { color: inherit; }
+          </style>
+          <h1>sw2robot — one-line install</h1>
+          <p><strong>Linux / macOS</strong></p>
+          <pre>curl -LsSf https://jsk-ros-pkg.github.io/solidworks_urdf_exporter2/install.sh | sh</pre>
+          <p><strong>Windows</strong> (PowerShell)</p>
+          <pre>powershell -ExecutionPolicy ByPass -c "irm https://jsk-ros-pkg.github.io/solidworks_urdf_exporter2/install.ps1 | iex"</pre>
+          <p>Then run <code>sw2robot-web</code>. See the
+          <a href="https://github.com/jsk-ros-pkg/solidworks_urdf_exporter2">project README</a>
+          and <a href="https://github.com/jsk-ros-pkg/solidworks_urdf_exporter2/releases/latest">latest release</a>.</p>
+          HTML
+
+          # To serve from a custom domain instead, uncomment and set your domain,
+          # then add the DNS records GitHub Pages documents:
+          # echo "sw2robot.dev" > _site/CNAME
+
+      - name: Configure Pages
+        # enablement: true turns Pages on for the repo on first run (source =
+        # GitHub Actions), so no manual Settings -> Pages click is needed.
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -64,6 +64,55 @@ Which one fits depends on your workflow, not on which is "better":
 | Edit an existing URDF | — | ✓ (any URDF, not just its own) |
 | Install | SolidWorks add-in | single prebuilt binary (no Python) |
 
+## Install in one line (no Python, no clone)
+
+A single command downloads the prebuilt editor for your OS, drops it on your
+`PATH` as `sw2robot-web`, and you're done. No Python, no cloning this repo.
+
+**Linux / macOS** — with `curl`:
+
+```bash
+curl -LsSf https://jsk-ros-pkg.github.io/solidworks_urdf_exporter2/install.sh | sh
+```
+
+…or with `wget` if you don't have `curl`:
+
+```bash
+wget -qO- https://jsk-ros-pkg.github.io/solidworks_urdf_exporter2/install.sh | sh
+```
+
+**Windows** — in PowerShell:
+
+```powershell
+powershell -ExecutionPolicy ByPass -c "irm https://jsk-ros-pkg.github.io/solidworks_urdf_exporter2/install.ps1 | iex"
+```
+
+Then launch the editor (it opens `http://localhost:8090` in your browser —
+`xdg-open` on Linux, the default browser elsewhere):
+
+```bash
+sw2robot-web
+```
+
+The installer picks the matching `sw2robot-web-<os>-<arch>` asset from the
+[latest release](https://github.com/jsk-ros-pkg/solidworks_urdf_exporter2/releases/latest),
+installs it to `~/.local/bin` (Windows: `%LOCALAPPDATA%\sw2robot\bin`), and adds
+that dir to `PATH` if needed. Knobs:
+
+```bash
+# pin a version instead of latest
+SW2ROBOT_VERSION=v0.3.2 curl -LsSf https://jsk-ros-pkg.github.io/solidworks_urdf_exporter2/install.sh | sh
+# or, when piping:  ... | sh -s -- --version v0.3.2 --bin-dir /usr/local/bin
+
+# choose the install dir / don't touch any shell rc
+SW2ROBOT_INSTALL_DIR=/usr/local/bin SW2ROBOT_NO_MODIFY_PATH=1 curl -LsSf .../install.sh | sh
+```
+
+Prebuilt binaries currently ship for **Linux x64**, **macOS (Apple Silicon)**,
+and **Windows x64**. Re-running the installer upgrades in place; the editor can
+also self-update from its own UI. Prefer to grab the file by hand, or need a
+different OS/arch? The per-OS steps below still apply.
+
 ## Quick start — download the Windows `.exe` (no Python)
 
 If you just want to convert a SolidWorks assembly, you don't need to install

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,94 @@
+<#
+.SYNOPSIS
+    sw2robot installer for Windows -- download the prebuilt .exe and put it on PATH.
+
+.DESCRIPTION
+    Like uv's Windows one-liner.  Run in PowerShell:
+
+        powershell -ExecutionPolicy ByPass -c "irm https://jsk-ros-pkg.github.io/solidworks_urdf_exporter2/install.ps1 | iex"
+
+    then launch the editor (opens your browser):
+
+        sw2robot-web
+
+    It downloads the matching sw2robot-web-windows-x64-vX.Y.Z.exe from the GitHub
+    Release and installs it to %LOCALAPPDATA%\sw2robot\bin as sw2robot-web.exe --
+    the same dir the exe itself relocates to on first run -- then adds that dir to
+    your user PATH.  Re-running upgrades in place; the editor can also self-update
+    from its own UI.
+
+    Knobs (env vars, set before running):
+        $env:SW2ROBOT_VERSION      pin a version, e.g. v0.3.2 (default: latest)
+        $env:SW2ROBOT_INSTALL_DIR  install location (default: %LOCALAPPDATA%\sw2robot\bin)
+
+    NOTE: the SolidWorks 'extract' step needs SolidWorks installed on this machine;
+    view / edit / build / export work without it.
+#>
+[CmdletBinding()]
+param(
+    [string]$Version   = $env:SW2ROBOT_VERSION,
+    [string]$InstallDir = $env:SW2ROBOT_INSTALL_DIR
+)
+
+$ErrorActionPreference = 'Stop'
+$Repo = 'jsk-ros-pkg/solidworks_urdf_exporter2'
+$App  = 'sw2robot-web'
+
+function Say([string]$m) { Write-Host "sw2robot: $m" }
+
+# ---- arch -------------------------------------------------------------------
+# The matrix ships windows-x64 only; on ARM64 Windows the x64 exe runs under
+# emulation, so x64 is the right asset there too.
+$Arch = 'x64'
+
+# ---- resolve the release tag ------------------------------------------------
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    Say 'querying the latest release...'
+    $headers = @{ 'User-Agent' = 'sw2robot-install' }
+    $rel = Invoke-RestMethod -Headers $headers `
+        -Uri "https://api.github.com/repos/$Repo/releases/latest"
+    $Version = $rel.tag_name
+    if ([string]::IsNullOrWhiteSpace($Version)) {
+        throw "could not determine the latest version; set `$env:SW2ROBOT_VERSION (e.g. v0.3.2)"
+    }
+}
+if ($Version -notmatch '^v') { $Version = "v$Version" }
+
+$Asset = "$App-windows-$Arch-$Version.exe"
+$Url   = "https://github.com/$Repo/releases/download/$Version/$Asset"
+
+# ---- install dir ------------------------------------------------------------
+if ([string]::IsNullOrWhiteSpace($InstallDir)) {
+    $base = if ($env:LOCALAPPDATA) { $env:LOCALAPPDATA } else { Join-Path $HOME 'AppData\Local' }
+    $InstallDir = Join-Path $base 'sw2robot\bin'
+}
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+$Dest = Join-Path $InstallDir "$App.exe"
+
+# ---- download ---------------------------------------------------------------
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("sw2robot-" + [System.IO.Path]::GetRandomFileName() + ".exe")
+Say "downloading $Asset"
+Say "  from $Url"
+try {
+    Invoke-WebRequest -Uri $Url -OutFile $tmp -UseBasicParsing
+} catch {
+    throw "download failed. Does release $Version publish $Asset?`n  Check: https://github.com/$Repo/releases/tag/$Version"
+}
+
+# ---- install (replace any running copy is fine: it's the on-disk file) ------
+Move-Item -Force -Path $tmp -Destination $Dest
+Say "installed $App $Version -> $Dest"
+
+# ---- add InstallDir to the user PATH ----------------------------------------
+$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+if ([string]::IsNullOrEmpty($userPath)) { $userPath = '' }
+$onPath = ($userPath -split ';') -contains $InstallDir
+if (-not $onPath) {
+    $newPath = if ($userPath.TrimEnd(';') -eq '') { $InstallDir } else { $userPath.TrimEnd(';') + ';' + $InstallDir }
+    [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
+    # reflect it in THIS session too so a chained call finds it immediately
+    $env:Path = $env:Path.TrimEnd(';') + ';' + $InstallDir
+    Say "added $InstallDir to your user PATH (restart terminals to pick it up)."
+}
+
+Say "done.  Launch the editor with:  $App"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,195 @@
+#!/bin/sh
+# sw2robot installer -- download the prebuilt web-editor binary and put it on PATH.
+#
+# Usage (like uv / rustup -- one line, no Python, no clone):
+#
+#     curl -LsSf https://jsk-ros-pkg.github.io/solidworks_urdf_exporter2/install.sh | sh
+#     wget -qO-  https://jsk-ros-pkg.github.io/solidworks_urdf_exporter2/install.sh | sh
+#
+# then just run it (Linux opens the editor in your browser via xdg-open):
+#
+#     sw2robot-web
+#
+# What it does: detects your OS/arch, grabs the matching
+# `sw2robot-web-<os>-<arch>-vX.Y.Z` asset from the GitHub Release, installs it as
+# `sw2robot-web` into ~/.local/bin (override with SW2ROBOT_INSTALL_DIR), and, if
+# that dir isn't on PATH, appends it to your shell rc.  Re-running upgrades in
+# place; the editor can also self-update from its own UI once installed.
+#
+# Knobs (env vars):
+#   SW2ROBOT_INSTALL_DIR   where to put the binary   (default: $XDG_BIN_HOME or ~/.local/bin)
+#   SW2ROBOT_VERSION       pin a version, e.g. v0.3.2 (default: latest release)
+#   SW2ROBOT_NO_MODIFY_PATH=1   don't touch any shell rc; just print the PATH hint
+#
+# Or as flags when piping:  ... | sh -s -- --version v0.3.2 --bin-dir /usr/local/bin
+set -eu
+
+REPO="jsk-ros-pkg/solidworks_urdf_exporter2"
+APP="sw2robot-web"
+
+# ---- args (optional; env vars are the primary interface) --------------------
+VERSION="${SW2ROBOT_VERSION:-}"
+INSTALL_DIR="${SW2ROBOT_INSTALL_DIR:-}"
+NO_MODIFY_PATH="${SW2ROBOT_NO_MODIFY_PATH:-}"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --version)          VERSION="$2"; shift 2 ;;
+        --version=*)        VERSION="${1#*=}"; shift ;;
+        --bin-dir)          INSTALL_DIR="$2"; shift 2 ;;
+        --bin-dir=*)        INSTALL_DIR="${1#*=}"; shift ;;
+        --no-modify-path)   NO_MODIFY_PATH=1; shift ;;
+        -h|--help)
+            sed -n '2,24p' "$0" 2>/dev/null || true
+            exit 0 ;;
+        *) echo "install.sh: unknown option '$1'" >&2; exit 2 ;;
+    esac
+done
+
+say()  { printf '%s\n' "sw2robot: $*"; }
+err()  { printf '%s\n' "sw2robot: error: $*" >&2; exit 1; }
+
+need() { command -v "$1" >/dev/null 2>&1; }
+
+# ---- pick a downloader (curl or wget) ---------------------------------------
+if need curl; then
+    DL="curl -fSL"          # -f fail on HTTP error, -S show errors, -L follow
+    DL_QUIET="curl -fsSL"
+elif need wget; then
+    DL="wget -O-"
+    DL_QUIET="wget -qO-"
+else
+    err "need curl or wget to download; please install one and retry"
+fi
+
+fetch()      { $DL "$1"; }         # to stdout, progress visible
+fetch_quiet(){ $DL_QUIET "$1"; }   # to stdout, quiet (for the API call)
+
+# ---- detect OS / arch, matching the release matrix asset names --------------
+# (see .github/workflows/release.yml: sw2robot-web-<os>-<arch>-<tag><ext>)
+uname_s="$(uname -s)"
+uname_m="$(uname -m)"
+case "$uname_s" in
+    Linux)   OS="linux";  EXT="" ;;
+    Darwin)  OS="macos";  EXT=".zip" ;;   # a zipped .app bundle
+    *) err "unsupported OS '$uname_s' -- prebuilt binaries exist only for Linux/macOS/Windows.
+       On Windows use install.ps1; otherwise install from source (see README)." ;;
+esac
+case "$uname_m" in
+    x86_64|amd64)   ARCH="x64" ;;
+    arm64|aarch64)  ARCH="arm64" ;;
+    *) err "unsupported CPU arch '$uname_m'" ;;
+esac
+
+# The release matrix ships only linux-x64 and macos-arm64 today.  Fail early with
+# a pointer rather than 404'ing on a guessed asset name.  Keep this list in sync
+# with the release matrix in .github/workflows/release.yml.
+case "$OS-$ARCH" in
+    linux-x64|macos-arm64) : ;;
+    *) err "no prebuilt binary for $OS-$ARCH yet.
+       See the releases page for what's published, or install from source (README):
+       https://github.com/$REPO/releases/latest" ;;
+esac
+
+# ---- resolve the release tag ------------------------------------------------
+if [ -z "$VERSION" ]; then
+    say "querying the latest release..."
+    api="https://api.github.com/repos/$REPO/releases/latest"
+    # No jq dependency: pull tag_name out of the JSON with sed.
+    VERSION="$(fetch_quiet "$api" \
+        | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+        | head -n1)"
+    [ -n "$VERSION" ] || err "could not determine the latest version from GitHub.
+       Set one explicitly:  SW2ROBOT_VERSION=v0.3.2 sh install.sh"
+fi
+# normalise to a leading 'v'
+case "$VERSION" in v*) : ;; *) VERSION="v$VERSION" ;; esac
+
+ASSET="$APP-$OS-$ARCH-$VERSION$EXT"
+URL="https://github.com/$REPO/releases/download/$VERSION/$ASSET"
+
+# ---- install dir ------------------------------------------------------------
+if [ -z "$INSTALL_DIR" ]; then
+    INSTALL_DIR="${XDG_BIN_HOME:-$HOME/.local/bin}"
+fi
+mkdir -p "$INSTALL_DIR"
+
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/sw2robot-install.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+say "downloading $ASSET"
+say "  from $URL"
+if ! fetch "$URL" > "$tmp/$ASSET"; then
+    err "download failed.  Does release $VERSION publish $ASSET?
+       Check: https://github.com/$REPO/releases/tag/$VERSION"
+fi
+
+dest="$INSTALL_DIR/$APP"
+
+if [ "$OS" = "macos" ]; then
+    # The macOS asset is a zip of a windowed .app bundle.  Unpack it into a data
+    # dir and symlink the inner Mach-O binary onto PATH -- running it directly
+    # keeps the .app structure the self-updater walks up to (Foo.app/Contents/
+    # MacOS/Foo).  See sw2robot/editor/update.py:_current_target.
+    need unzip || err "need 'unzip' to install the macOS build"
+    share="${XDG_DATA_HOME:-$HOME/.local/share}/sw2robot"
+    mkdir -p "$share"
+    rm -rf "$share/$APP.app"
+    unzip -q -o "$tmp/$ASSET" -d "$tmp/unzipped"
+    app="$(find "$tmp/unzipped" -maxdepth 2 -name '*.app' -type d | head -n1)"
+    [ -n "$app" ] || err "downloaded zip contained no .app bundle"
+    mv "$app" "$share/$APP.app"
+    inner="$(find "$share/$APP.app/Contents/MacOS" -maxdepth 1 -type f | head -n1)"
+    [ -n "$inner" ] || err ".app bundle has no Contents/MacOS binary"
+    chmod +x "$inner"
+    ln -sf "$inner" "$dest"
+else
+    # Linux: a single ELF -- drop it straight in and mark executable.
+    mv "$tmp/$ASSET" "$dest"
+    chmod +x "$dest"
+fi
+
+say "installed $APP $VERSION -> $dest"
+
+# ---- ensure INSTALL_DIR is on PATH ------------------------------------------
+on_path() {
+    case ":$PATH:" in *":$INSTALL_DIR:"*) return 0 ;; *) return 1 ;; esac
+}
+
+add_path_line() {
+    # append an export to the given rc file if it doesn't already reference the dir
+    rc="$1"
+    [ -f "$rc" ] || return 1
+    if ! grep -q "$INSTALL_DIR" "$rc" 2>/dev/null; then
+        {
+            printf '\n# added by sw2robot install.sh\n'
+            printf 'export PATH="%s:$PATH"\n' "$INSTALL_DIR"
+        } >> "$rc"
+        say "added $INSTALL_DIR to PATH in $rc"
+    fi
+    return 0
+}
+
+if on_path; then
+    :
+elif [ -n "$NO_MODIFY_PATH" ]; then
+    say "note: $INSTALL_DIR is not on your PATH."
+    say "  add it:  export PATH=\"$INSTALL_DIR:\$PATH\""
+else
+    # pick the rc for the user's login shell; fall back across the common ones
+    shell_name="$(basename "${SHELL:-sh}")"
+    case "$shell_name" in
+        zsh)  add_path_line "$HOME/.zshrc"  || add_path_line "$HOME/.zshenv" ;;
+        bash) add_path_line "$HOME/.bashrc" || add_path_line "$HOME/.bash_profile" \
+                  || add_path_line "$HOME/.profile" ;;
+        *)    add_path_line "$HOME/.profile" ;;
+    esac || {
+        say "note: $INSTALL_DIR is not on your PATH."
+        say "  add it:  export PATH=\"$INSTALL_DIR:\$PATH\""
+    }
+    say "open a new terminal (or 'source' the rc above) so '$APP' is found."
+fi
+
+say "done.  Launch the editor with:  $APP"
+if [ "$OS" != "macos" ]; then
+    say "(the Windows-only 'extract' step still needs SolidWorks; view/edit/build/export work anywhere.)"
+fi


### PR DESCRIPTION
## What

Adds a one-line installer for the prebuilt web-editor binary, published via GitHub Pages — no Python, no clone.

**Linux / macOS**

```sh
curl -LsSf https://jsk-ros-pkg.github.io/solidworks_urdf_exporter2/install.sh | sh
```

**Windows** (PowerShell)

```powershell
powershell -ExecutionPolicy ByPass -c "irm https://jsk-ros-pkg.github.io/solidworks_urdf_exporter2/install.ps1 | iex"
```

Then launch with `sw2robot-web`.

## How

- **`install.sh` / `install.ps1`** — detect OS/arch, resolve the latest release tag (or a pinned `SW2ROBOT_VERSION` / `--version`), download the matching `sw2robot-web-<os>-<arch>` asset, install it as `sw2robot-web` on `PATH` (`~/.local/bin`, or `%LOCALAPPDATA%\sw2robot\bin` on Windows), and add that dir to `PATH` when needed. curl **or** wget; no `jq` dependency.
- **`.github/workflows/pages.yml`** — on push to `main`, copies the repo-root scripts into the Pages artifact (single source of truth, so editing a script redeploys it) alongside a small landing page, and deploys to GitHub Pages. `configure-pages` enables Pages on first run.
- **README** — documents the one-line install.

## Notes

- The Pages URL goes live after this merges and the Pages workflow runs once.
- Needs the repo's Pages source set to **GitHub Actions** — the workflow sets `enablement: true`, but org policy may require enabling it once under Settings → Pages.
- Tested locally: `install.sh` downloads & installs the current linux-x64 release asset end-to-end; the Pages site-assemble step was reproduced (scripts copied verbatim, `.nojekyll` + landing page emitted); both scripts pass a syntax check and `install.ps1` parses under PowerShell.
- arm64 binaries + matrix are a separate follow-up PR.
