### PR TITLE
Build a linux-arm64 release binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,17 @@ name: Build & Release
 #     git tag v0.1.0 && git push origin v0.1.0
 #
 # NOTE: PyInstaller cannot cross-compile, so each OS/arch builds on its own
-# native runner.  Windows (.exe), macOS (Apple Silicon) and Linux (x64) each
-# ship the FULL-FEATURE editor: live self-collision + auto joint-limits
+# native runner.  Windows (.exe), macOS (Apple Silicon) and Linux (x64 + arm64)
+# each ship the FULL-FEATURE editor: live self-collision + auto joint-limits
 # (skrobot/fcl) AND CoACD collision decomposition (coacd) are bundled (the
 # default build_exe.py build).  Only Windows can run the SolidWorks `extract`
 # step; the macOS and Linux binaries do view / edit / build / export --
-# including the URDF-input editing mode -- without SolidWorks.  The Windows ARM64
+# including the URDF-input editing mode -- without SolidWorks.  linux-arm64 is
+# built on the ubuntu-22.04-arm hosted runner; every full-feature wheel
+# (skrobot/python-fcl/coacd) exists for aarch64, and the one dep that DOESN'T
+# ship an aarch64 wheel -- embreex, an optional trimesh accelerator -- is dropped
+# there via a platform marker in pyproject.toml, so the arm64 build is otherwise
+# identical to x64.  The Windows ARM64
 # build is commented out (windows-11-arm hosted runners are limited on private
 # repos) -- re-enable it once public; it must build --lean (base web editor
 # only), since python-fcl has no win-arm64 wheel.  fail-fast is off so one OS
@@ -65,6 +70,15 @@ jobs:
             arch: x64
             ext: ''
             build_args: ''
+          # linux-arm64 on the aarch64 hosted runner.  Same glibc-compat reasoning
+          # as x64: build on 22.04 (GLIBC 2.35) so the binary also runs on 24.04.
+          # Full-feature like the others -- embreex (no aarch64 wheel) is excluded
+          # by a marker in pyproject.toml, not here.
+          - runner: ubuntu-22.04-arm
+            os: linux
+            arch: arm64
+            ext: ''
+            build_args: ''
           # ARM64 Windows is disabled while the repo is private (windows-11-arm
           # hosted runners are limited/unavailable on private repos).
           # Re-enable once public, or swap in a self-hosted ARM runner.
@@ -85,9 +99,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           # the exe is the full-feature build, so install the same optional extras
-          # it bundles ([ui] = skrobot/fcl, [coacd]); trimesh[easy] (core) already
-          # pulls the pycollada/scipy/networkx mesh backends.  Wheels for
-          # skrobot/python-fcl/coacd exist on win-x64, macos-arm64 and linux-x64.
+          # it bundles ([ui] = skrobot/fcl, [coacd]); the core deps already pull
+          # the pycollada/scipy/networkx mesh backends (see pyproject.toml, which
+          # lists trimesh's [easy] set explicitly minus embreex on aarch64).
+          # Wheels for skrobot/python-fcl/coacd exist on win-x64, macos-arm64,
+          # linux-x64 AND linux-arm64.
           pip install ".[ui,coacd]" pyinstaller
 
       # Put the release version right before the extension so the binary is

--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@ SW2ROBOT_VERSION=v0.3.2 curl -LsSf https://jsk-ros-pkg.github.io/solidworks_urdf
 SW2ROBOT_INSTALL_DIR=/usr/local/bin SW2ROBOT_NO_MODIFY_PATH=1 curl -LsSf .../install.sh | sh
 ```
 
-Prebuilt binaries currently ship for **Linux x64**, **macOS (Apple Silicon)**,
-and **Windows x64**. Re-running the installer upgrades in place; the editor can
+Prebuilt binaries currently ship for **Linux x64**, **Linux arm64**,
+**macOS (Apple Silicon)**, and **Windows x64**. Re-running the installer upgrades
+in place; the editor can
 also self-update from its own UI. Prefer to grab the file by hand, or need a
 different OS/arch? The per-OS steps below still apply.
 

--- a/install.sh
+++ b/install.sh
@@ -80,11 +80,10 @@ case "$uname_m" in
     *) err "unsupported CPU arch '$uname_m'" ;;
 esac
 
-# The release matrix ships only linux-x64 and macos-arm64 today.  Fail early with
-# a pointer rather than 404'ing on a guessed asset name.  Keep this list in sync
-# with the release matrix in .github/workflows/release.yml.
+# Fail early with a pointer rather than 404'ing on a guessed asset name.  Keep
+# this list in sync with the release matrix in .github/workflows/release.yml.
 case "$OS-$ARCH" in
-    linux-x64|macos-arm64) : ;;
+    linux-x64|linux-arm64|macos-arm64) : ;;
     *) err "no prebuilt binary for $OS-$ARCH yet.
        See the releases page for what's published, or install from source (README):
        https://github.com/$REPO/releases/latest" ;;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,31 @@ license-files = ["LICENSE"]
 authors = [{ name = "Iori Yanokura", email = "ab.ioryz@gmail.com" }]
 dependencies = [
     "numpy>=2",
-    "trimesh[easy]>=3.9",
+    # trimesh core + the backends its [easy] extra pulls, listed EXPLICITLY
+    # instead of as `trimesh[easy]` so we can drop exactly ONE of them --
+    # embreex -- on linux-aarch64, the only platform without an embreex wheel.
+    # embreex is just an optional ray/mesh accelerator; trimesh runs without it,
+    # so linux-arm64 loses nothing user-visible.  This mirrors trimesh 4.x's
+    # [easy] set; keep it in sync when bumping trimesh (see release.yml arm job).
+    "trimesh>=3.9",
+    "colorlog",
+    "manifold3d>=2.3.0",
+    "charset-normalizer",
+    "jsonschema",
+    "networkx",
+    "svg.path",
+    "pycollada",
+    "shapely",
+    "xxhash",
+    "rtree",
+    "httpx",
+    "scipy",
+    "pillow",
+    "vhacdx",
+    "mapbox_earcut>=1.0.2",
+    # everywhere EXCEPT linux-aarch64 (PEP 508 has no unary `not`, so this is the
+    # De Morgan form of "not (linux and aarch64)")
+    "embreex; sys_platform != 'linux' or platform_machine != 'aarch64'",
     "lxml",
     "pydantic>=2",
     "pyyaml>=6",

--- a/tests/test_trimesh_runtime_deps.py
+++ b/tests/test_trimesh_runtime_deps.py
@@ -6,10 +6,12 @@ moment the web editor converts the scene to a single mesh.
 
 Two tests, on purpose:
 
-* ``test_pyproject_declares_trimesh_easy_extra`` is the deterministic guard --
-  it reads the declared dependency and fails if anyone reverts ``trimesh[easy]``
-  back to plain ``trimesh``.  This catches the regression even in an environment
-  that happens to have networkx/scipy from some other package.
+* ``test_pyproject_declares_trimesh_mesh_backends`` is the deterministic guard --
+  it reads the declared dependencies and fails if networkx/scipy stop being
+  pulled in, whether via the ``trimesh[easy]`` extra OR as explicit direct deps
+  (we do the latter so embreex -- the one [easy] backend without a linux-aarch64
+  wheel -- can be dropped there).  This catches the regression even in an
+  environment that happens to have networkx/scipy from some other package.
 * ``test_scene_to_single_mesh_works`` exercises the actual code path the robot
   view runs on every load, so the suite also fails outright on a fresh install
   that is genuinely missing the backends.
@@ -24,23 +26,29 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = REPO_ROOT / "pyproject.toml"
 
 
-def _trimesh_requirement():
+def _declared_dependencies():
     deps = tomllib.loads(PYPROJECT.read_text())["project"]["dependencies"]
-    for raw in deps:
-        req = Requirement(raw)
-        if req.name == "trimesh":
-            return req
-    raise AssertionError("trimesh is not declared in [project].dependencies")
+    return [Requirement(raw) for raw in deps]
 
 
-def test_pyproject_declares_trimesh_easy_extra():
-    # ``trimesh[easy]`` is what pulls networkx + scipy (and the other mesh
-    # backends) in; a bare ``trimesh`` install is missing them and breaks robot
-    # loading.  Guard against reverting that extra.
-    req = _trimesh_requirement()
-    assert "easy" in req.extras, (
-        f"trimesh must be declared with the 'easy' extra to pull networkx/scipy; "
-        f"got '{req}'"
+def test_pyproject_declares_trimesh_mesh_backends():
+    # networkx + scipy are what trimesh needs the moment a Scene is flattened to a
+    # single mesh (PR #88); a bare ``trimesh`` install is missing them and breaks
+    # robot loading.  They may be pulled EITHER via the ``trimesh[easy]`` extra OR
+    # as explicit direct deps -- we list them explicitly so embreex (the one
+    # [easy] backend without a linux-aarch64 wheel) can be dropped there; see
+    # pyproject.toml.  Guard that networkx/scipy stay declared one way or another.
+    reqs = _declared_dependencies()
+    names = {r.name for r in reqs}
+    assert any(r.name == "trimesh" for r in reqs), (
+        "trimesh is not declared in [project].dependencies"
+    )
+    via_easy = any(r.name == "trimesh" and "easy" in r.extras for r in reqs)
+    via_explicit = {"networkx", "scipy"} <= names
+    assert via_easy or via_explicit, (
+        "networkx + scipy must be pulled in -- either via trimesh[easy] or as "
+        "explicit direct deps -- so Scene->single-mesh doesn't ModuleNotFoundError "
+        f"(PR #88); got dependencies: {sorted(names)}"
     )
 
 


### PR DESCRIPTION
## What

Ship a **full-feature `linux-arm64`** prebuilt binary alongside the existing linux-x64 / macOS / Windows ones, so the one-line installer works on aarch64 Linux (Raspberry Pi / ARM servers / Apple-Silicon Linux VMs).

## How

- **`release.yml`** — add an `ubuntu-22.04-arm` matrix entry (22.04 for GLIBC 2.35 compat, same reasoning as the x64 job). All full-feature wheels — `scikit-robot`, `python-fcl`, `coacd` — exist for aarch64, so it's the same full build as the others.
- **`pyproject.toml`** — the one dependency without an aarch64 wheel is **embreex** (an optional trimesh ray/mesh accelerator). `trimesh[easy]` pulls it unconditionally, so the extra is expanded into its backends listed explicitly and embreex alone is guarded by a marker: `sys_platform != 'linux' or platform_machine != 'aarch64'` (the De Morgan form of "not (linux and aarch64)" — PEP 508 has no unary `not`). x86/macOS/Windows are unchanged; linux-arm64 just skips embreex and trimesh falls back to its pure-Python ray path (nothing user-visible lost).
- **`install.sh`** — accept `linux-arm64`.
- **README** — note the arm64 binary.

## Verification (locally on aarch64)

- Built the full-feature arm64 binary with `build_exe.py` (no `--lean`): `skrobot`/`fcl`/`coacd` bundled.
- Ran it: server boots, `GET /` → 200; the auto joint-limit sweep (`__autolimits__`) imports skrobot and returns joint limits — i.e. the full backend stack works at runtime on aarch64.
- `pip install ".[ui,coacd]"` resolves cleanly on aarch64 (no embreex error); the embreex marker was checked across linux-x64 / linux-arm64 / macOS / Windows and only excludes linux-arm64.

## Notes

- No version bump here — release/versioning is handled separately.
- What's different on arm64: only embreex (a speed-up for ray casting, which this project barely uses). `extract` remains Windows-only on every platform, as before.
