### PR TITLE
Add subassembly list panel

### DIFF
--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -1003,6 +1003,30 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     'rename.resetAllBtn': { en: '↺ reset all to defaults', ja: '↺ 全デフォルト名に戻す' },
     'rename.resetAllBtnTitle': { en: 'revert every joint/link name to its original',
                                  ja: 'すべての joint 名・link 名を元の名前に戻す' },
+    'subasm.btn': { en: 'Sub-assemblies', ja: 'サブアセンブリ' },
+    'subasm.btnTitle': { en: 'show CAD sub-assemblies and whether they are expanded',
+                         ja: 'CADサブアセンブリと展開状態を表示' },
+    'subasm.title': { en: 'CAD sub-assemblies', ja: 'CADサブアセンブリ' },
+    'subasm.help': { en: 'Read-only for now: shows the automatic expansion decision and any expand / no_expand override in joints.yaml.',
+                     ja: '現在は表示のみ: 自動展開の判定と joints.yaml の expand / no_expand 上書きを表示します。' },
+    'subasm.none': { en: 'No CAD sub-assemblies in this package.',
+                     ja: 'このパッケージにはCADサブアセンブリがありません。' },
+    'subasm.urdfMode': { en: 'Sub-assembly data is available for CAD-extracted packages only.',
+                         ja: 'サブアセンブリ情報はCADから抽出したパッケージでのみ利用できます。' },
+    'subasm.fail': { en: a => `sub-assembly list failed: ${a.e}`,
+                     ja: a => `サブアセンブリ一覧の取得に失敗: ${a.e}` },
+    'subasm.thName': { en: 'CAD name', ja: 'CAD名' },
+    'subasm.thLink': { en: 'link', ja: 'link' },
+    'subasm.thChildren': { en: 'children', ja: '子' },
+    'subasm.thEdges': { en: 'mates', ja: 'mate' },
+    'subasm.thState': { en: 'state', ja: '状態' },
+    'subasm.thPath': { en: 'file', ja: 'ファイル' },
+    'subasm.back': { en: '← rename list', ja: '← 改名リスト' },
+    'subasm.stateExpanded': { en: 'expanded', ja: '展開' },
+    'subasm.stateKept': { en: 'kept as one link', ja: '1リンク保持' },
+    'subasm.overrideAuto': { en: 'auto', ja: 'auto' },
+    'subasm.overrideExpand': { en: 'expand', ja: 'expand' },
+    'subasm.overrideNoExpand': { en: 'no_expand', ja: 'no_expand' },
     // joint rows / tree
     'row.jnameTitle': { en: a => `joint: ${a.name}\n${a.parent} → ${a.child}`,
                         ja: a => `関節: ${a.name}\n${a.parent} → ${a.child}` },
@@ -2609,13 +2633,93 @@ function attachInlineRename(el, kind, getOld) {
   });
 }
 
-// the ≣ 改名 list: every joint with its (editable) joint name + child link name
-function openRenameList() {
+function htmlEsc(s) {
+  return String(s ?? '').replace(/[&<>"]/g, c => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;'
+  }[c]));
+}
+
+function pathBase(p) {
+  const s = String(p ?? '');
+  return s.split(/[\\/]/).pop() || s;
+}
+
+function subasmOverrideLabel(v) {
+  if (v === 'expand') { return t('subasm.overrideExpand'); }
+  if (v === 'no_expand') { return t('subasm.overrideNoExpand'); }
+  return t('subasm.overrideAuto');
+}
+
+async function openSubassemblyList(ov) {
   if (!viewer.robot) { log(t('common.openFirst'), 'wrn'); return; }
-  document.getElementById('renamelist')?.remove();
+  const owned = ov || document.getElementById('renamelist') ||
+    document.createElement('div');
+  owned.id = 'renamelist';
+  try {
+    const resp = await fetch('/api/subassemblies');
+    const r = await resp.json();
+    if (!resp.ok || r.error) { throw new Error(r.error ?? resp.status); }
+    const card = document.createElement('div');
+    card.className = 'card';
+    let html =
+      '<div style="font-size:14px;margin-bottom:2px;color:#9fe0a8">' +
+      t('subasm.title') + '</div>' +
+      '<div style="font-size:11px;color:#8a93a3;margin-bottom:8px">' +
+      t('subasm.help') + '</div>';
+    const rows = r.subassemblies || [];
+    if (r.mode === 'urdf') {
+      html += '<div style="color:#d6b36b">' + t('subasm.urdfMode') + '</div>';
+    } else if (!rows.length) {
+      html += '<div style="color:#8a93a3">' + t('subasm.none') + '</div>';
+    } else {
+      html += '<table class="rntable"><thead><tr><th>' +
+        t('subasm.thName') + '</th><th>' + t('subasm.thLink') +
+        '</th><th>' + t('subasm.thChildren') + '</th><th>' +
+        t('subasm.thEdges') + '</th><th>' + t('subasm.thState') +
+        '</th><th>' + t('subasm.thPath') + '</th></tr></thead><tbody>';
+      for (const s of rows) {
+        const state = s.expanded ? t('subasm.stateExpanded')
+                                 : t('subasm.stateKept');
+        const col = s.expanded ? '#9fe0a8' : '#d6b36b';
+        html += `<tr title="${htmlEsc(s.reason)}">` +
+          `<td>${htmlEsc(s.name)}</td>` +
+          `<td style="color:#cfe3ff">${htmlEsc(s.link_name)}</td>` +
+          `<td>${s.children ?? 0}</td>` +
+          `<td>${s.internal_edges ?? 0}</td>` +
+          `<td><span style="color:${col}">${state}</span>` +
+          ` <span style="color:#8a93a3">(${subasmOverrideLabel(s.override)})</span></td>` +
+          `<td title="${htmlEsc(s.path)}">${htmlEsc(pathBase(s.path))}</td></tr>`;
+      }
+      html += '</tbody></table>';
+    }
+    card.innerHTML = html;
+    const bar = document.createElement('div');
+    bar.style.cssText = 'display:flex;gap:8px;margin-top:10px';
+    const back = document.createElement('button');
+    back.textContent = t('subasm.back');
+    back.addEventListener('click', () => openRenameList(owned));
+    const close = document.createElement('button');
+    close.textContent = t('common.close');
+    close.addEventListener('click', () => owned.remove());
+    bar.append(back, close);
+    card.appendChild(bar);
+    owned.replaceChildren(card);
+    if (!owned.parentElement) {
+      (document.getElementById('viewer').parentElement || document.body)
+        .appendChild(owned);
+    }
+  } catch (e) {
+    log(t('subasm.fail', { e: e.message ?? e }), 'err');
+  }
+}
+
+// the ≣ 改名 list: every joint with its (editable) joint name + child link name
+function openRenameList(ov = null) {
+  if (!viewer.robot) { log(t('common.openFirst'), 'wrn'); return; }
+  if (!ov) { document.getElementById('renamelist')?.remove(); }
   const linkOf = (j, tag) => [...(j.urdfNode?.children ?? [])]
     .find(e => e.tagName === tag)?.getAttribute('link') ?? '';
-  const ov = document.createElement('div');
+  ov = ov || document.createElement('div');
   ov.id = 'renamelist';
   const card = document.createElement('div');
   card.className = 'card';
@@ -2648,12 +2752,16 @@ function openRenameList() {
   resetAll.textContent = t('rename.resetAllBtn');
   resetAll.title = t('rename.resetAllBtnTitle');
   resetAll.addEventListener('click', resetAllNames);
+  const subasm = document.createElement('button');
+  subasm.textContent = t('subasm.btn');
+  subasm.title = t('subasm.btnTitle');
+  subasm.addEventListener('click', () => openSubassemblyList(ov));
   const close = document.createElement('button');
   close.textContent = t('common.close');
   close.addEventListener('click', () => ov.remove());
-  bar.append(resetAll, close);
+  bar.append(resetAll, subasm, close);
   card.appendChild(bar);
-  ov.appendChild(card);
+  ov.replaceChildren(card);
   card.querySelectorAll('.rn-input').forEach(inp => {
     inp.addEventListener('change', async () => {
       const v = inp.value.trim(), old = inp.dataset.old;
@@ -2663,11 +2771,13 @@ function openRenameList() {
       else { inp.value = old; }
     });
   });
-  (document.getElementById('viewer').parentElement || document.body)
-    .appendChild(ov);
+  if (!ov.parentElement) {
+    (document.getElementById('viewer').parentElement || document.body)
+      .appendChild(ov);
+  }
 }
 document.getElementById('renamelistbtn')
-  .addEventListener('click', openRenameList);
+  .addEventListener('click', () => openRenameList());
 
 function buildJointRows(robot) {
   jointsEl.innerHTML = '';

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -876,6 +876,67 @@ def _read_colors(pkg_dir, urdf_rel):
     return colors if isinstance(colors, dict) else {}
 
 
+def _subassemblies_payload(graph, yml_txt=""):
+    """Read-only summary for the editor's sub-assembly panel.
+
+    This intentionally reports top-level CAD sub-assembly *instances* first:
+    those are the units a user sees in the parent assembly and the same names
+    matched by the existing ``expand:`` / ``no_expand:`` config lists.
+    """
+    import yaml as _yaml
+
+    from sw2robot.exporter.model import _subgraph_is_movable
+
+    try:
+        cfg = _yaml.safe_load(yml_txt) or {}
+    except Exception:
+        cfg = {}
+    expand = [str(x).lower() for x in (cfg.get("expand") or [])]
+    no_expand = [str(x).lower() for x in (cfg.get("no_expand") or [])]
+
+    subs = getattr(graph, "subassemblies", None) or {}
+    out = []
+    for c in getattr(graph, "components", []) or []:
+        if not (getattr(c, "is_subassembly", False) and c.part_path):
+            continue
+        sub = subs.get(c.part_path)
+        nm = c.name.lower()
+        override = "auto"
+        if any(s in nm for s in no_expand):
+            override = "no_expand"
+        elif any(s in nm for s in expand):
+            override = "expand"
+        movable = bool(sub and _subgraph_is_movable(sub, subs))
+        expanded = override != "no_expand" and (
+            override == "expand" or movable)
+        if override == "no_expand":
+            reason = "kept by no_expand"
+        elif override == "expand":
+            reason = "forced expand"
+        elif movable:
+            reason = "auto-expanded: moving internals" if expanded \
+                else "moving internals"
+        else:
+            reason = "kept rigid: no moving internals"
+        out.append({
+            "name": c.name,
+            "link_name": c.link_name,
+            "path": c.part_path,
+            "children": len(sub.components) if sub else 0,
+            "internal_edges": len(sub.edges) if sub else 0,
+            "movable": movable,
+            "override": override,
+            "expanded": expanded,
+            "reason": reason,
+        })
+    out.sort(key=lambda x: x["name"])
+    return {
+        "subassemblies": out,
+        "expand": cfg.get("expand") or [],
+        "no_expand": cfg.get("no_expand") or [],
+    }
+
+
 def _upsert_yaml_map(txt, mapkey, key, value):
     """Set ``mapkey: {key: value}`` (block style) in joints.yaml text, replacing
     any existing entry for ``key`` and creating the map if needed."""
@@ -2335,6 +2396,23 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                                         "colors": colors,
                                         "mass_only": sorted(
                                             _read_mass_only(cls.pkg_dir))})
+            if path == "/api/subassemblies":
+                cls = type(self)
+                if not cls.pkg_dir:
+                    return self._send_json({"error": "no package open"}, 400)
+                if not _cad_mode(cls.pkg_dir):
+                    return self._send_json({"subassemblies": [],
+                                            "expand": [], "no_expand": [],
+                                            "mode": "urdf"})
+                from sw2robot.exporter.state import GraphState
+                gs = GraphState.load(os.path.join(cls.pkg_dir, "graph.json"))
+                name = os.path.splitext(os.path.basename(cls.urdf_rel))[0]
+                yml = os.path.join(cls.pkg_dir, name + ".joints.yaml")
+                txt = open(yml, encoding="utf-8").read() \
+                    if os.path.exists(yml) else ""
+                payload = _subassemblies_payload(gs, txt)
+                payload["mode"] = "cad"
+                return self._send_json(payload)
             if path == "/api/fs":
                 # tiny server-side file browser: the OS file dialog cannot
                 # hand a PATH to the page, so the page browses through us

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -101,6 +101,30 @@ def test_no_expand_override_keeps_instance():
     assert {c.name for c in comps} == {"plate-1", "servo-1"}
 
 
+def test_subassemblies_payload_reports_expansion_state():
+    from sw2robot.editor.webserver import _subassemblies_payload
+
+    payload = _subassemblies_payload(make_graph())
+    rows = payload["subassemblies"]
+    assert len(rows) == 1
+    assert rows[0]["name"] == "servo-1"
+    assert rows[0]["children"] == 2
+    assert rows[0]["internal_edges"] == 1
+    assert rows[0]["movable"] is True
+    assert rows[0]["expanded"] is True
+    assert rows[0]["override"] == "auto"
+
+
+def test_subassemblies_payload_reports_no_expand_override():
+    from sw2robot.editor.webserver import _subassemblies_payload
+
+    payload = _subassemblies_payload(make_graph(), "no_expand:\n- servo\n")
+    rows = payload["subassemblies"]
+    assert len(rows) == 1
+    assert rows[0]["expanded"] is False
+    assert rows[0]["override"] == "no_expand"
+
+
 def test_rigid_subassembly_not_expanded():
     g = make_graph()
     # make the internals rigid: bolt pair instead of a hinge


### PR DESCRIPTION
## Summary
Add a read-only /api/subassemblies endpoint for CAD-derived packages
Show CAD sub-assemblies from the rename panel
Display automatic expansion state and expand/no_expand overrides

