### PR TITLE
Add canonical subassembly tree and collapse preview

### DIFF
--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -1033,6 +1033,30 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     'rename.resetAllBtn': { en: '↺ reset all to defaults', ja: '↺ 全デフォルト名に戻す' },
     'rename.resetAllBtnTitle': { en: 'revert every joint/link name to its original',
                                  ja: 'すべての joint 名・link 名を元の名前に戻す' },
+    'subasm.btn': { en: 'Sub-assemblies', ja: 'サブアセンブリ' },
+    'subasm.btnTitle': { en: 'show CAD sub-assemblies and whether they are expanded',
+                         ja: 'CADサブアセンブリと展開状態を表示' },
+    'subasm.title': { en: 'CAD sub-assemblies', ja: 'CADサブアセンブリ' },
+    'subasm.help': { en: 'Read-only for now: shows the automatic expansion decision and any expand / no_expand override in joints.yaml.',
+                     ja: '現在は表示のみ: 自動展開の判定と joints.yaml の expand / no_expand 上書きを表示します。' },
+    'subasm.none': { en: 'No CAD sub-assemblies in this package.',
+                     ja: 'このパッケージにはCADサブアセンブリがありません。' },
+    'subasm.urdfMode': { en: 'Sub-assembly data is available for CAD-extracted packages only.',
+                         ja: 'サブアセンブリ情報はCADから抽出したパッケージでのみ利用できます。' },
+    'subasm.fail': { en: a => `sub-assembly list failed: ${a.e}`,
+                     ja: a => `サブアセンブリ一覧の取得に失敗: ${a.e}` },
+    'subasm.thName': { en: 'CAD name', ja: 'CAD名' },
+    'subasm.thLink': { en: 'link', ja: 'link' },
+    'subasm.thChildren': { en: 'children', ja: '子' },
+    'subasm.thEdges': { en: 'mates', ja: 'mate' },
+    'subasm.thState': { en: 'state', ja: '状態' },
+    'subasm.thPath': { en: 'file', ja: 'ファイル' },
+    'subasm.back': { en: '← rename list', ja: '← 改名リスト' },
+    'subasm.stateExpanded': { en: 'expanded', ja: '展開' },
+    'subasm.stateKept': { en: 'kept as one link', ja: '1リンク保持' },
+    'subasm.overrideAuto': { en: 'auto', ja: 'auto' },
+    'subasm.overrideExpand': { en: 'expand', ja: 'expand' },
+    'subasm.overrideNoExpand': { en: 'no_expand', ja: 'no_expand' },
     // mass editor (bulk mass / density / mass-only + default-mass guard)
     'mass.listTitle': { en: 'mass editor', ja: '質量エディタ' },
     'mass.listHelp': { en: 'set a target mass (kg) OR a density (kg/m³) per link — one clears the other. ⚠ links use a SolidWorks default mass (no material assigned); set a value or acknowledge them before export.',
@@ -2682,14 +2706,95 @@ function dockPanelBelowViews(ov) {
   if (v) { ov.style.top = (v.offsetTop + v.offsetHeight + 6) + 'px'; }
 }
 
+function htmlEsc(s) {
+  return String(s ?? '').replace(/[&<>"]/g, c => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;'
+  }[c]));
+}
+
+function pathBase(p) {
+  const s = String(p ?? '');
+  return s.split(/[\\/]/).pop() || s;
+}
+
+function subasmOverrideLabel(v) {
+  if (v === 'expand') { return t('subasm.overrideExpand'); }
+  if (v === 'no_expand') { return t('subasm.overrideNoExpand'); }
+  return t('subasm.overrideAuto');
+}
+
+async function openSubassemblyList(ov) {
+  if (!viewer.robot) { log(t('common.openFirst'), 'wrn'); return; }
+  const owned = ov || document.getElementById('renamelist') ||
+    document.createElement('div');
+  owned.id = 'renamelist';
+  dockPanelBelowViews(owned);
+  try {
+    const resp = await fetch('/api/subassemblies');
+    const r = await resp.json();
+    if (!resp.ok || r.error) { throw new Error(r.error ?? resp.status); }
+    const card = document.createElement('div');
+    card.className = 'card';
+    let html =
+      '<div style="font-size:14px;margin-bottom:2px;color:#9fe0a8">' +
+      t('subasm.title') + '</div>' +
+      '<div style="font-size:11px;color:#8a93a3;margin-bottom:8px">' +
+      t('subasm.help') + '</div>';
+    const rows = r.subassemblies || [];
+    if (r.mode === 'urdf') {
+      html += '<div style="color:#d6b36b">' + t('subasm.urdfMode') + '</div>';
+    } else if (!rows.length) {
+      html += '<div style="color:#8a93a3">' + t('subasm.none') + '</div>';
+    } else {
+      html += '<table class="rntable"><thead><tr><th>' +
+        t('subasm.thName') + '</th><th>' + t('subasm.thLink') +
+        '</th><th>' + t('subasm.thChildren') + '</th><th>' +
+        t('subasm.thEdges') + '</th><th>' + t('subasm.thState') +
+        '</th><th>' + t('subasm.thPath') + '</th></tr></thead><tbody>';
+      for (const s of rows) {
+        const state = s.expanded ? t('subasm.stateExpanded')
+                                 : t('subasm.stateKept');
+        const col = s.expanded ? '#9fe0a8' : '#d6b36b';
+        html += `<tr title="${htmlEsc(s.reason)}">` +
+          `<td>${htmlEsc(s.name)}</td>` +
+          `<td style="color:#cfe3ff">${htmlEsc(s.link_name)}</td>` +
+          `<td>${s.children ?? 0}</td>` +
+          `<td>${s.internal_edges ?? 0}</td>` +
+          `<td><span style="color:${col}">${state}</span>` +
+          ` <span style="color:#8a93a3">(${subasmOverrideLabel(s.override)})</span></td>` +
+          `<td title="${htmlEsc(s.path)}">${htmlEsc(pathBase(s.path))}</td></tr>`;
+      }
+      html += '</tbody></table>';
+    }
+    card.innerHTML = html;
+    const bar = document.createElement('div');
+    bar.style.cssText = 'display:flex;gap:8px;margin-top:10px';
+    const back = document.createElement('button');
+    back.textContent = t('subasm.back');
+    back.addEventListener('click', () => openRenameList(owned));
+    const close = document.createElement('button');
+    close.textContent = t('common.close');
+    close.addEventListener('click', () => owned.remove());
+    bar.append(back, close);
+    card.appendChild(bar);
+    owned.replaceChildren(card);
+    if (!owned.parentElement) {
+      (document.getElementById('viewer').parentElement || document.body)
+        .appendChild(owned);
+    }
+  } catch (e) {
+    log(t('subasm.fail', { e: e.message ?? e }), 'err');
+  }
+}
+
 // the ≣ 改名 list: every joint with its (editable) joint name + child link name
-function openRenameList() {
+function openRenameList(ov = null) {
   if (!viewer.robot) { log(t('common.openFirst'), 'wrn'); return; }
   document.getElementById('masslist')?.remove();   // the two panels are exclusive
-  document.getElementById('renamelist')?.remove();
+  if (!ov) { document.getElementById('renamelist')?.remove(); }
   const linkOf = (j, tag) => [...(j.urdfNode?.children ?? [])]
     .find(e => e.tagName === tag)?.getAttribute('link') ?? '';
-  const ov = document.createElement('div');
+  ov = ov || document.createElement('div');
   ov.id = 'renamelist';
   dockPanelBelowViews(ov);          // sit under the viewer's button row
   const card = document.createElement('div');
@@ -2723,12 +2828,16 @@ function openRenameList() {
   resetAll.textContent = t('rename.resetAllBtn');
   resetAll.title = t('rename.resetAllBtnTitle');
   resetAll.addEventListener('click', resetAllNames);
+  const subasm = document.createElement('button');
+  subasm.textContent = t('subasm.btn');
+  subasm.title = t('subasm.btnTitle');
+  subasm.addEventListener('click', () => openSubassemblyList(ov));
   const close = document.createElement('button');
   close.textContent = t('common.close');
   close.addEventListener('click', () => ov.remove());
-  bar.append(resetAll, close);
+  bar.append(resetAll, subasm, close);
   card.appendChild(bar);
-  ov.appendChild(card);
+  ov.replaceChildren(card);
   card.querySelectorAll('.rn-input').forEach(inp => {
     inp.addEventListener('change', async () => {
       const v = inp.value.trim(), old = inp.dataset.old;
@@ -2738,11 +2847,13 @@ function openRenameList() {
       else { inp.value = old; }
     });
   });
-  (document.getElementById('viewer').parentElement || document.body)
-    .appendChild(ov);
+  if (!ov.parentElement) {
+    (document.getElementById('viewer').parentElement || document.body)
+      .appendChild(ov);
+  }
 }
 document.getElementById('renamelistbtn')
-  .addEventListener('click', openRenameList);
+  .addEventListener('click', () => openRenameList());
 
 // shared material/density presets (label -> density kg/m³; 'custom' = prompt),
 // used by both the mass editor and the per-link select popup

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -1062,8 +1062,12 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
                               ja: a => `links ${a.cl} → ${a.pl}, joints ${a.cj} → ${a.pj}` },
     'subasm.previewNone': { en: 'No sub-assemblies are collapsed by the current modes.',
                             ja: '現在のmodeで畳まれるサブアセンブリはありません。' },
+    'subasm.previewTreeTitle': { en: 'Preview tree', ja: 'preview tree' },
+    'subasm.thTreeLink': { en: 'tree link', ja: 'tree link' },
+    'subasm.thTreeJoint': { en: 'joint', ja: 'joint' },
     'subasm.thMembers': { en: 'members', ja: '構成link' },
     'subasm.thDropped': { en: 'internal joints', ja: '内部joint' },
+    'subasm.collapsedTag': { en: 'collapsed', ja: '畳み込み' },
     'subasm.backSubasm': { en: '← sub-assemblies', ja: '← サブアセンブリ' },
     'subasm.stateExpanded': { en: 'expanded', ja: '展開' },
     'subasm.stateKept': { en: 'kept as one link', ja: '1リンク保持' },
@@ -2896,6 +2900,26 @@ async function openSubassemblyPreview(ov) {
           `<td>${s.member_links?.length ?? 0}</td>` +
           `<td>${s.internal_joints?.length ?? 0}</td>` +
           `<td>${subasmOverrideLabel(s.override)}</td></tr>`;
+      }
+      html += '</tbody></table>';
+    }
+    const treeRows = r.tree_rows || [];
+    if (treeRows.length) {
+      html += '<div style="font-size:13px;margin:12px 0 4px;color:#9fe0a8">' +
+        t('subasm.previewTreeTitle') + '</div>' +
+        '<table class="rntable"><thead><tr><th>' +
+        t('subasm.thTreeLink') + '</th><th>' + t('subasm.thTreeJoint') +
+        '</th><th>' + t('rename.thType') + '</th></tr></thead><tbody>';
+      for (const row of treeRows) {
+        const indent = Math.max(0, Number(row.depth || 0)) * 14;
+        const marker = row.root ? '⌂' : '·';
+        const collapsed = row.collapsed
+          ? ` <span style="color:#d6b36b">(${t('subasm.collapsedTag')})</span>`
+          : '';
+        html += `<tr><td><span style="display:inline-block;margin-left:${indent}px">` +
+          `${marker} ${htmlEsc(row.link)}${collapsed}</span></td>` +
+          `<td>${htmlEsc(row.joint || '')}</td>` +
+          `<td>${htmlEsc(row.joint_type || '')}</td></tr>`;
       }
       html += '</tbody></table>';
     }

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -1037,8 +1037,8 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     'subasm.btnTitle': { en: 'show CAD sub-assemblies and whether they are expanded',
                          ja: 'CADサブアセンブリと展開状態を表示' },
     'subasm.title': { en: 'CAD sub-assemblies', ja: 'CADサブアセンブリ' },
-    'subasm.help': { en: 'Read-only for now: shows the automatic expansion decision and any expand / no_expand override in joints.yaml.',
-                     ja: '現在は表示のみ: 自動展開の判定と joints.yaml の expand / no_expand 上書きを表示します。' },
+    'subasm.help': { en: 'Sub-assembly mode keeps the normal expanded tree as the baseline, then overrides only selected CAD sub-assemblies.',
+                     ja: 'サブアセンブリモードでは通常の全展開treeを基準にして、選んだCADサブアセンブリだけを上書きします。' },
     'subasm.none': { en: 'No CAD sub-assemblies in this package.',
                      ja: 'このパッケージにはCADサブアセンブリがありません。' },
     'subasm.urdfMode': { en: 'Sub-assembly data is available for CAD-extracted packages only.',
@@ -1050,6 +1050,7 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     'subasm.thChildren': { en: 'children', ja: '子' },
     'subasm.thEdges': { en: 'mates', ja: 'mate' },
     'subasm.thState': { en: 'state', ja: '状態' },
+    'subasm.thMode': { en: 'mode', ja: 'mode' },
     'subasm.thPath': { en: 'file', ja: 'ファイル' },
     'subasm.back': { en: '← rename list', ja: '← 改名リスト' },
     'subasm.stateExpanded': { en: 'expanded', ja: '展開' },
@@ -1057,6 +1058,10 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     'subasm.overrideAuto': { en: 'auto', ja: 'auto' },
     'subasm.overrideExpand': { en: 'expand', ja: 'expand' },
     'subasm.overrideNoExpand': { en: 'no_expand', ja: 'no_expand' },
+    'subasm.setOk': { en: a => `${a.name}: ${a.mode} ✓`,
+                      ja: a => `${a.name}: ${a.mode} ✓` },
+    'subasm.setFail': { en: a => `sub-assembly mode failed: ${a.e}`,
+                        ja: a => `サブアセンブリモード変更に失敗: ${a.e}` },
     // mass editor (bulk mass / density / mass-only + default-mass guard)
     'mass.listTitle': { en: 'mass editor', ja: '質量エディタ' },
     'mass.listHelp': { en: 'set a target mass (kg) OR a density (kg/m³) per link — one clears the other. ⚠ links use a SolidWorks default mass (no material assigned); set a value or acknowledge them before export.',
@@ -2723,8 +2728,28 @@ function subasmOverrideLabel(v) {
   return t('subasm.overrideAuto');
 }
 
+async function setSubassemblyMode(name, mode, ov) {
+  op('subassembly_mode', { name, mode });
+  log(t('common.rebuilding', { what: `${name} → ${mode}` }));
+  try {
+    const resp = await fetch('/api/set_subassembly_mode', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, mode }) });
+    const r = await resp.json();
+    if (!resp.ok || r.error) { throw new Error(r.error ?? resp.status); }
+    log(t('subasm.setOk', { name, mode }), 'ok');
+    refreshHistory();
+    await openSubassemblyList(ov);
+    loadRobot(currentInfo, { keepPose: true });
+  } catch (e) {
+    log(t('subasm.setFail', { e: e.message ?? e }), 'err');
+    await openSubassemblyList(ov);
+  }
+}
+
 async function openSubassemblyList(ov) {
-  if (!viewer.robot) { log(t('common.openFirst'), 'wrn'); return; }
+  if (!viewer.robot && !currentInfo) { log(t('common.openFirst'), 'wrn'); return; }
   const owned = ov || document.getElementById('renamelist') ||
     document.createElement('div');
   owned.id = 'renamelist';
@@ -2750,11 +2775,14 @@ async function openSubassemblyList(ov) {
         t('subasm.thName') + '</th><th>' + t('subasm.thLink') +
         '</th><th>' + t('subasm.thChildren') + '</th><th>' +
         t('subasm.thEdges') + '</th><th>' + t('subasm.thState') +
+        '</th><th>' + t('subasm.thMode') +
         '</th><th>' + t('subasm.thPath') + '</th></tr></thead><tbody>';
       for (const s of rows) {
         const state = s.expanded ? t('subasm.stateExpanded')
                                  : t('subasm.stateKept');
         const col = s.expanded ? '#9fe0a8' : '#d6b36b';
+        const opt = v => `<option value="${v}"${s.override === v ? ' selected' : ''}>` +
+          `${subasmOverrideLabel(v)}</option>`;
         html += `<tr title="${htmlEsc(s.reason)}">` +
           `<td>${htmlEsc(s.name)}</td>` +
           `<td style="color:#cfe3ff">${htmlEsc(s.link_name)}</td>` +
@@ -2762,6 +2790,8 @@ async function openSubassemblyList(ov) {
           `<td>${s.internal_edges ?? 0}</td>` +
           `<td><span style="color:${col}">${state}</span>` +
           ` <span style="color:#8a93a3">(${subasmOverrideLabel(s.override)})</span></td>` +
+          `<td><select class="subasm-mode" data-name="${htmlEsc(s.name)}">` +
+          opt('auto') + opt('expand') + opt('no_expand') + '</select></td>' +
           `<td title="${htmlEsc(s.path)}">${htmlEsc(pathBase(s.path))}</td></tr>`;
       }
       html += '</tbody></table>';
@@ -2778,6 +2808,14 @@ async function openSubassemblyList(ov) {
     bar.append(back, close);
     card.appendChild(bar);
     owned.replaceChildren(card);
+    card.querySelectorAll('.subasm-mode').forEach(sel => {
+      sel.addEventListener('change', () => {
+        const name = sel.dataset.name;
+        const mode = sel.value;
+        card.querySelectorAll('.subasm-mode').forEach(x => { x.disabled = true; });
+        setSubassemblyMode(name, mode, owned);
+      });
+    });
     if (!owned.parentElement) {
       (document.getElementById('viewer').parentElement || document.body)
         .appendChild(owned);

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -1053,6 +1053,18 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     'subasm.thMode': { en: 'mode', ja: 'mode' },
     'subasm.thPath': { en: 'file', ja: 'ファイル' },
     'subasm.back': { en: '← rename list', ja: '← 改名リスト' },
+    'subasm.previewBtn': { en: 'preview collapse', ja: '畳み込み preview' },
+    'subasm.previewTitle': { en: 'Sub-assembly collapse preview',
+                             ja: 'サブアセンブリ畳み込み preview' },
+    'subasm.previewHelp': { en: 'Read-only preview from the canonical expanded tree. URDF output is not changed here.',
+                            ja: '全展開treeから作った読み取り専用previewです。ここではURDF出力は変更しません。' },
+    'subasm.previewCounts': { en: a => `links ${a.cl} → ${a.pl}, joints ${a.cj} → ${a.pj}`,
+                              ja: a => `links ${a.cl} → ${a.pl}, joints ${a.cj} → ${a.pj}` },
+    'subasm.previewNone': { en: 'No sub-assemblies are collapsed by the current modes.',
+                            ja: '現在のmodeで畳まれるサブアセンブリはありません。' },
+    'subasm.thMembers': { en: 'members', ja: '構成link' },
+    'subasm.thDropped': { en: 'internal joints', ja: '内部joint' },
+    'subasm.backSubasm': { en: '← sub-assemblies', ja: '← サブアセンブリ' },
     'subasm.stateExpanded': { en: 'expanded', ja: '展開' },
     'subasm.stateKept': { en: 'kept as one link', ja: '1リンク保持' },
     'subasm.overrideAuto': { en: 'auto', ja: 'auto' },
@@ -2811,10 +2823,13 @@ async function openSubassemblyList(ov) {
     const back = document.createElement('button');
     back.textContent = t('subasm.back');
     back.addEventListener('click', () => openRenameList(owned));
+    const preview = document.createElement('button');
+    preview.textContent = t('subasm.previewBtn');
+    preview.addEventListener('click', () => openSubassemblyPreview(owned));
     const close = document.createElement('button');
     close.textContent = t('common.close');
     close.addEventListener('click', () => owned.remove());
-    bar.append(back, close);
+    bar.append(back, preview, close);
     card.appendChild(bar);
     owned.replaceChildren(card);
     card.querySelectorAll('.subasm-mode').forEach(sel => {
@@ -2833,6 +2848,69 @@ async function openSubassemblyList(ov) {
         setSubassemblyMode(name, mode, owned);
       });
     });
+    if (!owned.parentElement) {
+      (document.getElementById('viewer').parentElement || document.body)
+        .appendChild(owned);
+    }
+  } catch (e) {
+    log(t('subasm.fail', { e: e.message ?? e }), 'err');
+  }
+}
+
+async function openSubassemblyPreview(ov) {
+  if (!viewer.robot && !currentInfo) { log(t('common.openFirst'), 'wrn'); return; }
+  const owned = ov || document.getElementById('renamelist') ||
+    document.createElement('div');
+  owned.id = 'renamelist';
+  try {
+    const resp = await fetch('/api/collapse_preview');
+    const r = await resp.json();
+    if (!resp.ok || r.error) { throw new Error(r.error ?? resp.status); }
+    const card = document.createElement('div');
+    card.className = 'card';
+    const cc = r.canonical_counts || {};
+    const pc = r.preview_counts || {};
+    let html =
+      '<div style="font-size:14px;margin-bottom:2px;color:#9fe0a8">' +
+      t('subasm.previewTitle') + '</div>' +
+      '<div style="font-size:11px;color:#8a93a3;margin-bottom:8px">' +
+      t('subasm.previewHelp') + '</div>' +
+      '<div style="margin-bottom:8px;color:#cfe3ff">' +
+      t('subasm.previewCounts', {
+        cl: cc.links ?? 0, cj: cc.joints ?? 0,
+        pl: pc.links ?? 0, pj: pc.joints ?? 0,
+      }) + '</div>';
+    const rows = r.collapsed_subassemblies || [];
+    if (!rows.length) {
+      html += '<div style="color:#8a93a3">' + t('subasm.previewNone') + '</div>';
+    } else {
+      html += '<table class="rntable"><thead><tr><th>' +
+        t('subasm.thName') + '</th><th>' + t('subasm.thLink') +
+        '</th><th>' + t('subasm.thMembers') + '</th><th>' +
+        t('subasm.thDropped') + '</th><th>' +
+        t('subasm.thMode') + '</th></tr></thead><tbody>';
+      for (const s of rows) {
+        html += `<tr title="${htmlEsc(s.reason)}">` +
+          `<td>${htmlEsc(s.name)}</td>` +
+          `<td style="color:#cfe3ff">${htmlEsc(s.link_name)}</td>` +
+          `<td>${s.member_links?.length ?? 0}</td>` +
+          `<td>${s.internal_joints?.length ?? 0}</td>` +
+          `<td>${subasmOverrideLabel(s.override)}</td></tr>`;
+      }
+      html += '</tbody></table>';
+    }
+    card.innerHTML = html;
+    const bar = document.createElement('div');
+    bar.style.cssText = 'display:flex;gap:8px;margin-top:10px';
+    const back = document.createElement('button');
+    back.textContent = t('subasm.backSubasm');
+    back.addEventListener('click', () => openSubassemblyList(owned));
+    const close = document.createElement('button');
+    close.textContent = t('common.close');
+    close.addEventListener('click', () => owned.remove());
+    bar.append(back, close);
+    card.appendChild(bar);
+    owned.replaceChildren(card);
     if (!owned.parentElement) {
       (document.getElementById('viewer').parentElement || document.body)
         .appendChild(owned);

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -1062,6 +1062,9 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
                       ja: a => `${a.name}: ${a.mode} ✓` },
     'subasm.setFail': { en: a => `sub-assembly mode failed: ${a.e}`,
                         ja: a => `サブアセンブリモード変更に失敗: ${a.e}` },
+    'subasm.largeConfirm': {
+      en: a => `${a.name} contains ${a.children} children and ${a.edges} mates. Changing a large sub-assembly can take a long time. Continue?`,
+      ja: a => `${a.name} は子 ${a.children} 個、mate ${a.edges} 個を含みます。大きいサブアセンブリの切り替えには時間がかかることがあります。続行しますか？` },
     // mass editor (bulk mass / density / mass-only + default-mass guard)
     'mass.listTitle': { en: 'mass editor', ja: '質量エディタ' },
     'mass.listHelp': { en: 'set a target mass (kg) OR a density (kg/m³) per link — one clears the other. ⚠ links use a SolidWorks default mass (no material assigned); set a value or acknowledge them before export.',
@@ -2728,6 +2731,10 @@ function subasmOverrideLabel(v) {
   return t('subasm.overrideAuto');
 }
 
+function isLargeSubassembly(children, edges) {
+  return Number(children) >= 15 || Number(edges) >= 15;
+}
+
 async function setSubassemblyMode(name, mode, ov) {
   op('subassembly_mode', { name, mode });
   log(t('common.rebuilding', { what: `${name} → ${mode}` }));
@@ -2790,7 +2797,9 @@ async function openSubassemblyList(ov) {
           `<td>${s.internal_edges ?? 0}</td>` +
           `<td><span style="color:${col}">${state}</span>` +
           ` <span style="color:#8a93a3">(${subasmOverrideLabel(s.override)})</span></td>` +
-          `<td><select class="subasm-mode" data-name="${htmlEsc(s.name)}">` +
+          `<td><select class="subasm-mode" data-name="${htmlEsc(s.name)}" ` +
+          `data-prev="${htmlEsc(s.override)}" data-children="${s.children ?? 0}" ` +
+          `data-edges="${s.internal_edges ?? 0}">` +
           opt('auto') + opt('expand') + opt('no_expand') + '</select></td>' +
           `<td title="${htmlEsc(s.path)}">${htmlEsc(pathBase(s.path))}</td></tr>`;
       }
@@ -2812,6 +2821,14 @@ async function openSubassemblyList(ov) {
       sel.addEventListener('change', () => {
         const name = sel.dataset.name;
         const mode = sel.value;
+        const prev = sel.dataset.prev || 'auto';
+        const children = Number(sel.dataset.children || 0);
+        const edges = Number(sel.dataset.edges || 0);
+        if (mode !== prev && isLargeSubassembly(children, edges) &&
+            !confirm(t('subasm.largeConfirm', { name, children, edges }))) {
+          sel.value = prev;
+          return;
+        }
         card.querySelectorAll('.subasm-mode').forEach(x => { x.disabled = true; });
         setSubassemblyMode(name, mode, owned);
       });

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1206,6 +1206,86 @@ def _canonical_tree_payload(graph, yml_txt=""):
     }
 
 
+def _collapse_preview_payload(graph, yml_txt=""):
+    """Preview the tree after applying current sub-assembly collapse modes.
+
+    No URDF is rebuilt here.  The payload is the canonical expanded tree with
+    links belonging to each currently-collapsed CAD sub-assembly replaced by
+    that sub-assembly's own link.
+    """
+    canonical = _canonical_tree_payload(graph, yml_txt)
+    states = _subassemblies_payload(graph, yml_txt)
+    by_sub = {s["name"]: s for s in canonical["subassemblies"]}
+    collapse_link = {}
+    collapsed = []
+    for row in states["subassemblies"]:
+        if row.get("expanded", True):
+            continue
+        sub = by_sub.get(row["name"])
+        if not sub or not sub["member_links"]:
+            continue
+        info = {
+            "name": row["name"],
+            "link_name": row["link_name"],
+            "override": row["override"],
+            "reason": row["reason"],
+            "member_links": sub["member_links"],
+            "member_components": sub["member_components"],
+            "internal_joints": sub["internal_joints"],
+            "boundary_joints": sub["boundary_joints"],
+        }
+        collapsed.append(info)
+        for link in sub["member_links"]:
+            collapse_link[link] = row["link_name"]
+
+    links = []
+    inserted = set()
+    for link in canonical["links"]:
+        ln = link["link_name"]
+        repl = collapse_link.get(ln)
+        if repl:
+            if repl not in inserted:
+                sub = next(s for s in collapsed if s["link_name"] == repl)
+                links.append({
+                    "name": sub["name"],
+                    "link_name": repl,
+                    "collapsed": True,
+                    "member_links": sub["member_links"],
+                })
+                inserted.add(repl)
+            continue
+        links.append({**link, "collapsed": False})
+
+    joints, dropped = [], []
+    for j in canonical["joints"]:
+        parent = collapse_link.get(j["parent"], j["parent"])
+        child = collapse_link.get(j["child"], j["child"])
+        out = {**j, "source_name": j["name"],
+               "parent": parent, "child": child}
+        if parent == child:
+            dropped.append(out)
+            continue
+        out["name"] = f"{parent}__{child}"
+        joints.append(out)
+
+    base = collapse_link.get(canonical["base_link"], canonical["base_link"])
+    return {
+        "base_link": base,
+        "links": links,
+        "joints": joints,
+        "dropped_internal_joints": dropped,
+        "collapsed_subassemblies": collapsed,
+        "canonical_counts": {
+            "links": len(canonical["links"]),
+            "joints": len(canonical["joints"]),
+        },
+        "preview_counts": {
+            "links": len(links),
+            "joints": len(joints),
+        },
+    }
+
+
 def _upsert_yaml_map(txt, mapkey, key, value):
     """Set ``mapkey: {key: value}`` (block style) in joints.yaml text, replacing
     any existing entry for ``key`` and creating the map if needed."""
@@ -2747,6 +2827,23 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 txt = open(yml, encoding="utf-8").read() \
                     if os.path.exists(yml) else ""
                 payload = _canonical_tree_payload(gs, txt)
+                payload["mode"] = "cad"
+                return self._send_json(payload)
+            if path == "/api/collapse_preview":
+                cls = type(self)
+                if not cls.pkg_dir:
+                    return self._send_json({"error": "no package open"}, 400)
+                if not _cad_mode(cls.pkg_dir):
+                    return self._send_json(
+                        {"error": "collapse preview needs the CAD graph.json"},
+                        400)
+                from sw2robot.exporter.state import GraphState
+                gs = GraphState.load(os.path.join(cls.pkg_dir, "graph.json"))
+                name = os.path.splitext(os.path.basename(cls.urdf_rel))[0]
+                yml = os.path.join(cls.pkg_dir, name + ".joints.yaml")
+                txt = open(yml, encoding="utf-8").read() \
+                    if os.path.exists(yml) else ""
+                payload = _collapse_preview_payload(gs, txt)
                 payload["mode"] = "cad"
                 return self._send_json(payload)
             if path == "/api/fs":

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1140,6 +1140,72 @@ def _set_subassembly_mode_yaml(txt, graph, name, mode):
     return txt, {"expand": exp_members, "no_expand": noexp_members}
 
 
+def _canonical_tree_payload(graph, yml_txt=""):
+    """Fully-expanded tree plus CAD sub-assembly membership.
+
+    This is a read-only planning payload for the sub-assembly collapse work:
+    always expand CAD sub-assemblies, keep the user's directed tree edits where
+    possible, and report which expanded links/joints belong to each top-level
+    CAD sub-assembly instance.
+    """
+    import yaml as _yaml
+
+    from sw2robot.exporter import model as _M
+
+    try:
+        cfg = _yaml.safe_load(yml_txt) or {}
+        if not isinstance(cfg, dict):
+            cfg = {}
+    except Exception:
+        cfg = {}
+    full_cfg = dict(cfg)
+    full_cfg["expand"] = [""]       # substring override: force every subasm
+    full_cfg["no_expand"] = []
+    model = _M.build_model(graph, config=full_cfg)
+
+    links = [{"name": c.name, "link_name": c.link_name}
+             for c in model.components]
+    joints = [{"name": j.name, "parent": j.parent, "child": j.child,
+               "type": j.jtype}
+              for j in model.joints]
+    link_to_name = {c.link_name: c.name for c in model.components}
+    link_by_name = {c.name: c.link_name for c in model.components}
+
+    subassemblies = []
+    for c in getattr(graph, "components", []) or []:
+        if not (getattr(c, "is_subassembly", False) and c.part_path):
+            continue
+        prefix = c.name + "/"
+        member_names = sorted(n for n in link_by_name if n.startswith(prefix))
+        member_links = [link_by_name[n] for n in member_names]
+        member_set = set(member_links)
+        internal, boundary = [], []
+        for j in joints:
+            p_in = j["parent"] in member_set
+            c_in = j["child"] in member_set
+            if p_in and c_in:
+                internal.append(j)
+            elif p_in or c_in:
+                boundary.append(j)
+        subassemblies.append({
+            "name": c.name,
+            "link_name": c.link_name,
+            "path": c.part_path,
+            "member_components": member_names,
+            "member_links": member_links,
+            "internal_joints": internal,
+            "boundary_joints": boundary,
+        })
+    subassemblies.sort(key=lambda x: x["name"])
+    return {
+        "base_link": model.base_link,
+        "links": links,
+        "joints": joints,
+        "subassemblies": subassemblies,
+        "link_to_component": link_to_name,
+    }
+
+
 def _upsert_yaml_map(txt, mapkey, key, value):
     """Set ``mapkey: {key: value}`` (block style) in joints.yaml text, replacing
     any existing entry for ``key`` and creating the map if needed."""
@@ -2664,6 +2730,23 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 txt = open(yml, encoding="utf-8").read() \
                     if os.path.exists(yml) else ""
                 payload = _subassemblies_payload(gs, txt)
+                payload["mode"] = "cad"
+                return self._send_json(payload)
+            if path == "/api/canonical_tree":
+                cls = type(self)
+                if not cls.pkg_dir:
+                    return self._send_json({"error": "no package open"}, 400)
+                if not _cad_mode(cls.pkg_dir):
+                    return self._send_json(
+                        {"error": "canonical tree needs the CAD graph.json"},
+                        400)
+                from sw2robot.exporter.state import GraphState
+                gs = GraphState.load(os.path.join(cls.pkg_dir, "graph.json"))
+                name = os.path.splitext(os.path.basename(cls.urdf_rel))[0]
+                yml = os.path.join(cls.pkg_dir, name + ".joints.yaml")
+                txt = open(yml, encoding="utf-8").read() \
+                    if os.path.exists(yml) else ""
+                payload = _canonical_tree_payload(gs, txt)
                 payload["mode"] = "cad"
                 return self._send_json(payload)
             if path == "/api/fs":

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1023,6 +1023,67 @@ def _set_number_override(txt, mapkey, key, value):
     return (f"{mapkey}:\n{block}" + txt) if block else txt
 
 
+def _subassemblies_payload(graph, yml_txt=""):
+    """Read-only summary for the editor's sub-assembly panel.
+
+    This intentionally reports top-level CAD sub-assembly *instances* first:
+    those are the units a user sees in the parent assembly and the same names
+    matched by the existing ``expand:`` / ``no_expand:`` config lists.
+    """
+    import yaml as _yaml
+
+    from sw2robot.exporter.model import _subgraph_is_movable
+
+    try:
+        cfg = _yaml.safe_load(yml_txt) or {}
+    except Exception:
+        cfg = {}
+    expand = [str(x).lower() for x in (cfg.get("expand") or [])]
+    no_expand = [str(x).lower() for x in (cfg.get("no_expand") or [])]
+
+    subs = getattr(graph, "subassemblies", None) or {}
+    out = []
+    for c in getattr(graph, "components", []) or []:
+        if not (getattr(c, "is_subassembly", False) and c.part_path):
+            continue
+        sub = subs.get(c.part_path)
+        nm = c.name.lower()
+        override = "auto"
+        if any(s in nm for s in no_expand):
+            override = "no_expand"
+        elif any(s in nm for s in expand):
+            override = "expand"
+        movable = bool(sub and _subgraph_is_movable(sub, subs))
+        expanded = override != "no_expand" and (
+            override == "expand" or movable)
+        if override == "no_expand":
+            reason = "kept by no_expand"
+        elif override == "expand":
+            reason = "forced expand"
+        elif movable:
+            reason = "auto-expanded: moving internals" if expanded \
+                else "moving internals"
+        else:
+            reason = "kept rigid: no moving internals"
+        out.append({
+            "name": c.name,
+            "link_name": c.link_name,
+            "path": c.part_path,
+            "children": len(sub.components) if sub else 0,
+            "internal_edges": len(sub.edges) if sub else 0,
+            "movable": movable,
+            "override": override,
+            "expanded": expanded,
+            "reason": reason,
+        })
+    out.sort(key=lambda x: x["name"])
+    return {
+        "subassemblies": out,
+        "expand": cfg.get("expand") or [],
+        "no_expand": cfg.get("no_expand") or [],
+    }
+
+
 def _upsert_yaml_map(txt, mapkey, key, value):
     """Set ``mapkey: {key: value}`` (block style) in joints.yaml text, replacing
     any existing entry for ``key`` and creating the map if needed."""
@@ -2532,6 +2593,23 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                                         "urdf_masses": urdf_masses,
                                         "mass_only": sorted(
                                             _read_mass_only(cls.pkg_dir))})
+            if path == "/api/subassemblies":
+                cls = type(self)
+                if not cls.pkg_dir:
+                    return self._send_json({"error": "no package open"}, 400)
+                if not _cad_mode(cls.pkg_dir):
+                    return self._send_json({"subassemblies": [],
+                                            "expand": [], "no_expand": [],
+                                            "mode": "urdf"})
+                from sw2robot.exporter.state import GraphState
+                gs = GraphState.load(os.path.join(cls.pkg_dir, "graph.json"))
+                name = os.path.splitext(os.path.basename(cls.urdf_rel))[0]
+                yml = os.path.join(cls.pkg_dir, name + ".joints.yaml")
+                txt = open(yml, encoding="utf-8").read() \
+                    if os.path.exists(yml) else ""
+                payload = _subassemblies_payload(gs, txt)
+                payload["mode"] = "cad"
+                return self._send_json(payload)
             if path == "/api/fs":
                 # tiny server-side file browser: the OS file dialog cannot
                 # hand a PATH to the page, so the page browses through us

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1126,7 +1126,7 @@ def _set_subassembly_mode_yaml(txt, graph, name, mode):
     noexp = [str(x) for x in (cfg.get("no_expand") or [])]
     exp_rm, exp_shared = _matching_subasm_members(exp, name, names)
     noexp_rm, noexp_shared = _matching_subasm_members(noexp, name, names)
-    shared = exp_shared + noexp_shared
+    shared = [*exp_shared, *noexp_shared]
     if shared:
         raise ValueError(
             "cannot safely change this row because these substring override(s) "
@@ -1134,9 +1134,9 @@ def _set_subassembly_mode_yaml(txt, graph, name, mode):
     add_exp = [name] if mode == "expand" else []
     add_noexp = [name] if mode == "no_expand" else []
     txt, exp_members = _set_yaml_list_block(
-        txt, "expand", add=add_exp, remove=exp_rm + [name])
+        txt, "expand", add=add_exp, remove=[*exp_rm, name])
     txt, noexp_members = _set_yaml_list_block(
-        txt, "no_expand", add=add_noexp, remove=noexp_rm + [name])
+        txt, "no_expand", add=add_noexp, remove=[*noexp_rm, name])
     return txt, {"expand": exp_members, "no_expand": noexp_members}
 
 

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1084,6 +1084,62 @@ def _subassemblies_payload(graph, yml_txt=""):
     }
 
 
+def _subassembly_names(graph):
+    return sorted(c.name for c in (getattr(graph, "components", []) or [])
+                  if getattr(c, "is_subassembly", False) and c.part_path)
+
+
+def _matching_subasm_members(members, name, all_names):
+    """Config list entries that affect ``name`` and no other sub-assembly.
+
+    ``expand`` / ``no_expand`` are substring lists by design.  The web control
+    writes exact CAD instance names, but older hand-authored configs may contain
+    broad substrings.  Only remove a matching broad entry when it is unique to
+    this instance; otherwise the UI would silently change sibling rows too.
+    """
+    lname = name.lower()
+    safe, shared = [], []
+    for raw in members or []:
+        s = str(raw)
+        key = s.lower()
+        if key not in lname:
+            continue
+        matches = [n for n in all_names if key in n.lower()]
+        (safe if len(matches) <= 1 else shared).append(s)
+    return safe, shared
+
+
+def _set_subassembly_mode_yaml(txt, graph, name, mode):
+    """Set one CAD sub-assembly instance to auto / expand / no_expand."""
+    import yaml as _yaml
+
+    if mode not in ("auto", "expand", "no_expand"):
+        raise ValueError("mode must be auto, expand, or no_expand")
+    names = _subassembly_names(graph)
+    if name not in names:
+        raise ValueError(f"no CAD sub-assembly '{name}'")
+    try:
+        cfg = _yaml.safe_load(txt) or {}
+    except Exception:
+        cfg = {}
+    exp = [str(x) for x in (cfg.get("expand") or [])]
+    noexp = [str(x) for x in (cfg.get("no_expand") or [])]
+    exp_rm, exp_shared = _matching_subasm_members(exp, name, names)
+    noexp_rm, noexp_shared = _matching_subasm_members(noexp, name, names)
+    shared = exp_shared + noexp_shared
+    if shared:
+        raise ValueError(
+            "cannot safely change this row because these substring override(s) "
+            "also match other sub-assemblies: " + ", ".join(shared))
+    add_exp = [name] if mode == "expand" else []
+    add_noexp = [name] if mode == "no_expand" else []
+    txt, exp_members = _set_yaml_list_block(
+        txt, "expand", add=add_exp, remove=exp_rm + [name])
+    txt, noexp_members = _set_yaml_list_block(
+        txt, "no_expand", add=add_noexp, remove=noexp_rm + [name])
+    return txt, {"expand": exp_members, "no_expand": noexp_members}
+
+
 def _upsert_yaml_map(txt, mapkey, key, value):
     """Set ``mapkey: {key: value}`` (block style) in joints.yaml text, replacing
     any existing entry for ``key`` and creating the map if needed."""
@@ -3404,6 +3460,51 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 return self._send_json(
                     {"detected": len(applied) + len(missed),
                      "applied": applied, "missed": missed})
+            if parsed.path == "/api/set_subassembly_mode":
+                cls = type(self)
+                n = int(self.headers.get("Content-Length", 0))
+                body = json.loads(self.rfile.read(n) or b"{}")
+                name_in = (body.get("name") or "").strip()
+                mode = (body.get("mode") or "").strip()
+                if not cls.pkg_dir:
+                    return self._send_json({"error": "no package open"}, 400)
+                if not _cad_mode(cls.pkg_dir):
+                    return self._send_json(
+                        {"error": "sub-assembly modes need the CAD graph.json"},
+                        400)
+                if not name_in:
+                    return self._send_json({"error": "name required"}, 400)
+                from sw2robot.exporter.state import GraphState
+                graph = GraphState.load(os.path.join(cls.pkg_dir, "graph.json"))
+                name = os.path.splitext(os.path.basename(cls.urdf_rel))[0]
+                yml = os.path.join(cls.pkg_dir, name + ".joints.yaml")
+                if not os.path.exists(yml):
+                    return self._send_json(
+                        {"error": "joints.yaml not found -- re-extract once"},
+                        400)
+                with open(yml, encoding="utf-8") as f:
+                    txt = f.read()
+                try:
+                    txt, members = _set_subassembly_mode_yaml(
+                        txt, graph, name_in, mode)
+                except ValueError as e:
+                    return self._send_json({"error": str(e)}, 400)
+                _snapshot(cls.pkg_dir, yml,
+                          f"sub-assembly {name_in} -> {mode}")
+                with open(yml, "w", encoding="utf-8") as f:
+                    f.write(txt)
+                from sw2robot.exporter.export import build
+                try:
+                    build(cls.pkg_dir, config_path=yml)
+                except Exception as e:
+                    return self._send_json(
+                        {"error": f"rebuild failed: {e}"}, 500)
+                payload = _subassemblies_payload(graph, txt)
+                payload.update({"ok": True, "name": name_in, "mode": mode,
+                                **members})
+                print(f"[sw2robot.web] set_subassembly_mode: "
+                      f"{name_in} -> {mode}")
+                return self._send_json(payload)
             if parsed.path == "/api/set_base":
                 cls = type(self)
                 n = int(self.headers.get("Content-Length", 0))

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1273,6 +1273,7 @@ def _collapse_preview_payload(graph, yml_txt=""):
         "base_link": base,
         "links": links,
         "joints": joints,
+        "tree_rows": _tree_rows_payload(base, links, joints),
         "dropped_internal_joints": dropped,
         "collapsed_subassemblies": collapsed,
         "canonical_counts": {
@@ -1284,6 +1285,52 @@ def _collapse_preview_payload(graph, yml_txt=""):
             "joints": len(joints),
         },
     }
+
+
+def _tree_rows_payload(base_link, links, joints):
+    """Flatten a link/joint tree into display rows for preview UIs."""
+    link_info = {l["link_name"]: l for l in links}
+    by_parent = {}
+    child_links = set()
+    for j in joints:
+        by_parent.setdefault(j["parent"], []).append(j)
+        child_links.add(j["child"])
+    for rows in by_parent.values():
+        rows.sort(key=lambda j: (j["child"], j["name"]))
+
+    roots = []
+    if base_link in link_info:
+        roots.append(base_link)
+    roots.extend(sorted(ln for ln in link_info
+                        if ln not in child_links and ln != base_link))
+
+    out, seen = [], set()
+
+    def walk(link, depth, parent=None, joint=None):
+        if link in seen:
+            return
+        seen.add(link)
+        info = link_info.get(link, {})
+        out.append({
+            "link": link,
+            "name": info.get("name", link),
+            "depth": depth,
+            "parent": parent,
+            "joint": joint.get("name") if joint else None,
+            "source_joint": joint.get("source_name") if joint else None,
+            "joint_type": joint.get("type") if joint else "root",
+            "collapsed": bool(info.get("collapsed")),
+            "root": joint is None,
+        })
+        for child_joint in by_parent.get(link, []):
+            walk(child_joint["child"], depth + 1, link, child_joint)
+
+    for root in roots:
+        walk(root, 0)
+    for link in sorted(link_info):
+        if link not in seen:
+            walk(link, 0)
+    return out
 
 
 def _upsert_yaml_map(txt, mapkey, key, value):

--- a/sw2robot/exporter/model.py
+++ b/sw2robot/exporter/model.py
@@ -336,6 +336,33 @@ def _match_component(comps, ref):
     return None
 
 
+def _collapsed_ref_candidates(comps, ref):
+    """Preserved sub-assemblies whose expanded child name is referenced.
+
+    ``joints.yaml`` is intentionally authored against the fully-expanded tree.
+    When a later build keeps a CAD sub-assembly collapsed with ``no_expand``,
+    entries such as ``arm-1/plate-1`` or ``arm_1__plate_1`` should still point
+    at the preserved ``arm-1`` component instead of being treated as missing.
+    """
+    raw = str(ref)
+    safe = safe_name(raw)
+    out = []
+    for c in comps:
+        prefs = (
+            c.name + "/",
+            safe_name(c.name) + "/",
+            c.link_name + "__",
+        )
+        if raw.startswith(prefs) or safe.startswith(c.link_name + "__"):
+            out.append(c.name)
+    return out
+
+
+def _collapsed_anchor_for(comps, ref):
+    cands = _collapsed_ref_candidates(comps, ref)
+    return sorted(cands, key=lambda c: (-len(c), c))[0] if cands else None
+
+
 def _num(v):
     """Coerce a YAML scalar to float, or None if absent / unparseable."""
     if v is None:
@@ -390,8 +417,10 @@ def resolve_directed(comps, joints_cfg):
             pa, ca = j["between"][0], j["between"][1]
         else:
             continue
-        np_ = _match_component(comps, pa)
-        nc = _match_component(comps, ca)
+        np_ = _match_component(comps, pa) or _collapsed_anchor_for(comps, pa)
+        nc = _match_component(comps, ca) or _collapsed_anchor_for(comps, ca)
+        if np_ and nc and np_ == nc:
+            continue
         if not (np_ and nc):
             print(f"      WARN: joint config '{pa}->{ca}' did not match links")
             continue
@@ -814,6 +843,11 @@ def choose_base(comps, ground, base_hint=None, adjacency=None):
         for c in comps:
             if h in c.name.lower() or h in c.link_name.lower():
                 return c
+        collapsed = _collapsed_anchor_for(comps, base_hint)
+        if collapsed:
+            for c in comps:
+                if c.name == collapsed:
+                    return c
         print(f"      WARN: base hint '{base_hint}' matched nothing; "
               f"falling back to auto")
 

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -137,6 +137,48 @@ def test_no_expand_maps_expanded_base_hint_to_preserved_instance():
     assert model.base_link == "servo_1"
 
 
+def test_canonical_tree_payload_ignores_subassembly_modes():
+    from sw2robot.editor.webserver import _canonical_tree_payload
+
+    payload = _canonical_tree_payload(
+        make_graph(), "base: plate-1\nno_expand:\n- servo\n")
+    link_names = {x["link_name"] for x in payload["links"]}
+    assert "servo_1" not in link_names
+    assert {"servo_1__case_1", "servo_1__horn_1"} <= link_names
+
+    sub = payload["subassemblies"][0]
+    assert sub["name"] == "servo-1"
+    assert set(sub["member_links"]) == {"servo_1__case_1",
+                                        "servo_1__horn_1"}
+    assert {j["child"] for j in sub["internal_joints"]} == {
+        "servo_1__horn_1"}
+    assert {j["child"] for j in sub["boundary_joints"]} == {
+        "servo_1__case_1"}
+
+
+def test_canonical_tree_payload_keeps_directed_tree_edits():
+    from sw2robot.editor.webserver import _canonical_tree_payload
+
+    txt = """
+base: plate-1
+no_expand:
+- servo
+joints:
+  - parent: plate-1
+    child:  servo-1/case-1
+    type:   fixed
+  - parent: servo-1/case-1
+    child:  servo-1/horn-1
+    type:   fixed
+"""
+    payload = _canonical_tree_payload(make_graph(), txt)
+    sub = payload["subassemblies"][0]
+    assert [(j["parent"], j["child"], j["type"])
+            for j in sub["internal_joints"]] == [
+        ("servo_1__case_1", "servo_1__horn_1", "fixed")
+    ]
+
+
 def test_subassemblies_payload_reports_expansion_state():
     from sw2robot.editor.webserver import _subassemblies_payload
 

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -101,6 +101,30 @@ def test_no_expand_override_keeps_instance():
     assert {c.name for c in comps} == {"plate-1", "servo-1"}
 
 
+def test_subassemblies_payload_reports_expansion_state():
+    from sw2robot.editor.webserver import _subassemblies_payload
+
+    payload = _subassemblies_payload(make_graph())
+    rows = payload["subassemblies"]
+    assert len(rows) == 1
+    assert rows[0]["name"] == "servo-1"
+    assert rows[0]["children"] == 2
+    assert rows[0]["internal_edges"] == 1
+    assert rows[0]["movable"] is True
+    assert rows[0]["expanded"] is True
+    assert rows[0]["override"] == "auto"
+
+
+def test_subassemblies_payload_reports_no_expand_override():
+    from sw2robot.editor.webserver import _subassemblies_payload
+
+    payload = _subassemblies_payload(make_graph(), "no_expand:\n- servo\n")
+    rows = payload["subassemblies"]
+    assert len(rows) == 1
+    assert rows[0]["expanded"] is False
+    assert rows[0]["override"] == "no_expand"
+
+
 def test_rigid_subassembly_not_expanded():
     g = make_graph()
     # make the internals rigid: bolt pair instead of a hinge

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -101,6 +101,42 @@ def test_no_expand_override_keeps_instance():
     assert {c.name for c in comps} == {"plate-1", "servo-1"}
 
 
+def test_no_expand_reuses_fully_expanded_directed_tree():
+    cfg = {
+        # This is the fully-expanded tree written by the rename/joints panel.
+        # no_expand should collapse only the sub-assembly boundary, not discard
+        # the saved tree and attach the preserved instance somewhere arbitrary.
+        "base": "plate-1",
+        "no_expand": ["servo"],
+        "joints": [
+            {"parent": "plate-1", "child": "servo-1/case-1",
+             "type": "fixed"},
+            {"parent": "servo-1/case-1", "child": "servo-1/horn-1",
+             "type": "revolute"},
+        ],
+    }
+    model = build_model(make_graph(), config=cfg)
+    assert {c.name for c in model.components} == {"plate-1", "servo-1"}
+    assert [(j.parent, j.child, j.jtype) for j in model.joints] == [
+        ("plate_1", "servo_1", "fixed")
+    ]
+
+
+def test_no_expand_maps_expanded_base_hint_to_preserved_instance():
+    cfg = {
+        "base": "servo-1/case-1",
+        "no_expand": ["servo"],
+        "joints": [
+            {"parent": "plate-1", "child": "servo-1/case-1",
+             "type": "fixed"},
+            {"parent": "servo-1/case-1", "child": "servo-1/horn-1",
+             "type": "revolute"},
+        ],
+    }
+    model = build_model(make_graph(), config=cfg)
+    assert model.base_link == "servo_1"
+
+
 def test_subassemblies_payload_reports_expansion_state():
     from sw2robot.editor.webserver import _subassemblies_payload
 

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -179,6 +179,36 @@ joints:
     ]
 
 
+def test_collapse_preview_replaces_no_expand_subassembly_members():
+    from sw2robot.editor.webserver import _collapse_preview_payload
+
+    txt = "base: plate-1\nno_expand:\n- servo\n"
+    payload = _collapse_preview_payload(make_graph(), txt)
+    assert payload["canonical_counts"] == {"links": 3, "joints": 2}
+    assert payload["preview_counts"] == {"links": 2, "joints": 1}
+    assert {x["link_name"] for x in payload["links"]} == {
+        "plate_1", "servo_1"}
+    assert payload["collapsed_subassemblies"][0]["name"] == "servo-1"
+    assert set(payload["collapsed_subassemblies"][0]["member_links"]) == {
+        "servo_1__case_1", "servo_1__horn_1"}
+    assert [(j["parent"], j["child"], j["type"])
+            for j in payload["joints"]] == [
+        ("plate_1", "servo_1", "fixed")
+    ]
+    assert [j["source_name"] for j in payload["dropped_internal_joints"]] == [
+        "servo_1__case_1__servo_1__horn_1"
+    ]
+
+
+def test_collapse_preview_keeps_expanded_override():
+    from sw2robot.editor.webserver import _collapse_preview_payload
+
+    txt = "base: plate-1\nexpand:\n- servo\n"
+    payload = _collapse_preview_payload(make_graph(), txt)
+    assert payload["collapsed_subassemblies"] == []
+    assert payload["preview_counts"] == payload["canonical_counts"]
+
+
 def test_subassemblies_payload_reports_expansion_state():
     from sw2robot.editor.webserver import _subassemblies_payload
 

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -198,6 +198,11 @@ def test_collapse_preview_replaces_no_expand_subassembly_members():
     assert [j["source_name"] for j in payload["dropped_internal_joints"]] == [
         "servo_1__case_1__servo_1__horn_1"
     ]
+    assert [(r["link"], r["depth"], r["joint_type"], r["collapsed"])
+            for r in payload["tree_rows"]] == [
+        ("plate_1", 0, "root", False),
+        ("servo_1", 1, "fixed", True),
+    ]
 
 
 def test_collapse_preview_keeps_expanded_override():
@@ -207,6 +212,12 @@ def test_collapse_preview_keeps_expanded_override():
     payload = _collapse_preview_payload(make_graph(), txt)
     assert payload["collapsed_subassemblies"] == []
     assert payload["preview_counts"] == payload["canonical_counts"]
+    assert [(r["link"], r["depth"], r["joint_type"], r["collapsed"])
+            for r in payload["tree_rows"]] == [
+        ("plate_1", 0, "root", False),
+        ("servo_1__case_1", 1, "fixed", False),
+        ("servo_1__horn_1", 2, "revolute", False),
+    ]
 
 
 def test_subassemblies_payload_reports_expansion_state():

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -161,6 +161,48 @@ def test_subassemblies_payload_reports_no_expand_override():
     assert rows[0]["override"] == "no_expand"
 
 
+def test_set_subassembly_mode_yaml_round_trips_exact_name():
+    from sw2robot.editor.webserver import (
+        _set_subassembly_mode_yaml,
+        _subassemblies_payload,
+    )
+
+    txt, members = _set_subassembly_mode_yaml("", make_graph(), "servo-1",
+                                              "no_expand")
+    assert members["expand"] == []
+    assert members["no_expand"] == ["servo-1"]
+    row = _subassemblies_payload(make_graph(), txt)["subassemblies"][0]
+    assert row["expanded"] is False
+    assert row["override"] == "no_expand"
+
+    txt, members = _set_subassembly_mode_yaml(txt, make_graph(), "servo-1",
+                                              "expand")
+    assert members["expand"] == ["servo-1"]
+    assert members["no_expand"] == []
+    row = _subassemblies_payload(make_graph(), txt)["subassemblies"][0]
+    assert row["expanded"] is True
+    assert row["override"] == "expand"
+
+    txt, members = _set_subassembly_mode_yaml(txt, make_graph(), "servo-1",
+                                              "auto")
+    assert members["expand"] == []
+    assert members["no_expand"] == []
+    row = _subassemblies_payload(make_graph(), txt)["subassemblies"][0]
+    assert row["override"] == "auto"
+
+
+def test_set_subassembly_mode_yaml_rejects_shared_substring_override():
+    from sw2robot.editor.webserver import _set_subassembly_mode_yaml
+
+    g = make_graph()
+    inst2 = _comp("servo-2", "servo_2", xyz=(0.2, 0, 0), sub=True,
+                  path="X:/fake/servo_unit.SLDASM")
+    g.components.append(inst2)
+    with pytest.raises(ValueError, match="also match other sub-assemblies"):
+        _set_subassembly_mode_yaml("no_expand:\n- servo\n", g, "servo-1",
+                                   "expand")
+
+
 def test_rigid_subassembly_not_expanded():
     g = make_graph()
     # make the internals rigid: bolt pair instead of a hinge


### PR DESCRIPTION
## Notes
This PR builds on `clean/subassembly-list-panel`.
This is a stacked PR on top of #140.
GitHub shows the full diff against upstream/main until #140 is merged.

Reviewable diff:
https://github.com/poyotamu000/solidworks_urdf_exporter2/compare/clean/subassembly-list-panel...clean/subassembly-canonical-tree

## Summary

This PR adds the canonical expanded subassembly tree and a collapsed-tree preview for future subassembly-preserving URDF export.

- Add sub-assembly mode controls: auto / expand / no_expand
- Preserve the fully expanded tree as the baseline for sub-assembly handling
- Expose canonical expanded sub-assembly tree data from the web server
- Add a read-only collapsed sub-assembly preview tree
- Warn before changing large sub-assemblies because rebuilds may take time

Normal robot view and normal export are kept unchanged. The new behavior is limited to the sub-assembly panel / preview path.

## Motivation

The current exporter expands CAD subassemblies into individual links/joints. For future support of preserving CAD subassemblies as grouped URDF links, we need a stable canonical tree that remains fully expanded, then apply subassembly-level collapse as a separate transformation.


## Testing

pytest tests/test_expand.py
pytest tests/test_cad_mode_webserver.py tests/test_webserver_port.py
manually checked with .exe