### PR TITLE
Validate collapsed subassembly tree previews

### DIFF
--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -2769,10 +2769,47 @@ function htmlEsc(s) {
 function validationIssuesHtml(validation) {
   const issues = validation?.issues || [];
   if (!issues.length) { return ''; }
+  function previewList(values, limit = 5) {
+    const arr = (values || []).filter(v => v !== null && v !== undefined);
+    if (!arr.length) { return ''; }
+    const head = arr.slice(0, limit).map(htmlEsc).join(', ');
+    const more = arr.length > limit ? `, +${arr.length - limit} more` : '';
+    return head + more;
+  }
+  function issueDetailHtml(issue) {
+    const parts = [];
+    const parents = previewList(issue.parents);
+    if (parents) {
+      parts.push(`<div>candidates: ${parents}</div>`);
+    }
+    const joints = previewList(issue.source_joints || issue.joints);
+    if (joints) {
+      parts.push(`<div>joints: ${joints}</div>`);
+    }
+    const links = previewList(issue.links, 8);
+    if (links) {
+      parts.push(`<div>links: ${links}</div>`);
+    }
+    const comps = issue.components || [];
+    if (comps.length) {
+      const rows = comps.slice(0, 3).map((comp, i) => {
+        const label = previewList(comp, 4);
+        return `<div>group ${i + 1} (${comp.length}): ${label}</div>`;
+      });
+      if (comps.length > 3) {
+        rows.push(`<div>+${comps.length - 3} groups</div>`);
+      }
+      parts.push(rows.join(''));
+    }
+    if (!parts.length) { return ''; }
+    return `<div style="color:#c6ad79;margin:2px 0 5px 12px">` +
+      parts.join('') + `</div>`;
+  }
   const rows = issues.slice(0, 6).map(issue =>
     `<div style="margin-top:2px">` +
     `<span style="color:#d6b36b">${htmlEsc(issue.code || 'warning')}</span>` +
-    `: ${htmlEsc(issue.message || '')}</div>`).join('');
+    `: ${htmlEsc(issue.message || '')}</div>` +
+    issueDetailHtml(issue)).join('');
   const more = issues.length > 6
     ? `<div style="color:#8a93a3;margin-top:2px">+${issues.length - 6}</div>`
     : '';

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -1104,6 +1104,8 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
                           ja: a => `${a.n} 行` },
     'tree.memberCount': { en: a => `${a.n} links`,
                           ja: a => `${a.n} links` },
+    'tree.validationTitle': { en: a => `collapse validation: ${a.n} issue(s)`,
+                              ja: a => `畳み込み検証: ${a.n} 件` },
     // mass editor (bulk mass / density / mass-only + default-mass guard)
     'mass.listTitle': { en: 'mass editor', ja: '質量エディタ' },
     'mass.listHelp': { en: 'set a target mass (kg) OR a density (kg/m³) per link — one clears the other. ⚠ links use a SolidWorks default mass (no material assigned); set a value or acknowledge them before export.',
@@ -2764,6 +2766,23 @@ function htmlEsc(s) {
   }[c]));
 }
 
+function validationIssuesHtml(validation) {
+  const issues = validation?.issues || [];
+  if (!issues.length) { return ''; }
+  const rows = issues.slice(0, 6).map(issue =>
+    `<div style="margin-top:2px">` +
+    `<span style="color:#d6b36b">${htmlEsc(issue.code || 'warning')}</span>` +
+    `: ${htmlEsc(issue.message || '')}</div>`).join('');
+  const more = issues.length > 6
+    ? `<div style="color:#8a93a3;margin-top:2px">+${issues.length - 6}</div>`
+    : '';
+  return `<div style="border:1px solid #6b5730;background:#2b251b;` +
+    `color:#f0d49a;border-radius:4px;padding:6px 8px;margin:8px 0;` +
+    `font-size:11px">` +
+    `<div>${t('tree.validationTitle', { n: issues.length })}</div>` +
+    rows + more + `</div>`;
+}
+
 function pathBase(p) {
   const s = String(p ?? '');
   return s.split(/[\\/]/).pop() || s;
@@ -2913,7 +2932,8 @@ async function openSubassemblyPreview(ov) {
       t('subasm.previewCounts', {
         cl: cc.links ?? 0, cj: cc.joints ?? 0,
         pl: pc.links ?? 0, pj: pc.joints ?? 0,
-      }) + '</div>';
+      }) + '</div>' +
+      validationIssuesHtml(r.validation);
     const rows = r.collapsed_subassemblies || [];
     if (!rows.length) {
       html += '<div style="color:#8a93a3">' + t('subasm.previewNone') + '</div>';
@@ -3316,6 +3336,12 @@ async function renderSubassemblyTreeRows(robot, movable) {
       countEl.textContent = q
         ? t('jfilter.count', { n: treeRows.length, total: allRows.length })
         : t('tree.subasmCount', { n: treeRows.length });
+    }
+    const validationHtml = validationIssuesHtml(r.validation);
+    if (validationHtml) {
+      const warn = document.createElement('div');
+      warn.innerHTML = validationHtml;
+      jointsEl.appendChild(warn);
     }
     const hint = document.createElement('div');
     hint.className = 'joint';

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1269,11 +1269,14 @@ def _collapse_preview_payload(graph, yml_txt=""):
         joints.append(out)
 
     base = collapse_link.get(canonical["base_link"], canonical["base_link"])
+    validation = _validate_collapsed_tree(base, links, joints, collapsed,
+                                          collapse_link)
     return {
         "base_link": base,
         "links": links,
         "joints": joints,
         "tree_rows": _tree_rows_payload(base, links, joints),
+        "validation": validation,
         "dropped_internal_joints": dropped,
         "collapsed_subassemblies": collapsed,
         "canonical_counts": {
@@ -1284,6 +1287,134 @@ def _collapse_preview_payload(graph, yml_txt=""):
             "links": len(links),
             "joints": len(joints),
         },
+    }
+
+
+def _validate_collapsed_tree(base_link, links, joints, collapsed,
+                             collapse_link=None):
+    """Report structural hazards in a collapsed preview tree."""
+    collapse_link = collapse_link or {}
+    link_names = {l["link_name"] for l in links}
+    issues = []
+
+    incoming = {}
+    for j in joints:
+        incoming.setdefault(j["child"], []).append(j)
+    for child, rows in sorted(incoming.items()):
+        parents = sorted({j["parent"] for j in rows})
+        if len(parents) > 1:
+            issues.append({
+                "severity": "warning",
+                "code": "multiple_parents",
+                "link": child,
+                "parents": parents,
+                "joints": [j.get("name") for j in rows],
+                "source_joints": [j.get("source_name") for j in rows],
+                "message": (
+                    f"{child} has {len(parents)} parent candidates after "
+                    "sub-assembly collapse"),
+            })
+
+    adj = {}
+    for j in joints:
+        adj.setdefault(j["parent"], []).append(j["child"])
+    seen_cycles, colour, stack = set(), {}, []
+
+    def dfs(node):
+        colour[node] = "gray"
+        stack.append(node)
+        for child in adj.get(node, []):
+            if colour.get(child) == "gray":
+                i = stack.index(child)
+                cyc = [*stack[i:], child]
+                key = tuple(cyc)
+                if key not in seen_cycles:
+                    seen_cycles.add(key)
+                    issues.append({
+                        "severity": "error",
+                        "code": "cycle",
+                        "links": cyc,
+                        "message": "collapsed tree contains a directed cycle",
+                    })
+            elif colour.get(child) != "black":
+                dfs(child)
+        stack.pop()
+        colour[node] = "black"
+
+    roots = [base_link] if base_link in link_names else []
+    roots.extend(sorted(link_names - set(roots)))
+    for root in roots:
+        if colour.get(root) is None:
+            dfs(root)
+
+    for sub in collapsed:
+        members = list(sub.get("member_links") or [])
+        if len(members) <= 1:
+            continue
+        member_set = set(members)
+        internal_adj = {m: set() for m in members}
+        for j in sub.get("internal_joints") or []:
+            p, c = j.get("parent"), j.get("child")
+            if p in member_set and c in member_set:
+                internal_adj[p].add(c)
+                internal_adj[c].add(p)
+        comps = []
+        todo = set(members)
+        while todo:
+            start = todo.pop()
+            comp = [start]
+            q = [start]
+            while q:
+                cur = q.pop()
+                for nxt in internal_adj.get(cur, ()):
+                    if nxt in todo:
+                        todo.remove(nxt)
+                        comp.append(nxt)
+                        q.append(nxt)
+            comps.append(sorted(comp))
+        # ``todo`` is a set, so the discovery order of the groups is not
+        # deterministic across platforms/hash seeds -- sort the groups (each
+        # already sorted internally) so the payload is stable.
+        comps.sort()
+        if len(comps) > 1:
+            issues.append({
+                "severity": "warning",
+                "code": "disconnected_members",
+                "subassembly": sub.get("name"),
+                "link": sub.get("link_name"),
+                "components": comps,
+                "message": (
+                    f"{sub.get('name')} maps to {len(comps)} disconnected "
+                    "member groups in the expanded tree"),
+            })
+
+        incoming_boundary = []
+        for j in sub.get("boundary_joints") or []:
+            parent = collapse_link.get(j["parent"], j["parent"])
+            child = collapse_link.get(j["child"], j["child"])
+            if child == sub.get("link_name") and parent != child:
+                incoming_boundary.append({
+                    "parent": parent,
+                    "joint": j.get("name"),
+                })
+        parents = sorted({x["parent"] for x in incoming_boundary})
+        if len(parents) > 1:
+            issues.append({
+                "severity": "warning",
+                "code": "multiple_boundary_parents",
+                "subassembly": sub.get("name"),
+                "link": sub.get("link_name"),
+                "parents": parents,
+                "joints": [x["joint"] for x in incoming_boundary],
+                "message": (
+                    f"{sub.get('name')} has {len(parents)} external parent "
+                    "candidates after collapse"),
+            })
+
+    return {
+        "ok": not any(i["severity"] == "error" for i in issues),
+        "issue_count": len(issues),
+        "issues": issues,
     }
 
 

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -237,6 +237,12 @@ def test_validate_collapsed_tree_reports_multiple_parents_and_cycles():
     payload = _validate_collapsed_tree("base", links, joints, [])
     codes = {i["code"] for i in payload["issues"]}
     assert {"multiple_parents", "cycle"} <= codes
+    multi = next(i for i in payload["issues"]
+                 if i["code"] == "multiple_parents")
+    assert multi["parents"] == ["alt", "base"]
+    assert multi["source_joints"] == ["j1", "j2"]
+    cycle = next(i for i in payload["issues"] if i["code"] == "cycle")
+    assert cycle["links"] == ["base", "arm", "base"]
     assert payload["ok"] is False
 
 
@@ -259,6 +265,7 @@ def test_validate_collapsed_tree_reports_disconnected_members():
     issue = payload["issues"][0]
     assert issue["code"] == "disconnected_members"
     assert issue["subassembly"] == "sub-1"
+    assert issue["components"] == [["sub_1__a"], ["sub_1__b"]]
 
 
 def test_subassemblies_payload_reports_expansion_state():

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -222,6 +222,45 @@ def test_collapse_preview_keeps_expanded_override():
     ]
 
 
+def test_validate_collapsed_tree_reports_multiple_parents_and_cycles():
+    from sw2robot.editor.webserver import _validate_collapsed_tree
+
+    links = [{"link_name": n} for n in ("base", "alt", "arm")]
+    joints = [
+        {"name": "base__arm", "parent": "base", "child": "arm",
+         "type": "fixed", "source_name": "j1"},
+        {"name": "alt__arm", "parent": "alt", "child": "arm",
+         "type": "fixed", "source_name": "j2"},
+        {"name": "arm__base", "parent": "arm", "child": "base",
+         "type": "fixed", "source_name": "j3"},
+    ]
+    payload = _validate_collapsed_tree("base", links, joints, [])
+    codes = {i["code"] for i in payload["issues"]}
+    assert {"multiple_parents", "cycle"} <= codes
+    assert payload["ok"] is False
+
+
+def test_validate_collapsed_tree_reports_disconnected_members():
+    from sw2robot.editor.webserver import _validate_collapsed_tree
+
+    collapsed = [{
+        "name": "sub-1",
+        "link_name": "sub_1",
+        "member_links": ["sub_1__a", "sub_1__b"],
+        "internal_joints": [],
+        "boundary_joints": [],
+    }]
+    payload = _validate_collapsed_tree(
+        "base",
+        [{"link_name": "base"}, {"link_name": "sub_1"}],
+        [{"name": "base__sub_1", "parent": "base", "child": "sub_1",
+          "type": "fixed"}],
+        collapsed)
+    issue = payload["issues"][0]
+    assert issue["code"] == "disconnected_members"
+    assert issue["subassembly"] == "sub-1"
+
+
 def test_subassemblies_payload_reports_expansion_state():
     from sw2robot.editor.webserver import _subassemblies_payload
 


### PR DESCRIPTION
This is a stacked PR on top of the sub-assembly tree view mode PR.

GitHub shows the full diff against upstream/main until the previous PR is merged.

Reviewable diff:
https://github.com/poyotamu000/solidworks_urdf_exporter2/compare/clean/subassembly-tree-view-mode...clean/subassembly-collapse-validation


## Summary
- Add validation for collapsed sub-assembly preview trees
- Detect structural issues such as multiple parents, cycles, disconnected member groups, and ambiguous boundary parents
- Show validation warnings in the collapse preview and right-side sub-assembly tree
- Include candidate link/joint details in validation messages to make debugging easier




## Background

While testing the subassembly-based tree preview with the `kleiyn` 

> Yoneda, Keita, et al. "KLEIYN: A Quadruped Robot with an Active Waist for Both Locomotion and Wall Climbing." 2025 IEEE/RSJ International Conference on Intelligent Robots and Systems (IROS). IEEE, 2025.

 CAD model, I found that the collapsed subassembly tree does not always preserve the parent-child relationships represented by the extracted joints.

For example, the generated `kleiyn.joints.yaml` contains the following joint:

```yaml
- parent: back_body2_1__ak70_10_2
  child: BR_scapula_link_1
```

This indicates that a component belonging to `back_body` should be the parent of `BR_scapula_link_1`.

However, in the collapsed subassembly tree preview, `back_body` does not appear as the parent of `BR_scapula_link_1`, as shown in the attached image.

I also found cases where joints between members of two subassemblies imply conflicting parent-child directions. For example:

```yaml
- parent: BR_thigh_link_1__FCLHDF_D6_L27_T2_H12_MC3_LFC6_1
  child: BR_calf_link_1__c_606HZZ_2

- parent: BR_calf_link_1__foot_avoid_singular_mirror_1
  child: BR_thigh_link_1__HK0609_2
```

After collapsing the component-level graph into subassemblies, these joints imply both:

```text
thigh -> calf
```

and:

```text
calf -> thigh
```

This makes the parent-child relationship between the collapsed subassemblies ambiguous and may introduce a directed cycle.

Similar problems can occur when:

* multiple component-level joints produce multiple possible parents for one collapsed subassembly,
* members of a subassembly are not connected as a single group, or
* multiple external joints imply conflicting parent candidates.

These cases are difficult to identify from the collapsed preview alone and may cause problems in later processing. Therefore, the preview tree should validate the collapsed graph and explicitly report ambiguous or unsafe structures before they affect URDF export.



## Notes

This PR only reports ambiguous or unsafe collapse cases.

It does not yet resolve them automatically or change URDF export behavior.

[kleiyn-demo (3).webm](https://github.com/user-attachments/assets/8ab7b658-8162-4dcf-b686-25e46bb20dd8)
