### PR TITLE
Add cycle break controls for collapsed subassembly previews

### DIFF
--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -1084,6 +1084,15 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
                               ja: a => `接続先parentを保存中: ${a.name} → ${a.parent} ...` },
     'subasm.parentSetFail': { en: a => `attach parent failed: ${a.e}`,
                               ja: a => `接続先parentの保存に失敗: ${a.e}` },
+    'subasm.originLinkChoicesTitle': { en: 'Sub-assembly origin links',
+                                      ja: 'サブアセンブリ原点link' },
+    'subasm.originLinkAuto': { en: 'auto', ja: 'auto' },
+    'subasm.originLinkSetOk': { en: a => `${a.name}: origin link ${a.originLink} ✓`,
+                                ja: a => `${a.name}: origin link ${a.originLink} ✓` },
+    'subasm.originLinkSetting': { en: a => `saving origin link: ${a.name} → ${a.originLink} ...`,
+                                  ja: a => `サブアセンブリ原点linkを保存中: ${a.name} → ${a.originLink} ...` },
+    'subasm.originLinkSetFail': { en: a => `origin link failed: ${a.e}`,
+                                  ja: a => `サブアセンブリ原点linkの保存に失敗: ${a.e}` },
     'subasm.backSubasm': { en: '← sub-assemblies', ja: '← サブアセンブリ' },
     'subasm.stateExpanded': { en: 'expanded', ja: '展開' },
     'subasm.stateKept': { en: 'kept as one link', ja: '1リンク保持' },
@@ -2898,6 +2907,79 @@ function bindSubassemblyParentChoices(root, ov) {
   });
 }
 
+function originLinkChoicesHtml(groupChoices) {
+  const choices = (groupChoices || []).filter(c =>
+    (c.groups || []).length > 1 || c.selected_origin_link);
+  if (!choices.length) { return ''; }
+  const rows = choices.map(c => {
+    const selected = c.selected_origin_link || '';
+    const opts = [`<option value=""${selected ? '' : ' selected'}>` +
+      `${t('subasm.originLinkAuto')}</option>`].concat((c.groups || []).map((g, i) => {
+      const label = `group ${i + 1} (${g.size || (g.links || []).length})`;
+      const originLink = g.origin_link || (g.links || [])[0] || '';
+      return `<option value="${htmlEsc(originLink)}"` +
+        `${selected === originLink ? ' selected' : ''}>` +
+        `${htmlEsc(label)} origin link: ${htmlEsc(originLink)}</option>`;
+    })).join('');
+    const groups = (c.groups || []).map((g, i) => {
+      const links = (g.links || []).slice(0, 4).map(htmlEsc).join(', ');
+      const more = (g.links || []).length > 4
+        ? `, +${(g.links || []).length - 4} more` : '';
+      return `<div style="color:#6b7480">group ${i + 1} links: ${links}${more}</div>`;
+    }).join('');
+    return `<div style="display:grid;grid-template-columns:minmax(110px,1fr) ` +
+      `minmax(120px,1.4fr);gap:6px;align-items:start;margin-top:5px">` +
+      `<div><div style="color:#cfe3ff">${htmlEsc(c.subassembly)}</div>` +
+      `<div style="color:#6b7480">${htmlEsc(c.link_name)}</div></div>` +
+      `<div><select class="subasm-origin-link-choice" ` +
+      `data-name="${htmlEsc(c.subassembly)}" data-prev="${htmlEsc(selected)}">` +
+      opts + `</select>${groups}</div></div>`;
+  }).join('');
+  return `<div style="border:1px solid #4d4536;background:#24231d;` +
+    `border-radius:4px;padding:6px 8px;margin:8px 0;font-size:11px">` +
+    `<div style="color:#d6c18c">${t('subasm.originLinkChoicesTitle')}</div>` +
+    rows + `</div>`;
+}
+
+async function setSubassemblyOriginLinkChoice(name, originLink, ov) {
+  const label = originLink || t('subasm.originLinkAuto');
+  op('subassembly_origin_link', { name, origin_link: originLink });
+  log(t('subasm.originLinkSetting', { name, originLink: label }));
+  try {
+    const resp = await fetch('/api/set_subassembly_origin_link', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, origin_link: originLink }) });
+    const r = await resp.json();
+    if (!resp.ok || r.error) { throw new Error(r.error ?? resp.status); }
+    log(t('subasm.originLinkSetOk', { name, originLink: label }), 'ok');
+    refreshHistory();
+    if (ov) {
+      await openSubassemblyPreview(ov);
+    }
+    if (viewer.robot && treeViewMode === 'subassembly') {
+      buildJointRows(viewer.robot);
+    }
+  } catch (e) {
+    log(t('subasm.originLinkSetFail', { e: e.message ?? e }), 'err');
+    if (ov) {
+      await openSubassemblyPreview(ov);
+    }
+  }
+}
+
+function bindSubassemblyOriginLinkChoices(root, ov) {
+  root.querySelectorAll('.subasm-origin-link-choice').forEach(sel => {
+    sel.addEventListener('change', () => {
+      const name = sel.dataset.name;
+      const originLink = sel.value;
+      root.querySelectorAll('.subasm-origin-link-choice')
+        .forEach(x => { x.disabled = true; });
+      setSubassemblyOriginLinkChoice(name, originLink, ov);
+    });
+  });
+}
+
 function pathBase(p) {
   const s = String(p ?? '');
   return s.split(/[\\/]/).pop() || s;
@@ -3049,7 +3131,8 @@ async function openSubassemblyPreview(ov) {
         pl: pc.links ?? 0, pj: pc.joints ?? 0,
       }) + '</div>' +
       validationIssuesHtml(r.validation) +
-      parentChoicesHtml(r.parent_choices);
+      parentChoicesHtml(r.parent_choices) +
+      originLinkChoicesHtml(r.group_choices);
     const rows = r.collapsed_subassemblies || [];
     if (!rows.length) {
       html += '<div style="color:#8a93a3">' + t('subasm.previewNone') + '</div>';
@@ -3091,6 +3174,7 @@ async function openSubassemblyPreview(ov) {
     }
     card.innerHTML = html;
     bindSubassemblyParentChoices(card, owned);
+    bindSubassemblyOriginLinkChoices(card, owned);
     const bar = document.createElement('div');
     bar.style.cssText = 'display:flex;gap:8px;margin-top:10px';
     const back = document.createElement('button');
@@ -3466,6 +3550,13 @@ async function renderSubassemblyTreeRows(robot, movable) {
       choices.innerHTML = choicesHtml;
       jointsEl.appendChild(choices);
       bindSubassemblyParentChoices(choices);
+    }
+    const groupChoices = originLinkChoicesHtml(r.group_choices);
+    if (groupChoices) {
+      const groups = document.createElement('div');
+      groups.innerHTML = groupChoices;
+      jointsEl.appendChild(groups);
+      bindSubassemblyOriginLinkChoices(groups);
     }
     const hint = document.createElement('div');
     hint.className = 'joint';

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -2850,7 +2850,7 @@ function parentChoicesHtml(parentChoices) {
       `<div><div style="color:#cfe3ff">${htmlEsc(c.subassembly)}</div>` +
       `<div style="color:#6b7480">${htmlEsc(c.link_name)}</div></div>` +
       `<div><select class="subasm-parent-choice" ` +
-      `data-name="${htmlEsc(c.subassembly)}" data-prev="${htmlEsc(selected)}">` +
+      `data-name="${htmlEsc(c.subassembly)}">` +
       opts + `</select>${joints}</div></div>`;
   }).join('');
   return `<div style="border:1px solid #3c4654;background:#1f242c;` +

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -2909,10 +2909,15 @@ function bindSubassemblyParentChoices(root, ov) {
 
 function originLinkChoicesHtml(groupChoices) {
   const choices = (groupChoices || []).filter(c =>
-    (c.groups || []).length > 1 || c.selected_origin_link);
+    (c.groups || []).length > 1 || c.selected_origin_link ||
+    c.stale_origin_link);
   if (!choices.length) { return ''; }
   const rows = choices.map(c => {
     const selected = c.selected_origin_link || '';
+    const stale = c.stale_origin_link
+      ? `<div style="color:#d68c8c">stale saved link: ` +
+        `${htmlEsc(c.stale_origin_link)}</div>`
+      : '';
     const opts = [`<option value=""${selected ? '' : ' selected'}>` +
       `${t('subasm.originLinkAuto')}</option>`].concat((c.groups || []).map((g, i) => {
       const label = `group ${i + 1} (${g.size || (g.links || []).length})`;
@@ -2932,8 +2937,8 @@ function originLinkChoicesHtml(groupChoices) {
       `<div><div style="color:#cfe3ff">${htmlEsc(c.subassembly)}</div>` +
       `<div style="color:#6b7480">${htmlEsc(c.link_name)}</div></div>` +
       `<div><select class="subasm-origin-link-choice" ` +
-      `data-name="${htmlEsc(c.subassembly)}" data-prev="${htmlEsc(selected)}">` +
-      opts + `</select>${groups}</div></div>`;
+      `data-name="${htmlEsc(c.subassembly)}">` +
+      opts + `</select>${stale}${groups}</div></div>`;
   }).join('');
   return `<div style="border:1px solid #4d4536;background:#24231d;` +
     `border-radius:4px;padding:6px 8px;margin:8px 0;font-size:11px">` +
@@ -2964,6 +2969,9 @@ async function setSubassemblyOriginLinkChoice(name, originLink, ov) {
     log(t('subasm.originLinkSetFail', { e: e.message ?? e }), 'err');
     if (ov) {
       await openSubassemblyPreview(ov);
+    } else {
+      document.querySelectorAll('.subasm-origin-link-choice')
+        .forEach(x => { x.disabled = false; });
     }
   }
 }

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -1075,6 +1075,15 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     'subasm.thMembers': { en: 'members', ja: '構成link' },
     'subasm.thDropped': { en: 'internal joints', ja: '内部joint' },
     'subasm.collapsedTag': { en: 'collapsed', ja: '畳み込み' },
+    'subasm.parentChoicesTitle': { en: 'Attach parent choices',
+                                   ja: '接続先parent候補' },
+    'subasm.parentAuto': { en: 'auto', ja: 'auto' },
+    'subasm.parentSetOk': { en: a => `${a.name}: attach parent ${a.parent} ✓`,
+                            ja: a => `${a.name}: attach parent ${a.parent} ✓` },
+    'subasm.parentSetting': { en: a => `saving attach parent: ${a.name} → ${a.parent} ...`,
+                              ja: a => `接続先parentを保存中: ${a.name} → ${a.parent} ...` },
+    'subasm.parentSetFail': { en: a => `attach parent failed: ${a.e}`,
+                              ja: a => `接続先parentの保存に失敗: ${a.e}` },
     'subasm.backSubasm': { en: '← sub-assemblies', ja: '← サブアセンブリ' },
     'subasm.stateExpanded': { en: 'expanded', ja: '展開' },
     'subasm.stateKept': { en: 'kept as one link', ja: '1リンク保持' },
@@ -2820,6 +2829,75 @@ function validationIssuesHtml(validation) {
     rows + more + `</div>`;
 }
 
+function parentChoicesHtml(parentChoices) {
+  const choices = (parentChoices || []).filter(c =>
+    (c.parents || []).length > 1 || c.selected_parent);
+  if (!choices.length) { return ''; }
+  const rows = choices.map(c => {
+    const selected = c.selected_parent || '';
+    const opts = [`<option value=""${selected ? '' : ' selected'}>` +
+      `${t('subasm.parentAuto')}</option>`].concat((c.parents || []).map(p =>
+      `<option value="${htmlEsc(p.link)}"${selected === p.link ? ' selected' : ''}>` +
+      `${htmlEsc(p.link)}</option>`)).join('');
+    const joints = (c.parents || []).map(p => {
+      const js = (p.joints || []).slice(0, 3).map(htmlEsc).join(', ');
+      const more = (p.joints || []).length > 3
+        ? `, +${(p.joints || []).length - 3} more` : '';
+      return `<div style="color:#6b7480">${htmlEsc(p.link)}: ${js}${more}</div>`;
+    }).join('');
+    return `<div style="display:grid;grid-template-columns:minmax(110px,1fr) ` +
+      `minmax(120px,1.4fr);gap:6px;align-items:start;margin-top:5px">` +
+      `<div><div style="color:#cfe3ff">${htmlEsc(c.subassembly)}</div>` +
+      `<div style="color:#6b7480">${htmlEsc(c.link_name)}</div></div>` +
+      `<div><select class="subasm-parent-choice" ` +
+      `data-name="${htmlEsc(c.subassembly)}" data-prev="${htmlEsc(selected)}">` +
+      opts + `</select>${joints}</div></div>`;
+  }).join('');
+  return `<div style="border:1px solid #3c4654;background:#1f242c;` +
+    `border-radius:4px;padding:6px 8px;margin:8px 0;font-size:11px">` +
+    `<div style="color:#9fb7de">${t('subasm.parentChoicesTitle')}</div>` +
+    rows + `</div>`;
+}
+
+async function setSubassemblyParentChoice(name, parent, ov) {
+  const label = parent || t('subasm.parentAuto');
+  op('subassembly_parent', { name, parent });
+  log(t('subasm.parentSetting', { name, parent: label }));
+  try {
+    const resp = await fetch('/api/set_subassembly_parent', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, parent }) });
+    const r = await resp.json();
+    if (!resp.ok || r.error) { throw new Error(r.error ?? resp.status); }
+    log(t('subasm.parentSetOk', { name, parent: label }), 'ok');
+    refreshHistory();
+    if (ov) {
+      await openSubassemblyPreview(ov);
+    }
+    if (viewer.robot && treeViewMode === 'subassembly') {
+      buildJointRows(viewer.robot);
+    }
+  } catch (e) {
+    log(t('subasm.parentSetFail', { e: e.message ?? e }), 'err');
+    if (ov) {
+      await openSubassemblyPreview(ov);
+    }
+  }
+}
+
+function bindSubassemblyParentChoices(root, ov) {
+  root.querySelectorAll('.subasm-parent-choice').forEach(sel => {
+    sel.addEventListener('change', () => {
+      const name = sel.dataset.name;
+      const parent = sel.value;
+      root.querySelectorAll('.subasm-parent-choice')
+        .forEach(x => { x.disabled = true; });
+      setSubassemblyParentChoice(name, parent, ov);
+    });
+  });
+}
+
 function pathBase(p) {
   const s = String(p ?? '');
   return s.split(/[\\/]/).pop() || s;
@@ -2970,7 +3048,8 @@ async function openSubassemblyPreview(ov) {
         cl: cc.links ?? 0, cj: cc.joints ?? 0,
         pl: pc.links ?? 0, pj: pc.joints ?? 0,
       }) + '</div>' +
-      validationIssuesHtml(r.validation);
+      validationIssuesHtml(r.validation) +
+      parentChoicesHtml(r.parent_choices);
     const rows = r.collapsed_subassemblies || [];
     if (!rows.length) {
       html += '<div style="color:#8a93a3">' + t('subasm.previewNone') + '</div>';
@@ -3011,6 +3090,7 @@ async function openSubassemblyPreview(ov) {
       html += '</tbody></table>';
     }
     card.innerHTML = html;
+    bindSubassemblyParentChoices(card, owned);
     const bar = document.createElement('div');
     bar.style.cssText = 'display:flex;gap:8px;margin-top:10px';
     const back = document.createElement('button');
@@ -3379,6 +3459,13 @@ async function renderSubassemblyTreeRows(robot, movable) {
       const warn = document.createElement('div');
       warn.innerHTML = validationHtml;
       jointsEl.appendChild(warn);
+    }
+    const choicesHtml = parentChoicesHtml(r.parent_choices);
+    if (choicesHtml) {
+      const choices = document.createElement('div');
+      choices.innerHTML = choicesHtml;
+      jointsEl.appendChild(choices);
+      bindSubassemblyParentChoices(choices);
     }
     const hint = document.createElement('div');
     hint.className = 'joint';

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -1096,8 +1096,9 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     'subasm.cycleBreakChoicesTitle': { en: 'Cycle break joints',
                                        ja: 'cycle解消joint' },
     'subasm.cycleBreakAuto': { en: 'auto', ja: 'auto' },
-    'subasm.cycleBreakResolved': { en: 'resolved by selected drop',
-                                   ja: '選択したdropで解消済み' },
+    'subasm.cycleBreakStale': {
+      en: 'saved drop is not on an active cycle; reset to auto if no longer needed',
+      ja: '保存済みdropは現在のcycle候補にありません。不要ならautoに戻してください' },
     'subasm.cycleBreakSetOk': { en: a => `cycle break ${a.sourceJoint} ✓`,
                                 ja: a => `cycle break ${a.sourceJoint} ✓` },
     'subasm.cycleBreakSetting': { en: a => `saving cycle break: ${a.sourceJoint} ...`,
@@ -3005,6 +3006,7 @@ function cycleBreakChoicesHtml(cycleChoices) {
   if (!choices.length) { return ''; }
   const rows = choices.map((c, i) => {
     const selected = c.selected_source_joint || '';
+    const stale = !!c.stale;
     const seen = new Set();
     const opts = [`<option value=""${selected ? '' : ' selected'}>` +
       `${t('subasm.cycleBreakAuto')}</option>`].concat((c.candidates || [])
@@ -3021,10 +3023,10 @@ function cycleBreakChoicesHtml(cycleChoices) {
           `${selected === source ? ' selected' : ''}>` +
           `drop: ${htmlEsc(edge)}</option>`;
       })).join('');
-    const path = (c.links || []).length
-      ? `<div style="color:#6b7480">links: ` +
-        `${(c.links || []).map(htmlEsc).join(' → ')}</div>`
-      : `<div style="color:#6b7480">${t('subasm.cycleBreakResolved')}</div>`;
+    const path = stale
+      ? `<div style="color:#d6c18c">${t('subasm.cycleBreakStale')}</div>`
+      : `<div style="color:#6b7480">links: ` +
+        `${(c.links || []).map(htmlEsc).join(' → ')}</div>`;
     const joints = (c.candidates || []).map(j => {
       const source = j.source_joint || j.joint || '';
       const edge = j.parent && j.child ? `${j.parent} → ${j.child}` : '';
@@ -3033,7 +3035,7 @@ function cycleBreakChoicesHtml(cycleChoices) {
     }).join('');
     return `<div style="display:grid;grid-template-columns:minmax(80px,0.6fr) ` +
       `minmax(150px,1.8fr);gap:6px;align-items:start;margin-top:5px">` +
-      `<div><div style="color:#cfe3ff">cycle ${i + 1}</div>` +
+      `<div><div style="color:#cfe3ff">${stale ? 'saved drop' : `cycle ${i + 1}`}</div>` +
       path + `</div>` +
       `<div><select class="subasm-cycle-break-choice" ` +
       `data-prev="${htmlEsc(selected)}">` + opts +
@@ -3068,6 +3070,9 @@ async function setSubassemblyCycleBreakChoice(sourceJoint, previousSourceJoint, 
     refreshHistory();
     if (ov) {
       await openSubassemblyPreview(ov);
+    } else {
+      document.querySelectorAll('.subasm-cycle-break-choice')
+        .forEach(x => { x.disabled = false; });
     }
     if (viewer.robot && treeViewMode === 'subassembly') {
       buildJointRows(viewer.robot);
@@ -3076,6 +3081,9 @@ async function setSubassemblyCycleBreakChoice(sourceJoint, previousSourceJoint, 
     log(t('subasm.cycleBreakSetFail', { e: e.message ?? e }), 'err');
     if (ov) {
       await openSubassemblyPreview(ov);
+    } else {
+      document.querySelectorAll('.subasm-cycle-break-choice')
+        .forEach(x => { x.disabled = false; });
     }
   }
 }

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -1093,6 +1093,17 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
                                   ja: a => `サブアセンブリ原点linkを保存中: ${a.name} → ${a.originLink} ...` },
     'subasm.originLinkSetFail': { en: a => `origin link failed: ${a.e}`,
                                   ja: a => `サブアセンブリ原点linkの保存に失敗: ${a.e}` },
+    'subasm.cycleBreakChoicesTitle': { en: 'Cycle break joints',
+                                       ja: 'cycle解消joint' },
+    'subasm.cycleBreakAuto': { en: 'auto', ja: 'auto' },
+    'subasm.cycleBreakResolved': { en: 'resolved by selected drop',
+                                   ja: '選択したdropで解消済み' },
+    'subasm.cycleBreakSetOk': { en: a => `cycle break ${a.sourceJoint} ✓`,
+                                ja: a => `cycle break ${a.sourceJoint} ✓` },
+    'subasm.cycleBreakSetting': { en: a => `saving cycle break: ${a.sourceJoint} ...`,
+                                  ja: a => `cycle解消jointを保存中: ${a.sourceJoint} ...` },
+    'subasm.cycleBreakSetFail': { en: a => `cycle break failed: ${a.e}`,
+                                  ja: a => `cycle解消jointの保存に失敗: ${a.e}` },
     'subasm.backSubasm': { en: '← sub-assemblies', ja: '← サブアセンブリ' },
     'subasm.stateExpanded': { en: 'expanded', ja: '展開' },
     'subasm.stateKept': { en: 'kept as one link', ja: '1リンク保持' },
@@ -2988,6 +2999,99 @@ function bindSubassemblyOriginLinkChoices(root, ov) {
   });
 }
 
+function cycleBreakChoicesHtml(cycleChoices) {
+  const choices = (cycleChoices || []).filter(c =>
+    (c.candidates || []).length || c.selected_source_joint);
+  if (!choices.length) { return ''; }
+  const rows = choices.map((c, i) => {
+    const selected = c.selected_source_joint || '';
+    const seen = new Set();
+    const opts = [`<option value=""${selected ? '' : ' selected'}>` +
+      `${t('subasm.cycleBreakAuto')}</option>`].concat((c.candidates || [])
+      .filter(j => {
+        const source = j.source_joint || j.joint || '';
+        if (!source || seen.has(source)) { return false; }
+        seen.add(source);
+        return true;
+      }).map(j => {
+        const source = j.source_joint || j.joint || '';
+        const edge = j.parent && j.child
+          ? `${j.parent} → ${j.child}` : source;
+        return `<option value="${htmlEsc(source)}"` +
+          `${selected === source ? ' selected' : ''}>` +
+          `drop: ${htmlEsc(edge)}</option>`;
+      })).join('');
+    const path = (c.links || []).length
+      ? `<div style="color:#6b7480">links: ` +
+        `${(c.links || []).map(htmlEsc).join(' → ')}</div>`
+      : `<div style="color:#6b7480">${t('subasm.cycleBreakResolved')}</div>`;
+    const joints = (c.candidates || []).map(j => {
+      const source = j.source_joint || j.joint || '';
+      const edge = j.parent && j.child ? `${j.parent} → ${j.child}` : '';
+      return `<div style="color:#6b7480">${htmlEsc(source)}` +
+        `${edge ? `: ${htmlEsc(edge)}` : ''}</div>`;
+    }).join('');
+    return `<div style="display:grid;grid-template-columns:minmax(80px,0.6fr) ` +
+      `minmax(150px,1.8fr);gap:6px;align-items:start;margin-top:5px">` +
+      `<div><div style="color:#cfe3ff">cycle ${i + 1}</div>` +
+      path + `</div>` +
+      `<div><select class="subasm-cycle-break-choice" ` +
+      `data-prev="${htmlEsc(selected)}">` + opts +
+      `</select>${joints}</div></div>`;
+  }).join('');
+  return `<div style="border:1px solid #5a3940;background:#271e22;` +
+    `border-radius:4px;padding:6px 8px;margin:8px 0;font-size:11px">` +
+    `<div style="color:#e2a6b1">${t('subasm.cycleBreakChoicesTitle')}</div>` +
+    rows + `</div>`;
+}
+
+async function setSubassemblyCycleBreakChoice(sourceJoint, previousSourceJoint, ov) {
+  const label = sourceJoint || t('subasm.cycleBreakAuto');
+  const target = sourceJoint || previousSourceJoint;
+  op('subassembly_cycle_break', {
+    source_joint: sourceJoint,
+    previous_source_joint: previousSourceJoint,
+  });
+  log(t('subasm.cycleBreakSetting', { sourceJoint: label }));
+  try {
+    const resp = await fetch('/api/set_subassembly_cycle_break', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        source_joint: sourceJoint,
+        previous_source_joint: previousSourceJoint,
+        drop: !!sourceJoint,
+      }) });
+    const r = await resp.json();
+    if (!resp.ok || r.error) { throw new Error(r.error ?? resp.status); }
+    log(t('subasm.cycleBreakSetOk', { sourceJoint: target || label }), 'ok');
+    refreshHistory();
+    if (ov) {
+      await openSubassemblyPreview(ov);
+    }
+    if (viewer.robot && treeViewMode === 'subassembly') {
+      buildJointRows(viewer.robot);
+    }
+  } catch (e) {
+    log(t('subasm.cycleBreakSetFail', { e: e.message ?? e }), 'err');
+    if (ov) {
+      await openSubassemblyPreview(ov);
+    }
+  }
+}
+
+function bindSubassemblyCycleBreakChoices(root, ov) {
+  root.querySelectorAll('.subasm-cycle-break-choice').forEach(sel => {
+    sel.addEventListener('change', () => {
+      const sourceJoint = sel.value;
+      const previousSourceJoint = sel.dataset.prev || '';
+      root.querySelectorAll('.subasm-cycle-break-choice')
+        .forEach(x => { x.disabled = true; });
+      setSubassemblyCycleBreakChoice(sourceJoint, previousSourceJoint, ov);
+    });
+  });
+}
+
 function pathBase(p) {
   const s = String(p ?? '');
   return s.split(/[\\/]/).pop() || s;
@@ -3140,7 +3244,8 @@ async function openSubassemblyPreview(ov) {
       }) + '</div>' +
       validationIssuesHtml(r.validation) +
       parentChoicesHtml(r.parent_choices) +
-      originLinkChoicesHtml(r.group_choices);
+      originLinkChoicesHtml(r.group_choices) +
+      cycleBreakChoicesHtml(r.cycle_break_choices);
     const rows = r.collapsed_subassemblies || [];
     if (!rows.length) {
       html += '<div style="color:#8a93a3">' + t('subasm.previewNone') + '</div>';
@@ -3183,6 +3288,7 @@ async function openSubassemblyPreview(ov) {
     card.innerHTML = html;
     bindSubassemblyParentChoices(card, owned);
     bindSubassemblyOriginLinkChoices(card, owned);
+    bindSubassemblyCycleBreakChoices(card, owned);
     const bar = document.createElement('div');
     bar.style.cssText = 'display:flex;gap:8px;margin-top:10px';
     const back = document.createElement('button');
@@ -3565,6 +3671,13 @@ async function renderSubassemblyTreeRows(robot, movable) {
       groups.innerHTML = groupChoices;
       jointsEl.appendChild(groups);
       bindSubassemblyOriginLinkChoices(groups);
+    }
+    const cycleChoices = cycleBreakChoicesHtml(r.cycle_break_choices);
+    if (cycleChoices) {
+      const cycles = document.createElement('div');
+      cycles.innerHTML = cycleChoices;
+      jointsEl.appendChild(cycles);
+      bindSubassemblyCycleBreakChoices(cycles);
     }
     const hint = document.createElement('div');
     hint.className = 'joint';

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1261,7 +1261,7 @@ def _collapse_preview_payload(graph, yml_txt=""):
             "member_components": sub["member_components"],
             "internal_joints": sub["internal_joints"],
             "boundary_joints": sub["boundary_joints"],
-            "selected_parent": parent_overrides.get(row["name"], ""),
+            "selected_parent": "",
         }
         collapsed.append(info)
         for link in sub["member_links"]:
@@ -1269,6 +1269,13 @@ def _collapse_preview_payload(graph, yml_txt=""):
 
     parent_choices = _collapse_parent_choices(
         collapsed, collapse_link, parent_overrides)
+    selected_parent_by_subassembly = {
+        c.get("subassembly"): c.get("selected_parent", "")
+        for c in parent_choices
+    }
+    for sub in collapsed:
+        sub["selected_parent"] = selected_parent_by_subassembly.get(
+            sub["name"], "")
 
     links = []
     inserted = set()
@@ -1348,7 +1355,8 @@ def _collapse_parent_choices(collapsed, collapse_link, parent_overrides):
             child = collapse_link.get(j["child"], j["child"])
             if child == link_name and parent != child:
                 by_parent.setdefault(parent, []).append(j.get("name"))
-        selected = parent_overrides.get(sub.get("name"), "")
+        raw_selected = parent_overrides.get(sub.get("name"), "")
+        selected = raw_selected if raw_selected in by_parent else ""
         if len(by_parent) <= 1 and not selected:
             continue
         choices.append({

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1167,6 +1167,34 @@ def _set_subassembly_parent_override_yaml(txt, graph, name, parent):
     return _remove_yaml_map_entry(txt, "subassembly_parent_overrides", name)
 
 
+def _subassembly_origin_links(yml_txt):
+    """Preview-only representative member links for collapsed sub-assemblies."""
+    import yaml as _yaml
+
+    try:
+        cfg = _yaml.safe_load(yml_txt) or {}
+        if not isinstance(cfg, dict):
+            return {}
+    except Exception:
+        return {}
+    raw = cfg.get("subassembly_origin_links") or {}
+    if not isinstance(raw, dict):
+        return {}
+    return {str(k): str(v) for k, v in raw.items() if v is not None}
+
+
+def _set_subassembly_origin_link_yaml(txt, graph, name, origin_link):
+    """Set/reset one preview-only collapsed sub-assembly origin link."""
+    names = _subassembly_names(graph)
+    if name not in names:
+        raise ValueError(f"no CAD sub-assembly '{name}'")
+    if origin_link:
+        return _upsert_yaml_map(
+            txt, "subassembly_origin_links", name,
+            _yaml_scalar(origin_link))
+    return _remove_yaml_map_entry(txt, "subassembly_origin_links", name)
+
+
 def _canonical_tree_payload(graph, yml_txt=""):
     """Fully-expanded tree plus CAD sub-assembly membership.
 
@@ -1243,6 +1271,7 @@ def _collapse_preview_payload(graph, yml_txt=""):
     canonical = _canonical_tree_payload(graph, yml_txt)
     states = _subassemblies_payload(graph, yml_txt)
     parent_overrides = _subassembly_parent_overrides(yml_txt)
+    origin_links = _subassembly_origin_links(yml_txt)
     by_sub = {s["name"]: s for s in canonical["subassemblies"]}
     collapse_link = {}
     collapsed = []
@@ -1262,6 +1291,7 @@ def _collapse_preview_payload(graph, yml_txt=""):
             "internal_joints": sub["internal_joints"],
             "boundary_joints": sub["boundary_joints"],
             "selected_parent": "",
+            "selected_origin_link": origin_links.get(row["name"], ""),
         }
         collapsed.append(info)
         for link in sub["member_links"]:
@@ -1276,6 +1306,7 @@ def _collapse_preview_payload(graph, yml_txt=""):
     for sub in collapsed:
         sub["selected_parent"] = selected_parent_by_subassembly.get(
             sub["name"], "")
+    group_choices = _collapse_group_choices(collapsed, origin_links)
 
     links = []
     inserted = set()
@@ -1327,6 +1358,7 @@ def _collapse_preview_payload(graph, yml_txt=""):
         "dropped_internal_joints": dropped,
         "collapsed_subassemblies": collapsed,
         "parent_choices": parent_choices,
+        "group_choices": group_choices,
         "canonical_counts": {
             "links": len(canonical["links"]),
             "joints": len(canonical["joints"]),
@@ -1364,6 +1396,56 @@ def _collapse_parent_choices(collapsed, collapse_link, parent_overrides):
             "parents": [
                 {"link": p, "joints": sorted(x for x in js if x)}
                 for p, js in sorted(by_parent.items())
+            ],
+        })
+    return choices
+
+
+def _subassembly_member_groups(sub):
+    """Connected components of a collapsed sub-assembly's expanded members."""
+    members = list(sub.get("member_links") or [])
+    if not members:
+        return []
+    member_set = set(members)
+    internal_adj = {m: set() for m in members}
+    for j in sub.get("internal_joints") or []:
+        p, c = j.get("parent"), j.get("child")
+        if p in member_set and c in member_set:
+            internal_adj[p].add(c)
+            internal_adj[c].add(p)
+    comps = []
+    todo = set(members)
+    while todo:
+        start = todo.pop()
+        comp = [start]
+        q = [start]
+        while q:
+            cur = q.pop()
+            for nxt in internal_adj.get(cur, ()):
+                if nxt in todo:
+                    todo.remove(nxt)
+                    comp.append(nxt)
+                    q.append(nxt)
+        comps.append(sorted(comp))
+    comps.sort(key=lambda x: (x[0] if x else "", len(x)))
+    return comps
+
+
+def _collapse_group_choices(collapsed, origin_links):
+    """List origin link candidates for disconnected collapsed member groups."""
+    choices = []
+    for sub in collapsed:
+        groups = _subassembly_member_groups(sub)
+        selected = origin_links.get(sub.get("name"), "")
+        if len(groups) <= 1 and not selected:
+            continue
+        choices.append({
+            "subassembly": sub.get("name"),
+            "link_name": sub.get("link_name"),
+            "selected_origin_link": selected,
+            "groups": [
+                {"origin_link": g[0], "links": g, "size": len(g)}
+                for g in groups
             ],
         })
     return choices
@@ -1427,35 +1509,25 @@ def _validate_collapsed_tree(base_link, links, joints, collapsed,
             dfs(root)
 
     for sub in collapsed:
-        members = list(sub.get("member_links") or [])
-        if len(members) <= 1:
+        comps = _subassembly_member_groups(sub)
+        if len(comps) <= 1:
             continue
-        member_set = set(members)
-        internal_adj = {m: set() for m in members}
-        for j in sub.get("internal_joints") or []:
-            p, c = j.get("parent"), j.get("child")
-            if p in member_set and c in member_set:
-                internal_adj[p].add(c)
-                internal_adj[c].add(p)
-        comps = []
-        todo = set(members)
-        while todo:
-            start = todo.pop()
-            comp = [start]
-            q = [start]
-            while q:
-                cur = q.pop()
-                for nxt in internal_adj.get(cur, ()):
-                    if nxt in todo:
-                        todo.remove(nxt)
-                        comp.append(nxt)
-                        q.append(nxt)
-            comps.append(sorted(comp))
-        # ``todo`` is a set, so the discovery order of the groups is not
-        # deterministic across platforms/hash seeds -- sort the groups (each
-        # already sorted internally) so the payload is stable.
-        comps.sort()
-        if len(comps) > 1:
+        selected_origin_link = sub.get("selected_origin_link")
+        if selected_origin_link and any(selected_origin_link in comp for comp in comps):
+            pass
+        elif selected_origin_link:
+            issues.append({
+                "severity": "warning",
+                "code": "invalid_origin_link",
+                "subassembly": sub.get("name"),
+                "link": sub.get("link_name"),
+                "origin_link": selected_origin_link,
+                "components": comps,
+                "message": (
+                    f"{sub.get('name')} uses stale origin link "
+                    f"{selected_origin_link}"),
+            })
+        else:
             issues.append({
                 "severity": "warning",
                 "code": "disconnected_members",
@@ -3998,6 +4070,67 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                                 "parent": parent, "preview_only": True,
                                 "rebuilt": False})
                 print(f"[sw2robot.web] set_subassembly_parent: "
+                      f"{name_in} -> {label} (preview only)")
+                return self._send_json(payload)
+            if parsed.path == "/api/set_subassembly_origin_link":
+                cls = type(self)
+                n = int(self.headers.get("Content-Length", 0))
+                body = json.loads(self.rfile.read(n) or b"{}")
+                name_in = (body.get("name") or "").strip()
+                origin_link = (body.get("origin_link") or "").strip()
+                if origin_link == "auto":
+                    origin_link = ""
+                if not cls.pkg_dir:
+                    return self._send_json({"error": "no package open"}, 400)
+                if not _cad_mode(cls.pkg_dir):
+                    return self._send_json(
+                        {"error": "sub-assembly origin links need the CAD "
+                                  "graph.json"},
+                        400)
+                if not name_in:
+                    return self._send_json({"error": "name required"}, 400)
+                from sw2robot.exporter.state import GraphState
+                graph = GraphState.load(os.path.join(cls.pkg_dir, "graph.json"))
+                name = os.path.splitext(os.path.basename(cls.urdf_rel))[0]
+                yml = os.path.join(cls.pkg_dir, name + ".joints.yaml")
+                if not os.path.exists(yml):
+                    return self._send_json(
+                        {"error": "joints.yaml not found -- re-extract once"},
+                        400)
+                with open(yml, encoding="utf-8") as f:
+                    txt = f.read()
+                try:
+                    preview = _collapse_preview_payload(graph, txt)
+                    choices = {
+                        c.get("subassembly"): c
+                        for c in preview.get("group_choices", [])
+                    }
+                    if origin_link:
+                        allowed = {
+                            link
+                            for group in choices.get(name_in, {}).get("groups", [])
+                            for link in group.get("links", [])
+                        }
+                        if origin_link not in allowed:
+                            return self._send_json(
+                                {"error": f"'{origin_link}' is not a member "
+                                          f"origin link candidate for {name_in}"},
+                                400)
+                    txt = _set_subassembly_origin_link_yaml(
+                        txt, graph, name_in, origin_link)
+                except ValueError as e:
+                    return self._send_json({"error": str(e)}, 400)
+                label = origin_link or "auto"
+                _snapshot(cls.pkg_dir, yml,
+                          f"sub-assembly origin link {name_in} -> {label}")
+                with open(yml, "w", encoding="utf-8") as f:
+                    f.write(txt)
+                payload = _collapse_preview_payload(graph, txt)
+                payload.update({"ok": True, "name": name_in,
+                                "origin_link": origin_link,
+                                "preview_only": True,
+                                "rebuilt": False})
+                print(f"[sw2robot.web] set_subassembly_origin_link: "
                       f"{name_in} -> {label} (preview only)")
                 return self._send_json(payload)
             if parsed.path == "/api/set_base":

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1199,6 +1199,37 @@ def _set_subassembly_origin_link_yaml(txt, graph, name, origin_link):
     return _remove_yaml_map_entry(txt, "subassembly_origin_links", name)
 
 
+def _subassembly_cycle_break_joints(yml_txt):
+    """Preview-only source joints dropped to break collapsed-tree cycles."""
+    import yaml as _yaml
+
+    try:
+        cfg = _yaml.safe_load(yml_txt) or {}
+        if not isinstance(cfg, dict):
+            return set()
+    except Exception:
+        return set()
+    raw = cfg.get("subassembly_cycle_break_joints") or []
+    if not isinstance(raw, list):
+        return set()
+    return {str(x) for x in raw if x is not None}
+
+
+def _set_subassembly_cycle_break_joint_yaml(
+        txt, source_joint, drop, previous_source_joint=""):
+    """Set/reset one preview-only source joint dropped for cycle breaking."""
+    source_joint = str(source_joint or "").strip()
+    previous_source_joint = str(previous_source_joint or "").strip()
+    target = source_joint or previous_source_joint
+    if not target:
+        raise ValueError("source_joint required")
+    remove = [x for x in (previous_source_joint, source_joint) if x]
+    add = [source_joint] if drop and source_joint else []
+    new_txt, _members = _set_yaml_list_block(
+        txt, "subassembly_cycle_break_joints", add=add, remove=remove)
+    return new_txt
+
+
 def _canonical_tree_payload(graph, yml_txt=""):
     """Fully-expanded tree plus CAD sub-assembly membership.
 
@@ -1276,6 +1307,7 @@ def _collapse_preview_payload(graph, yml_txt=""):
     states = _subassemblies_payload(graph, yml_txt)
     parent_overrides = _subassembly_parent_overrides(yml_txt)
     origin_links = _subassembly_origin_links(yml_txt)
+    cycle_break_joints = _subassembly_cycle_break_joints(yml_txt)
     by_sub = {s["name"]: s for s in canonical["subassemblies"]}
     collapse_link = {}
     collapsed = []
@@ -1361,6 +1393,18 @@ def _collapse_preview_payload(graph, yml_txt=""):
         joints.append(out)
 
     base = collapse_link.get(canonical["base_link"], canonical["base_link"])
+    cycle_break_choices = _collapse_cycle_break_choices(
+        base, links, joints, cycle_break_joints)
+    dropped_cycle_joints = []
+    if cycle_break_joints:
+        kept = []
+        for j in joints:
+            if _joint_source_name(j) in cycle_break_joints:
+                dropped_cycle_joints.append(j)
+            else:
+                kept.append(j)
+        joints = kept
+
     validation = _validate_collapsed_tree(base, links, joints, collapsed,
                                           collapse_link)
     return {
@@ -1370,9 +1414,11 @@ def _collapse_preview_payload(graph, yml_txt=""):
         "tree_rows": _tree_rows_payload(base, links, joints),
         "validation": validation,
         "dropped_internal_joints": dropped,
+        "dropped_cycle_joints": dropped_cycle_joints,
         "collapsed_subassemblies": collapsed,
         "parent_choices": parent_choices,
         "group_choices": group_choices,
+        "cycle_break_choices": cycle_break_choices,
         "canonical_counts": {
             "links": len(canonical["links"]),
             "joints": len(canonical["joints"]),
@@ -1472,11 +1518,109 @@ def _collapse_group_choices(collapsed, origin_links):
     return choices
 
 
+def _joint_source_name(joint):
+    return str(joint.get("source_name") or joint.get("name") or "")
+
+
+def _directed_cycle_reports(base_link, links, joints):
+    """Return directed cycles with the preview joints that form them."""
+    link_names = {l["link_name"] for l in links}
+    by_parent = {}
+    for j in joints:
+        by_parent.setdefault(j.get("parent"), []).append(j)
+    for rows in by_parent.values():
+        rows.sort(key=lambda j: (j.get("child", ""), j.get("name", "")))
+
+    reports, seen_cycles, colour = [], set(), {}
+    stack_links, stack_edges = [], []
+
+    def add_cycle(child, back_edge):
+        try:
+            i = stack_links.index(child)
+        except ValueError:
+            return
+        cycle_links = [*stack_links[i:], child]
+        cycle_edges = [*stack_edges[i:], back_edge]
+        key = tuple(_joint_source_name(j) for j in cycle_edges) or \
+            tuple(cycle_links)
+        if key in seen_cycles:
+            return
+        seen_cycles.add(key)
+        candidates = [{
+            "joint": j.get("name"),
+            "source_joint": _joint_source_name(j),
+            "parent": j.get("parent"),
+            "child": j.get("child"),
+        } for j in cycle_edges]
+        reports.append({
+            "links": cycle_links,
+            "joints": [j.get("name") for j in cycle_edges],
+            "source_joints": [_joint_source_name(j) for j in cycle_edges],
+            "candidates": candidates,
+        })
+
+    def dfs(node):
+        colour[node] = "gray"
+        stack_links.append(node)
+        for j in by_parent.get(node, []):
+            child = j.get("child")
+            if child not in link_names:
+                continue
+            if colour.get(child) == "gray":
+                add_cycle(child, j)
+            elif colour.get(child) != "black":
+                stack_edges.append(j)
+                dfs(child)
+                stack_edges.pop()
+        stack_links.pop()
+        colour[node] = "black"
+
+    roots = [base_link] if base_link in link_names else []
+    roots.extend(sorted(link_names - set(roots)))
+    for root in roots:
+        if colour.get(root) is None:
+            dfs(root)
+    return reports
+
+
+def _collapse_cycle_break_choices(base_link, links, joints, selected_sources):
+    """List preview source-joint candidates that can break active cycles."""
+    selected_sources = set(selected_sources or [])
+    choices = []
+    active_sources = set()
+    for cycle in _directed_cycle_reports(base_link, links, joints):
+        candidates = cycle.get("candidates", [])
+        for c in candidates:
+            if c.get("source_joint"):
+                active_sources.add(c["source_joint"])
+        selected = next((c.get("source_joint") for c in candidates
+                         if c.get("source_joint") in selected_sources), "")
+        choices.append({
+            **cycle,
+            "selected_source_joint": selected,
+            "resolved": False,
+        })
+    for source in sorted(selected_sources - active_sources):
+        choices.append({
+            "links": [],
+            "joints": [],
+            "source_joints": [source],
+            "selected_source_joint": source,
+            "resolved": True,
+            "candidates": [{
+                "joint": source,
+                "source_joint": source,
+                "parent": "",
+                "child": "",
+            }],
+        })
+    return choices
+
+
 def _validate_collapsed_tree(base_link, links, joints, collapsed,
                              collapse_link=None):
     """Report structural hazards in a collapsed preview tree."""
     collapse_link = collapse_link or {}
-    link_names = {l["link_name"] for l in links}
     issues = []
 
     incoming = {}
@@ -1497,37 +1641,16 @@ def _validate_collapsed_tree(base_link, links, joints, collapsed,
                     "sub-assembly collapse"),
             })
 
-    adj = {}
-    for j in joints:
-        adj.setdefault(j["parent"], []).append(j["child"])
-    seen_cycles, colour, stack = set(), {}, []
-
-    def dfs(node):
-        colour[node] = "gray"
-        stack.append(node)
-        for child in adj.get(node, []):
-            if colour.get(child) == "gray":
-                i = stack.index(child)
-                cyc = [*stack[i:], child]
-                key = tuple(cyc)
-                if key not in seen_cycles:
-                    seen_cycles.add(key)
-                    issues.append({
-                        "severity": "error",
-                        "code": "cycle",
-                        "links": cyc,
-                        "message": "collapsed tree contains a directed cycle",
-                    })
-            elif colour.get(child) != "black":
-                dfs(child)
-        stack.pop()
-        colour[node] = "black"
-
-    roots = [base_link] if base_link in link_names else []
-    roots.extend(sorted(link_names - set(roots)))
-    for root in roots:
-        if colour.get(root) is None:
-            dfs(root)
+    for cycle in _directed_cycle_reports(base_link, links, joints):
+        issues.append({
+            "severity": "error",
+            "code": "cycle",
+            "links": cycle["links"],
+            "joints": cycle["joints"],
+            "source_joints": cycle["source_joints"],
+            "candidates": cycle["candidates"],
+            "message": "collapsed tree contains a directed cycle",
+        })
 
     for sub in collapsed:
         comps = _subassembly_member_groups(sub)
@@ -4164,6 +4287,65 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                                 "rebuilt": False})
                 print(f"[sw2robot.web] set_subassembly_origin_link: "
                       f"{name_in} -> {label} (preview only)")
+                return self._send_json(payload)
+            if parsed.path == "/api/set_subassembly_cycle_break":
+                cls = type(self)
+                n = int(self.headers.get("Content-Length", 0))
+                body = json.loads(self.rfile.read(n) or b"{}")
+                source_joint = (body.get("source_joint") or "").strip()
+                previous_source_joint = (
+                    body.get("previous_source_joint") or "").strip()
+                drop = bool(body.get("drop", True))
+                target = source_joint or previous_source_joint
+                if not cls.pkg_dir:
+                    return self._send_json({"error": "no package open"}, 400)
+                if not _cad_mode(cls.pkg_dir):
+                    return self._send_json(
+                        {"error": "sub-assembly cycle breaks need the CAD "
+                                  "graph.json"},
+                        400)
+                if not target:
+                    return self._send_json(
+                        {"error": "source_joint required"}, 400)
+                from sw2robot.exporter.state import GraphState
+                graph = GraphState.load(os.path.join(cls.pkg_dir, "graph.json"))
+                name = os.path.splitext(os.path.basename(cls.urdf_rel))[0]
+                yml = os.path.join(cls.pkg_dir, name + ".joints.yaml")
+                if not os.path.exists(yml):
+                    return self._send_json(
+                        {"error": "joints.yaml not found -- re-extract once"},
+                        400)
+                with open(yml, encoding="utf-8") as f:
+                    txt = f.read()
+                try:
+                    preview = _collapse_preview_payload(graph, txt)
+                    selected = _subassembly_cycle_break_joints(txt)
+                    allowed = set(selected)
+                    for choice in preview.get("cycle_break_choices", []):
+                        for cand in choice.get("candidates", []):
+                            if cand.get("source_joint"):
+                                allowed.add(cand["source_joint"])
+                    if target not in allowed:
+                        return self._send_json(
+                            {"error": f"'{target}' is not a cycle-break "
+                                      "candidate"},
+                            400)
+                    txt = _set_subassembly_cycle_break_joint_yaml(
+                        txt, source_joint, drop, previous_source_joint)
+                except ValueError as e:
+                    return self._send_json({"error": str(e)}, 400)
+                label = source_joint if drop else "auto"
+                _snapshot(cls.pkg_dir, yml,
+                          f"sub-assembly cycle break {target} -> {label}")
+                with open(yml, "w", encoding="utf-8") as f:
+                    f.write(txt)
+                payload = _collapse_preview_payload(graph, txt)
+                payload.update({"ok": True, "source_joint": source_joint,
+                                "previous_source_joint": previous_source_joint,
+                                "drop": drop, "preview_only": True,
+                                "rebuilt": False})
+                print(f"[sw2robot.web] set_subassembly_cycle_break: "
+                      f"{target} -> {label} (preview only)")
                 return self._send_json(payload)
             if parsed.path == "/api/set_base":
                 cls = type(self)

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1393,8 +1393,6 @@ def _collapse_preview_payload(graph, yml_txt=""):
         joints.append(out)
 
     base = collapse_link.get(canonical["base_link"], canonical["base_link"])
-    cycle_break_choices = _collapse_cycle_break_choices(
-        base, links, joints, cycle_break_joints)
     dropped_cycle_joints = []
     if cycle_break_joints:
         kept = []
@@ -1404,6 +1402,8 @@ def _collapse_preview_payload(graph, yml_txt=""):
             else:
                 kept.append(j)
         joints = kept
+    cycle_break_choices = _collapse_cycle_break_choices(
+        base, links, joints, cycle_break_joints)
 
     validation = _validate_collapsed_tree(base, links, joints, collapsed,
                                           collapse_link)
@@ -1541,8 +1541,7 @@ def _directed_cycle_reports(base_link, links, joints):
             return
         cycle_links = [*stack_links[i:], child]
         cycle_edges = [*stack_edges[i:], back_edge]
-        key = tuple(_joint_source_name(j) for j in cycle_edges) or \
-            tuple(cycle_links)
+        key = tuple(_joint_source_name(j) for j in cycle_edges)
         if key in seen_cycles:
             return
         seen_cycles.add(key)
@@ -1598,7 +1597,7 @@ def _collapse_cycle_break_choices(base_link, links, joints, selected_sources):
         choices.append({
             **cycle,
             "selected_source_joint": selected,
-            "resolved": False,
+            "stale": False,
         })
     for source in sorted(selected_sources - active_sources):
         choices.append({
@@ -1606,7 +1605,7 @@ def _collapse_cycle_break_choices(base_link, links, joints, selected_sources):
             "joints": [],
             "source_joints": [source],
             "selected_source_joint": source,
-            "resolved": True,
+            "stale": True,
             "candidates": [{
                 "joint": source,
                 "source_joint": source,

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1168,7 +1168,11 @@ def _set_subassembly_parent_override_yaml(txt, graph, name, parent):
 
 
 def _subassembly_origin_links(yml_txt):
-    """Preview-only representative member links for collapsed sub-assemblies."""
+    """Preview-only representative member links for collapsed sub-assemblies.
+
+    The build/export path does not consume this yet; it only documents the
+    user's intended anchor for collapsed preview diagnostics.
+    """
     import yaml as _yaml
 
     try:
@@ -1307,6 +1311,16 @@ def _collapse_preview_payload(graph, yml_txt=""):
         sub["selected_parent"] = selected_parent_by_subassembly.get(
             sub["name"], "")
     group_choices = _collapse_group_choices(collapsed, origin_links)
+    origin_choice_by_subassembly = {
+        c.get("subassembly"): c
+        for c in group_choices
+    }
+    for sub in collapsed:
+        choice = origin_choice_by_subassembly.get(sub["name"], {})
+        sub["selected_origin_link"] = choice.get("selected_origin_link", "")
+        stale = choice.get("stale_origin_link", "")
+        if stale:
+            sub["stale_origin_link"] = stale
 
     links = []
     inserted = set()
@@ -1436,13 +1450,20 @@ def _collapse_group_choices(collapsed, origin_links):
     choices = []
     for sub in collapsed:
         groups = _subassembly_member_groups(sub)
-        selected = origin_links.get(sub.get("name"), "")
-        if len(groups) <= 1 and not selected:
+        members = set(sub.get("member_links") or [])
+        raw_selected = origin_links.get(sub.get("name"), "")
+        selected = raw_selected if raw_selected in members else ""
+        stale = (
+            raw_selected
+            if raw_selected and raw_selected not in members
+            else "")
+        if len(groups) <= 1 and not selected and not stale:
             continue
         choices.append({
             "subassembly": sub.get("name"),
             "link_name": sub.get("link_name"),
             "selected_origin_link": selected,
+            "stale_origin_link": stale,
             "groups": [
                 {"origin_link": g[0], "links": g, "size": len(g)}
                 for g in groups
@@ -1510,22 +1531,33 @@ def _validate_collapsed_tree(base_link, links, joints, collapsed,
 
     for sub in collapsed:
         comps = _subassembly_member_groups(sub)
-        if len(comps) <= 1:
-            continue
-        selected_origin_link = sub.get("selected_origin_link")
-        if selected_origin_link and any(selected_origin_link in comp for comp in comps):
-            pass
-        elif selected_origin_link:
+        stale_origin_link = sub.get("stale_origin_link")
+        if stale_origin_link:
             issues.append({
                 "severity": "warning",
                 "code": "invalid_origin_link",
                 "subassembly": sub.get("name"),
                 "link": sub.get("link_name"),
-                "origin_link": selected_origin_link,
+                "origin_link": stale_origin_link,
                 "components": comps,
                 "message": (
                     f"{sub.get('name')} uses stale origin link "
-                    f"{selected_origin_link}"),
+                    f"{stale_origin_link}"),
+            })
+        selected_origin_link = sub.get("selected_origin_link")
+        if len(comps) <= 1:
+            continue
+        if selected_origin_link:
+            issues.append({
+                "severity": "info",
+                "code": "disconnected_members",
+                "subassembly": sub.get("name"),
+                "link": sub.get("link_name"),
+                "origin_link": selected_origin_link,
+                "components": comps,
+                "message": (
+                    f"{sub.get('name')} maps to {len(comps)} disconnected "
+                    f"member groups; anchored at {selected_origin_link}"),
             })
         else:
             issues.append({

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1300,7 +1300,7 @@ def _collapse_preview_payload(graph, yml_txt=""):
         for c in parent_choices
         if c.get("selected_parent")
     }
-    joints, dropped, dropped_parent_override = [], [], []
+    joints, dropped = [], []
     for j in canonical["joints"]:
         parent = collapse_link.get(j["parent"], j["parent"])
         child = collapse_link.get(j["child"], j["child"])
@@ -1311,7 +1311,6 @@ def _collapse_preview_payload(graph, yml_txt=""):
             continue
         selected = selected_by_link.get(child)
         if selected and parent != selected:
-            dropped_parent_override.append(out)
             continue
         out["name"] = f"{parent}__{child}"
         joints.append(out)
@@ -1326,7 +1325,6 @@ def _collapse_preview_payload(graph, yml_txt=""):
         "tree_rows": _tree_rows_payload(base, links, joints),
         "validation": validation,
         "dropped_internal_joints": dropped,
-        "dropped_parent_override_joints": dropped_parent_override,
         "collapsed_subassemblies": collapsed,
         "parent_choices": parent_choices,
         "canonical_counts": {

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1140,6 +1140,33 @@ def _set_subassembly_mode_yaml(txt, graph, name, mode):
     return txt, {"expand": exp_members, "no_expand": noexp_members}
 
 
+def _subassembly_parent_overrides(yml_txt):
+    """Preview-only parent choices for collapsed CAD sub-assemblies."""
+    import yaml as _yaml
+
+    try:
+        cfg = _yaml.safe_load(yml_txt) or {}
+        if not isinstance(cfg, dict):
+            return {}
+    except Exception:
+        return {}
+    raw = cfg.get("subassembly_parent_overrides") or {}
+    if not isinstance(raw, dict):
+        return {}
+    return {str(k): str(v) for k, v in raw.items() if v is not None}
+
+
+def _set_subassembly_parent_override_yaml(txt, graph, name, parent):
+    """Set/reset one preview-only collapsed sub-assembly parent choice."""
+    names = _subassembly_names(graph)
+    if name not in names:
+        raise ValueError(f"no CAD sub-assembly '{name}'")
+    if parent:
+        return _upsert_yaml_map(
+            txt, "subassembly_parent_overrides", name, _yaml_scalar(parent))
+    return _remove_yaml_map_entry(txt, "subassembly_parent_overrides", name)
+
+
 def _canonical_tree_payload(graph, yml_txt=""):
     """Fully-expanded tree plus CAD sub-assembly membership.
 
@@ -1215,6 +1242,7 @@ def _collapse_preview_payload(graph, yml_txt=""):
     """
     canonical = _canonical_tree_payload(graph, yml_txt)
     states = _subassemblies_payload(graph, yml_txt)
+    parent_overrides = _subassembly_parent_overrides(yml_txt)
     by_sub = {s["name"]: s for s in canonical["subassemblies"]}
     collapse_link = {}
     collapsed = []
@@ -1233,10 +1261,14 @@ def _collapse_preview_payload(graph, yml_txt=""):
             "member_components": sub["member_components"],
             "internal_joints": sub["internal_joints"],
             "boundary_joints": sub["boundary_joints"],
+            "selected_parent": parent_overrides.get(row["name"], ""),
         }
         collapsed.append(info)
         for link in sub["member_links"]:
             collapse_link[link] = row["link_name"]
+
+    parent_choices = _collapse_parent_choices(
+        collapsed, collapse_link, parent_overrides)
 
     links = []
     inserted = set()
@@ -1256,7 +1288,12 @@ def _collapse_preview_payload(graph, yml_txt=""):
             continue
         links.append({**link, "collapsed": False})
 
-    joints, dropped = [], []
+    selected_by_link = {
+        c["link_name"]: c.get("selected_parent", "")
+        for c in parent_choices
+        if c.get("selected_parent")
+    }
+    joints, dropped, dropped_parent_override = [], [], []
     for j in canonical["joints"]:
         parent = collapse_link.get(j["parent"], j["parent"])
         child = collapse_link.get(j["child"], j["child"])
@@ -1264,6 +1301,10 @@ def _collapse_preview_payload(graph, yml_txt=""):
                "parent": parent, "child": child}
         if parent == child:
             dropped.append(out)
+            continue
+        selected = selected_by_link.get(child)
+        if selected and parent != selected:
+            dropped_parent_override.append(out)
             continue
         out["name"] = f"{parent}__{child}"
         joints.append(out)
@@ -1278,7 +1319,9 @@ def _collapse_preview_payload(graph, yml_txt=""):
         "tree_rows": _tree_rows_payload(base, links, joints),
         "validation": validation,
         "dropped_internal_joints": dropped,
+        "dropped_parent_override_joints": dropped_parent_override,
         "collapsed_subassemblies": collapsed,
+        "parent_choices": parent_choices,
         "canonical_counts": {
             "links": len(canonical["links"]),
             "joints": len(canonical["joints"]),
@@ -1288,6 +1331,36 @@ def _collapse_preview_payload(graph, yml_txt=""):
             "joints": len(joints),
         },
     }
+
+
+def _collapse_parent_choices(collapsed, collapse_link, parent_overrides):
+    """List attach-parent candidates for collapsed sub-assemblies.
+
+    The candidates are computed before any override is applied so the UI can
+    still change an existing choice after it resolves the validation warning.
+    """
+    choices = []
+    for sub in collapsed:
+        by_parent = {}
+        link_name = sub.get("link_name")
+        for j in sub.get("boundary_joints") or []:
+            parent = collapse_link.get(j["parent"], j["parent"])
+            child = collapse_link.get(j["child"], j["child"])
+            if child == link_name and parent != child:
+                by_parent.setdefault(parent, []).append(j.get("name"))
+        selected = parent_overrides.get(sub.get("name"), "")
+        if len(by_parent) <= 1 and not selected:
+            continue
+        choices.append({
+            "subassembly": sub.get("name"),
+            "link_name": link_name,
+            "selected_parent": selected,
+            "parents": [
+                {"link": p, "joints": sorted(x for x in js if x)}
+                for p, js in sorted(by_parent.items())
+            ],
+        })
+    return choices
 
 
 def _validate_collapsed_tree(base_link, links, joints, collapsed,
@@ -1389,9 +1462,12 @@ def _validate_collapsed_tree(base_link, links, joints, collapsed,
             })
 
         incoming_boundary = []
+        selected_parent = sub.get("selected_parent")
         for j in sub.get("boundary_joints") or []:
             parent = collapse_link.get(j["parent"], j["parent"])
             child = collapse_link.get(j["child"], j["child"])
+            if selected_parent and parent != selected_parent:
+                continue
             if child == sub.get("link_name") and parent != child:
                 incoming_boundary.append({
                     "parent": parent,
@@ -3858,6 +3934,65 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                                 **members})
                 print(f"[sw2robot.web] set_subassembly_mode: "
                       f"{name_in} -> {mode} (preview only)")
+                return self._send_json(payload)
+            if parsed.path == "/api/set_subassembly_parent":
+                cls = type(self)
+                n = int(self.headers.get("Content-Length", 0))
+                body = json.loads(self.rfile.read(n) or b"{}")
+                name_in = (body.get("name") or "").strip()
+                parent = (body.get("parent") or "").strip()
+                if parent == "auto":
+                    parent = ""
+                if not cls.pkg_dir:
+                    return self._send_json({"error": "no package open"}, 400)
+                if not _cad_mode(cls.pkg_dir):
+                    return self._send_json(
+                        {"error": "sub-assembly parent choices need the CAD "
+                                  "graph.json"},
+                        400)
+                if not name_in:
+                    return self._send_json({"error": "name required"}, 400)
+                from sw2robot.exporter.state import GraphState
+                graph = GraphState.load(os.path.join(cls.pkg_dir, "graph.json"))
+                name = os.path.splitext(os.path.basename(cls.urdf_rel))[0]
+                yml = os.path.join(cls.pkg_dir, name + ".joints.yaml")
+                if not os.path.exists(yml):
+                    return self._send_json(
+                        {"error": "joints.yaml not found -- re-extract once"},
+                        400)
+                with open(yml, encoding="utf-8") as f:
+                    txt = f.read()
+                try:
+                    preview = _collapse_preview_payload(graph, txt)
+                    choices = {
+                        c.get("subassembly"): c
+                        for c in preview.get("parent_choices", [])
+                    }
+                    if parent:
+                        allowed = {
+                            p.get("link")
+                            for p in choices.get(name_in, {}).get("parents", [])
+                        }
+                        if parent not in allowed:
+                            return self._send_json(
+                                {"error": f"'{parent}' is not a parent "
+                                          f"candidate for {name_in}"},
+                                400)
+                    txt = _set_subassembly_parent_override_yaml(
+                        txt, graph, name_in, parent)
+                except ValueError as e:
+                    return self._send_json({"error": str(e)}, 400)
+                label = parent or "auto"
+                _snapshot(cls.pkg_dir, yml,
+                          f"sub-assembly parent {name_in} -> {label}")
+                with open(yml, "w", encoding="utf-8") as f:
+                    f.write(txt)
+                payload = _collapse_preview_payload(graph, txt)
+                payload.update({"ok": True, "name": name_in,
+                                "parent": parent, "preview_only": True,
+                                "rebuilt": False})
+                print(f"[sw2robot.web] set_subassembly_parent: "
+                      f"{name_in} -> {label} (preview only)")
                 return self._send_json(payload)
             if parsed.path == "/api/set_base":
                 cls = type(self)

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -225,6 +225,7 @@ def test_collapse_preview_keeps_expanded_override():
 def test_collapse_preview_applies_subassembly_parent_override():
     from sw2robot.editor.webserver import (
         _collapse_preview_payload,
+        _set_subassembly_origin_link_yaml,
         _set_subassembly_parent_override_yaml,
     )
 
@@ -252,7 +253,8 @@ joints:
         "bracket_1", "plate_1"]
     assert {
         i["code"] for i in payload["validation"]["issues"]
-    } >= {"multiple_parents", "multiple_boundary_parents"}
+    } >= {"multiple_parents", "multiple_boundary_parents",
+          "disconnected_members"}
 
     txt = _set_subassembly_parent_override_yaml(
         txt, graph, "servo-1", "bracket_1")
@@ -263,6 +265,21 @@ joints:
         ("plate_1", "bracket_1"),
     ]
     assert "multiple_boundary_parents" not in {
+        i["code"] for i in payload["validation"]["issues"]
+    }
+    assert payload["group_choices"][0]["subassembly"] == "servo-1"
+    assert [g["origin_link"] for g in payload["group_choices"][0]["groups"]] == [
+        "servo_1__case_1", "servo_1__horn_1"]
+    assert "disconnected_members" in {
+        i["code"] for i in payload["validation"]["issues"]
+    }
+
+    txt = _set_subassembly_origin_link_yaml(
+        txt, graph, "servo-1", "servo_1__horn_1")
+    payload = _collapse_preview_payload(graph, txt)
+    assert payload["group_choices"][0]["selected_origin_link"] == \
+        "servo_1__horn_1"
+    assert "disconnected_members" not in {
         i["code"] for i in payload["validation"]["issues"]
     }
 

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -271,6 +271,81 @@ joints:
     }
 
 
+def test_collapse_preview_ignores_stale_subassembly_parent_override():
+    from sw2robot.editor.webserver import _collapse_preview_payload
+
+    graph = make_graph()
+    graph.components.append(_comp("bracket-1", "bracket_1", xyz=(0, 0.1, 0)))
+    txt = """
+base: plate-1
+no_expand:
+- servo
+subassembly_parent_overrides:
+  servo-1: missing_parent
+joints:
+  - parent: plate-1
+    child:  servo-1/case-1
+    type:   fixed
+  - parent: bracket-1
+    child:  servo-1/horn-1
+    type:   fixed
+  - parent: plate-1
+    child:  bracket-1
+    type:   fixed
+"""
+    payload = _collapse_preview_payload(graph, txt)
+    assert payload["parent_choices"][0]["selected_parent"] == ""
+    assert payload["collapsed_subassemblies"][0]["selected_parent"] == ""
+    assert {
+        (j["parent"], j["child"]) for j in payload["joints"]
+    } >= {
+        ("plate_1", "servo_1"),
+        ("bracket_1", "servo_1"),
+    }
+    assert "multiple_boundary_parents" in {
+        i["code"] for i in payload["validation"]["issues"]
+    }
+
+
+def test_collapse_preview_can_reset_subassembly_parent_override_to_auto():
+    from sw2robot.editor.webserver import (
+        _collapse_preview_payload,
+        _set_subassembly_parent_override_yaml,
+        _subassembly_parent_overrides,
+    )
+
+    graph = make_graph()
+    graph.components.append(_comp("bracket-1", "bracket_1", xyz=(0, 0.1, 0)))
+    txt = """
+base: plate-1
+no_expand:
+- servo
+joints:
+  - parent: plate-1
+    child:  servo-1/case-1
+    type:   fixed
+  - parent: bracket-1
+    child:  servo-1/horn-1
+    type:   fixed
+  - parent: plate-1
+    child:  bracket-1
+    type:   fixed
+"""
+    txt = _set_subassembly_parent_override_yaml(
+        txt, graph, "servo-1", "bracket_1")
+    txt = _set_subassembly_parent_override_yaml(txt, graph, "servo-1", "")
+    assert _subassembly_parent_overrides(txt) == {}
+
+    payload = _collapse_preview_payload(graph, txt)
+    assert payload["parent_choices"][0]["selected_parent"] == ""
+    assert {
+        (j["parent"], j["child"]) for j in payload["joints"]
+    } >= {
+        ("plate_1", "servo_1"),
+        ("bracket_1", "servo_1"),
+    }
+
+
 def test_validate_collapsed_tree_reports_multiple_parents_and_cycles():
     from sw2robot.editor.webserver import _validate_collapsed_tree
 

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -222,6 +222,55 @@ def test_collapse_preview_keeps_expanded_override():
     ]
 
 
+def test_collapse_preview_applies_subassembly_parent_override():
+    from sw2robot.editor.webserver import (
+        _collapse_preview_payload,
+        _set_subassembly_parent_override_yaml,
+    )
+
+    graph = make_graph()
+    graph.components.append(_comp("bracket-1", "bracket_1", xyz=(0, 0.1, 0)))
+    txt = """
+base: plate-1
+no_expand:
+- servo
+joints:
+  - parent: plate-1
+    child:  servo-1/case-1
+    type:   fixed
+  - parent: bracket-1
+    child:  servo-1/horn-1
+    type:   fixed
+  - parent: plate-1
+    child:  bracket-1
+    type:   fixed
+"""
+    payload = _collapse_preview_payload(graph, txt)
+    choices = payload["parent_choices"]
+    assert choices[0]["subassembly"] == "servo-1"
+    assert [p["link"] for p in choices[0]["parents"]] == [
+        "bracket_1", "plate_1"]
+    assert {
+        i["code"] for i in payload["validation"]["issues"]
+    } >= {"multiple_parents", "multiple_boundary_parents"}
+
+    txt = _set_subassembly_parent_override_yaml(
+        txt, graph, "servo-1", "bracket_1")
+    payload = _collapse_preview_payload(graph, txt)
+    assert payload["parent_choices"][0]["selected_parent"] == "bracket_1"
+    assert [(j["parent"], j["child"]) for j in payload["joints"]] == [
+        ("bracket_1", "servo_1"),
+        ("plate_1", "bracket_1"),
+    ]
+    assert [j["source_name"]
+            for j in payload["dropped_parent_override_joints"]] == [
+        "plate_1__servo_1__case_1"
+    ]
+    assert "multiple_boundary_parents" not in {
+        i["code"] for i in payload["validation"]["issues"]
+    }
+
+
 def test_validate_collapsed_tree_reports_multiple_parents_and_cycles():
     from sw2robot.editor.webserver import _validate_collapsed_tree
 

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -491,7 +491,46 @@ def test_validate_collapsed_tree_reports_multiple_parents_and_cycles():
     assert multi["source_joints"] == ["j1", "j2"]
     cycle = next(i for i in payload["issues"] if i["code"] == "cycle")
     assert cycle["links"] == ["base", "arm", "base"]
+    assert cycle["source_joints"] == ["j1", "j3"]
+    assert cycle["candidates"] == [
+        {"joint": "base__arm", "source_joint": "j1",
+         "parent": "base", "child": "arm"},
+        {"joint": "arm__base", "source_joint": "j3",
+         "parent": "arm", "child": "base"},
+    ]
     assert payload["ok"] is False
+
+
+def test_subassembly_cycle_break_choices_drop_source_joint():
+    from sw2robot.editor.webserver import (
+        _collapse_cycle_break_choices,
+        _set_subassembly_cycle_break_joint_yaml,
+        _subassembly_cycle_break_joints,
+        _validate_collapsed_tree,
+    )
+
+    links = [{"link_name": n} for n in ("base", "arm")]
+    joints = [
+        {"name": "base__arm", "parent": "base", "child": "arm",
+         "type": "fixed", "source_name": "j1"},
+        {"name": "arm__base", "parent": "arm", "child": "base",
+         "type": "fixed", "source_name": "j2"},
+    ]
+    choices = _collapse_cycle_break_choices("base", links, joints, set())
+    assert len(choices) == 1
+    assert choices[0]["links"] == ["base", "arm", "base"]
+    assert [c["source_joint"] for c in choices[0]["candidates"]] == [
+        "j1", "j2"]
+
+    txt = _set_subassembly_cycle_break_joint_yaml("", "j2", True)
+    drops = _subassembly_cycle_break_joints(txt)
+    assert drops == {"j2"}
+    kept = [j for j in joints if j["source_name"] not in drops]
+    assert _validate_collapsed_tree(
+        "base", links, kept, [])["ok"] is True
+
+    txt = _set_subassembly_cycle_break_joint_yaml(txt, "", False, "j2")
+    assert _subassembly_cycle_break_joints(txt) == set()
 
 
 def test_validate_collapsed_tree_reports_disconnected_members():

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -2,6 +2,12 @@
 graph: a 'servo unit' sub-assembly whose horn turns inside, mounted on a
 base plate.  Expansion must splice the children in, keep the internal
 revolute, and re-attach the mounting mate to the owning child."""
+import json
+import socket
+import threading
+import urllib.error
+import urllib.request
+
 import numpy as np
 import pytest
 from test_classify_geo import O, Z, coinc_planes, conc, dup
@@ -63,6 +69,25 @@ def make_graph():
                       components=[plate, inst], edges=[mount],
                       ground=["plate-1"],
                       subassemblies={"X:/fake/servo_unit.SLDASM": sub})
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def _post_json(base, path, body):
+    req = urllib.request.Request(
+        base + path, data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"}, method="POST")
+    try:
+        with urllib.request.urlopen(req) as r:
+            return r.status, json.loads(r.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read().decode("utf-8"))
 
 
 def test_expand_splices_children():
@@ -279,9 +304,95 @@ joints:
     payload = _collapse_preview_payload(graph, txt)
     assert payload["group_choices"][0]["selected_origin_link"] == \
         "servo_1__horn_1"
-    assert "disconnected_members" not in {
-        i["code"] for i in payload["validation"]["issues"]
-    }
+    anchored = next(
+        i for i in payload["validation"]["issues"]
+        if i["code"] == "disconnected_members")
+    assert anchored["severity"] == "info"
+    assert anchored["origin_link"] == "servo_1__horn_1"
+
+
+def test_collapse_preview_reports_stale_subassembly_origin_link():
+    from sw2robot.editor.webserver import _collapse_preview_payload
+
+    txt = """
+base: plate-1
+no_expand:
+- servo
+subassembly_origin_links:
+  servo-1: missing_link
+"""
+    payload = _collapse_preview_payload(make_graph(), txt)
+    choices = payload["group_choices"]
+    assert choices[0]["subassembly"] == "servo-1"
+    assert choices[0]["selected_origin_link"] == ""
+    assert choices[0]["stale_origin_link"] == "missing_link"
+    assert payload["collapsed_subassemblies"][0]["selected_origin_link"] == ""
+    assert payload["collapsed_subassemblies"][0]["stale_origin_link"] == \
+        "missing_link"
+    issue = next(
+        i for i in payload["validation"]["issues"]
+        if i["code"] == "invalid_origin_link")
+    assert issue["origin_link"] == "missing_link"
+
+
+def test_set_subassembly_origin_link_rejects_non_candidate(tmp_path):
+    from sw2robot.editor import webserver
+
+    graph = make_graph()
+    graph.components.append(_comp("bracket-1", "bracket_1", xyz=(0, 0.1, 0)))
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "urdf").mkdir()
+    graph.save(pkg / "graph.json")
+    yml = pkg / "t.joints.yaml"
+    yml.write_text("""
+base: plate-1
+no_expand:
+- servo
+joints:
+  - parent: plate-1
+    child:  servo-1/case-1
+    type:   fixed
+  - parent: bracket-1
+    child:  servo-1/horn-1
+    type:   fixed
+  - parent: plate-1
+    child:  bracket-1
+    type:   fixed
+""", encoding="utf-8")
+
+    old_state = (
+        webserver._Handler.pkg_dir,
+        webserver._Handler.urdf_rel,
+        webserver._Handler.robot_name,
+        webserver._Handler.root_dir,
+    )
+    webserver._Handler.pkg_dir = str(pkg)
+    webserver._Handler.urdf_rel = "urdf/t.urdf"
+    webserver._Handler.robot_name = "t"
+    webserver._Handler.root_dir = str(pkg)
+    httpd, port = webserver._bind_free_port(
+        webserver._Handler, _free_port())
+    httpd.daemon_threads = True
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    try:
+        code, payload = _post_json(
+            f"http://127.0.0.1:{port}",
+            "/api/set_subassembly_origin_link",
+            {"name": "servo-1", "origin_link": "not_a_member"})
+        assert code == 400
+        assert "not a member origin link candidate" in payload["error"]
+        assert "subassembly_origin_links" not in yml.read_text(
+            encoding="utf-8")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        (
+            webserver._Handler.pkg_dir,
+            webserver._Handler.urdf_rel,
+            webserver._Handler.robot_name,
+            webserver._Handler.root_dir,
+        ) = old_state
 
 
 def test_collapse_preview_ignores_stale_subassembly_parent_override():

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -262,10 +262,6 @@ joints:
         ("bracket_1", "servo_1"),
         ("plate_1", "bracket_1"),
     ]
-    assert [j["source_name"]
-            for j in payload["dropped_parent_override_joints"]] == [
-        "plate_1__servo_1__case_1"
-    ]
     assert "multiple_boundary_parents" not in {
         i["code"] for i in payload["validation"]["issues"]
     }

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -501,13 +501,8 @@ def test_validate_collapsed_tree_reports_multiple_parents_and_cycles():
     assert payload["ok"] is False
 
 
-def test_subassembly_cycle_break_choices_drop_source_joint():
-    from sw2robot.editor.webserver import (
-        _collapse_cycle_break_choices,
-        _set_subassembly_cycle_break_joint_yaml,
-        _subassembly_cycle_break_joints,
-        _validate_collapsed_tree,
-    )
+def test_collapse_preview_applies_cycle_break_before_choices(monkeypatch):
+    from sw2robot.editor import webserver
 
     links = [{"link_name": n} for n in ("base", "arm")]
     joints = [
@@ -516,21 +511,85 @@ def test_subassembly_cycle_break_choices_drop_source_joint():
         {"name": "arm__base", "parent": "arm", "child": "base",
          "type": "fixed", "source_name": "j2"},
     ]
-    choices = _collapse_cycle_break_choices("base", links, joints, set())
-    assert len(choices) == 1
-    assert choices[0]["links"] == ["base", "arm", "base"]
-    assert [c["source_joint"] for c in choices[0]["candidates"]] == [
-        "j1", "j2"]
+    monkeypatch.setattr(webserver, "_canonical_tree_payload", lambda *_: {
+        "base_link": "base",
+        "links": links,
+        "joints": joints,
+        "subassemblies": [],
+    })
+    monkeypatch.setattr(webserver, "_subassemblies_payload", lambda *_: {
+        "subassemblies": [],
+    })
+
+    payload = webserver._collapse_preview_payload(
+        object(), "subassembly_cycle_break_joints:\n- arm__base\n")
+
+    assert [j["source_name"] for j in payload["joints"]] == ["base__arm"]
+    assert not any(i["code"] == "cycle"
+                   for i in payload["validation"]["issues"])
+    assert payload["cycle_break_choices"] == [{
+        "links": [],
+        "joints": [],
+        "source_joints": ["arm__base"],
+        "selected_source_joint": "arm__base",
+        "stale": True,
+        "candidates": [{
+            "joint": "arm__base",
+            "source_joint": "arm__base",
+            "parent": "",
+            "child": "",
+        }],
+    }]
+
+
+def test_subassembly_cycle_break_yaml_adds_and_resets_source_joint():
+    from sw2robot.editor.webserver import (
+        _set_subassembly_cycle_break_joint_yaml,
+        _subassembly_cycle_break_joints,
+    )
 
     txt = _set_subassembly_cycle_break_joint_yaml("", "j2", True)
-    drops = _subassembly_cycle_break_joints(txt)
-    assert drops == {"j2"}
-    kept = [j for j in joints if j["source_name"] not in drops]
-    assert _validate_collapsed_tree(
-        "base", links, kept, [])["ok"] is True
+    assert _subassembly_cycle_break_joints(txt) == {"j2"}
 
     txt = _set_subassembly_cycle_break_joint_yaml(txt, "", False, "j2")
     assert _subassembly_cycle_break_joints(txt) == set()
+
+
+def test_directed_cycle_reports_self_loop():
+    from sw2robot.editor.webserver import _directed_cycle_reports
+
+    reports = _directed_cycle_reports(
+        "base", [{"link_name": "base"}], [{
+            "name": "base__base", "parent": "base", "child": "base",
+            "type": "fixed", "source_name": "self_joint",
+        }])
+
+    assert len(reports) == 1
+    assert reports[0]["links"] == ["base", "base"]
+    assert reports[0]["source_joints"] == ["self_joint"]
+
+
+def test_cycle_break_shared_candidate_resolves_two_cycles():
+    from sw2robot.editor.webserver import _directed_cycle_reports
+
+    links = [{"link_name": n} for n in ("base", "arm", "tip")]
+    joints = [
+        {"name": "base__arm", "parent": "base", "child": "arm",
+         "source_name": "shared"},
+        {"name": "arm__base", "parent": "arm", "child": "base",
+         "source_name": "short_return"},
+        {"name": "arm__tip", "parent": "arm", "child": "tip",
+         "source_name": "to_tip"},
+        {"name": "tip__base", "parent": "tip", "child": "base",
+         "source_name": "long_return"},
+    ]
+
+    reports = _directed_cycle_reports("base", links, joints)
+    assert len(reports) == 2
+    assert all("shared" in r["source_joints"] for r in reports)
+
+    kept = [j for j in joints if j["source_name"] != "shared"]
+    assert _directed_cycle_reports("base", links, kept) == []
 
 
 def test_validate_collapsed_tree_reports_disconnected_members():


### PR DESCRIPTION
If this PR is stacked on top of the member-group-anchor PR, the focused diff is:

https://github.com/poyotamu000/solidworks_urdf_exporter2/compare/clean/subassembly-member-group-anchor...clean/subassembly-cycle-break-preview


## Summary

This PR adds GUI controls for resolving directed cycles in collapsed sub-assembly previews.

The previous PRs make ambiguous collapsed trees explicit and editable by adding parent choices and member group anchor choices. This PR handles the next class of ambiguity: cases where the collapsed preview graph still contains a directed cycle after sub-assemblies are folded.

Instead of silently dropping an arbitrary joint, the UI now shows the cycle and lets the user choose which source joint should be removed from the collapsed preview tree.

## Background

When CAD sub-assemblies are collapsed into single robot links, multiple SolidWorks mates can create graph structures that are not valid URDF trees. One common case is a directed cycle between collapsed links.

SolidWorks mates do not define a single robot hierarchy, so automatically choosing which edge to remove can easily produce an unexpected tree. This PR follows the same con

servative approach as the earlier validation work: report the ambiguity, show the candidate joints, and let the user choose the intended cycle break.

For typical robot models, I expect that this cycle case will rarely be encountered if all relevant sub-assemblies are collapsed and the resulting parent-child relationships are resolved through the GUI.

However, future users may want to keep selected parts of the structure expanded between particular sub-assemblies while applying additional processing. Such a workflow should not become impossible solely because a cycle remains in the preview graph. Therefore, this PR provides a minimal cycle-break mechanism as a fallback for these less common cases.

This is not intended to be a comprehensive solution for arbitrary cyclic mechanisms, but rather a simple way to prevent partially expanded workflows from being blocked.


## Changes

- Detects directed cycles in the collapsed preview graph.
- Reports cycle issues with candidate preview joints and their source joints.
- Adds cycle break choices to the collapsed preview payload.
- Adds Web UI controls for selecting the source joint to drop from each cycle.
- Applies selected cycle break choices when rebuilding the collapsed preview tree.
- ~~Keeps selected cycle break choices visible as resolved/stale entries when appropriate.~~ Keeps saved cycle-break selections that are no longer on an active cycle visible as stale entries so users can reset them.
- Adds tests for cycle detection and cycle break behavior.

## User-Facing Behavior

In sub-assembly preview mode, when the collapsed graph contains a directed cycle, the UI now lists the cycle and the candidate joints that can be removed.
The user can choose one source joint as the cycle break. The preview is then rebuilt without that joint, allowing the collapsed sub-assembly tree to become a valid tree when the selected break resolves the cycle.

This makes the workflow explicit:

1. Collapse selected CAD sub-assemblies.
2. Validation reports ambiguous or invalid collapsed structure.
3. The user chooses parent direction where needed.
4. The user chooses member group anchors where needed.
5. The user chooses which joint should break each remaining cycle.

## Scope

This PR is preview-side only.

It does not change normal expanded robot behavior, normal tree editing, rename behavior, or normal Export. The goal is to add the missing user input needed for future collapsed-subassembly URDF output while preserving the existing workflow.

[kleiyn-demo (7).webm](https://github.com/user-attachments/assets/9f847f34-901c-452b-9b57-157584a7d3da)