### PR TITLE
Add preview-only motion driver joint choices for collapsed subassemblies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ tests/e2e/package-lock.json
 # e2e fixtures pristine -- the overlay sidecar + live copy are regenerated)
 tests/e2e/fixtures/**/*.sw2robot.json
 tests/e2e/fixtures/**/.*.live.urdf
+tests/e2e/fixtures/**/.*.expanded-preview-source.urdf
+tests/e2e/fixtures/**/.*.collapsed-preview.urdf
 _server*.txt
 _client_report.json
 _sldasm_index.json

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -1095,6 +1095,15 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
                                   ja: a => `サブアセンブリ原点linkを保存中: ${a.name} → ${a.originLink} ...` },
     'subasm.originLinkSetFail': { en: a => `origin link failed: ${a.e}`,
                                   ja: a => `サブアセンブリ原点linkの保存に失敗: ${a.e}` },
+    'subasm.driverJointChoicesTitle': { en: 'Motion driver joints',
+                                        ja: 'motion代表joint' },
+    'subasm.driverJointAuto': { en: 'auto', ja: 'auto' },
+    'subasm.driverJointSetOk': { en: a => `${a.name}: driver joint ${a.sourceJoint} ✓`,
+                                 ja: a => `${a.name}: driver joint ${a.sourceJoint} ✓` },
+    'subasm.driverJointSetting': { en: a => `saving driver joint: ${a.name} → ${a.sourceJoint} ...`,
+                                   ja: a => `motion代表jointを保存中: ${a.name} → ${a.sourceJoint} ...` },
+    'subasm.driverJointSetFail': { en: a => `driver joint failed: ${a.e}`,
+                                   ja: a => `motion代表jointの保存に失敗: ${a.e}` },
     'subasm.cycleBreakChoicesTitle': { en: 'Cycle break joints',
                                        ja: 'cycle解消joint' },
     'subasm.cycleBreakAuto': { en: 'auto', ja: 'auto' },
@@ -3018,6 +3027,90 @@ function bindSubassemblyOriginLinkChoices(root, ov) {
   });
 }
 
+function driverJointChoicesHtml(driverChoices) {
+  const choices = (driverChoices || []).filter(c =>
+    (c.candidates || []).length || c.selected_driver_joint);
+  if (!choices.length) { return ''; }
+  const rows = choices.map(c => {
+    const selected = c.selected_driver_joint || '';
+    const auto = c.auto_driver_joint || '';
+    const opts = [`<option value=""${selected ? '' : ' selected'}>` +
+      `${t('subasm.driverJointAuto')}${auto ? `: ${htmlEsc(auto)}` : ''}` +
+      `</option>`].concat((c.candidates || []).map(j => {
+        const source = j.source_joint || j.joint || '';
+        const edge = j.source_parent && j.source_child
+          ? `${j.source_parent} → ${j.source_child}`
+          : (j.parent && j.child ? `${j.parent} → ${j.child}` : source);
+        const label = `${j.role || 'joint'} ${j.type || ''}: ${edge}`;
+        return `<option value="${htmlEsc(source)}"` +
+          `${selected === source ? ' selected' : ''}>` +
+          `${htmlEsc(label)}</option>`;
+      })).join('');
+    const details = (c.candidates || []).slice(0, 5).map(j => {
+      const source = j.source_joint || j.joint || '';
+      const edge = j.source_parent && j.source_child
+        ? `${j.source_parent} → ${j.source_child}` : '';
+      const mov = j.movable ? 'movable' : 'fixed';
+      return `<div style="color:#6b7480">${htmlEsc(j.role || 'joint')}: ` +
+        `${htmlEsc(source)} ${htmlEsc(j.type || '')} ${htmlEsc(mov)}` +
+        `${edge ? ` (${htmlEsc(edge)})` : ''}</div>`;
+    }).join('');
+    const more = (c.candidates || []).length > 5
+      ? `<div style="color:#6b7480">+${(c.candidates || []).length - 5} more</div>`
+      : '';
+    return `<div style="display:grid;grid-template-columns:minmax(110px,1fr) ` +
+      `minmax(150px,1.7fr);gap:6px;align-items:start;margin-top:5px">` +
+      `<div><div style="color:#cfe3ff">${htmlEsc(c.subassembly)}</div>` +
+      `<div style="color:#6b7480">${htmlEsc(c.link_name)}</div></div>` +
+      `<div><select class="subasm-driver-joint-choice" ` +
+      `data-name="${htmlEsc(c.subassembly)}" data-prev="${htmlEsc(selected)}">` +
+      opts + `</select>${details}${more}</div></div>`;
+  }).join('');
+  return `<div style="border:1px solid #3d5244;background:#1f2a25;` +
+    `border-radius:4px;padding:6px 8px;margin:8px 0;font-size:11px">` +
+    `<div style="color:#9bd6ad">${t('subasm.driverJointChoicesTitle')}</div>` +
+    rows + `</div>`;
+}
+
+async function setSubassemblyDriverJointChoice(name, sourceJoint, ov) {
+  const label = sourceJoint || t('subasm.driverJointAuto');
+  op('subassembly_driver_joint', { name, source_joint: sourceJoint });
+  log(t('subasm.driverJointSetting', { name, sourceJoint: label }));
+  try {
+    const resp = await fetch('/api/set_subassembly_driver_joint', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, source_joint: sourceJoint }) });
+    const r = await resp.json();
+    if (!resp.ok || r.error) { throw new Error(r.error ?? resp.status); }
+    log(t('subasm.driverJointSetOk', { name, sourceJoint: label }), 'ok');
+    refreshHistory();
+    if (ov) {
+      await openSubassemblyPreview(ov);
+    }
+    if (viewer.robot && treeViewMode === 'subassembly') {
+      buildJointRows(viewer.robot);
+    }
+  } catch (e) {
+    log(t('subasm.driverJointSetFail', { e: e.message ?? e }), 'err');
+    if (ov) {
+      await openSubassemblyPreview(ov);
+    }
+  }
+}
+
+function bindSubassemblyDriverJointChoices(root, ov) {
+  root.querySelectorAll('.subasm-driver-joint-choice').forEach(sel => {
+    sel.addEventListener('change', () => {
+      const name = sel.dataset.name;
+      const sourceJoint = sel.value;
+      root.querySelectorAll('.subasm-driver-joint-choice')
+        .forEach(x => { x.disabled = true; });
+      setSubassemblyDriverJointChoice(name, sourceJoint, ov);
+    });
+  });
+}
+
 function cycleBreakChoicesHtml(cycleChoices) {
   const choices = (cycleChoices || []).filter(c =>
     (c.candidates || []).length || c.selected_source_joint);
@@ -3816,6 +3909,13 @@ async function renderSubassemblyTreeRows(robot, movable) {
       groups.innerHTML = groupChoices;
       jointsEl.appendChild(groups);
       bindSubassemblyOriginLinkChoices(groups);
+    }
+    const driverChoices = driverJointChoicesHtml(r.driver_joint_choices);
+    if (driverChoices) {
+      const drivers = document.createElement('div');
+      drivers.innerHTML = driverChoices;
+      jointsEl.appendChild(drivers);
+      bindSubassemblyDriverJointChoices(drivers);
     }
     const cycleChoices = cycleBreakChoicesHtml(r.cycle_break_choices);
     if (cycleChoices) {

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -3063,7 +3063,7 @@ function driverJointChoicesHtml(driverChoices) {
       `<div><div style="color:#cfe3ff">${htmlEsc(c.subassembly)}</div>` +
       `<div style="color:#6b7480">${htmlEsc(c.link_name)}</div></div>` +
       `<div><select class="subasm-driver-joint-choice" ` +
-      `data-name="${htmlEsc(c.subassembly)}" data-prev="${htmlEsc(selected)}">` +
+      `data-name="${htmlEsc(c.subassembly)}">` +
       opts + `</select>${details}${more}</div></div>`;
   }).join('');
   return `<div style="border:1px solid #3d5244;background:#1f2a25;` +
@@ -3087,6 +3087,9 @@ async function setSubassemblyDriverJointChoice(name, sourceJoint, ov) {
     refreshHistory();
     if (ov) {
       await openSubassemblyPreview(ov);
+    } else {
+      document.querySelectorAll('.subasm-driver-joint-choice')
+        .forEach(x => { x.disabled = false; });
     }
     if (viewer.robot && treeViewMode === 'subassembly') {
       buildJointRows(viewer.robot);
@@ -3095,6 +3098,9 @@ async function setSubassemblyDriverJointChoice(name, sourceJoint, ov) {
     log(t('subasm.driverJointSetFail', { e: e.message ?? e }), 'err');
     if (ov) {
       await openSubassemblyPreview(ov);
+    } else {
+      document.querySelectorAll('.subasm-driver-joint-choice')
+        .forEach(x => { x.disabled = false; });
     }
   }
 }
@@ -3398,6 +3404,7 @@ async function openSubassemblyPreview(ov) {
       validationIssuesHtml(r.validation) +
       parentChoicesHtml(r.parent_choices) +
       originLinkChoicesHtml(r.group_choices) +
+      driverJointChoicesHtml(r.driver_joint_choices) +
       cycleBreakChoicesHtml(r.cycle_break_choices);
     const rows = r.collapsed_subassemblies || [];
     if (!rows.length) {
@@ -3441,6 +3448,7 @@ async function openSubassemblyPreview(ov) {
     card.innerHTML = html;
     bindSubassemblyParentChoices(card, owned);
     bindSubassemblyOriginLinkChoices(card, owned);
+    bindSubassemblyDriverJointChoices(card, owned);
     bindSubassemblyCycleBreakChoices(card, owned);
     const bar = document.createElement('div');
     bar.style.cssText = 'display:flex;gap:8px;margin-top:10px';

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -1084,6 +1084,15 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
                               ja: a => `接続先parentを保存中: ${a.name} → ${a.parent} ...` },
     'subasm.parentSetFail': { en: a => `attach parent failed: ${a.e}`,
                               ja: a => `接続先parentの保存に失敗: ${a.e}` },
+    'subasm.originLinkChoicesTitle': { en: 'Sub-assembly origin links',
+                                      ja: 'サブアセンブリ原点link' },
+    'subasm.originLinkAuto': { en: 'auto', ja: 'auto' },
+    'subasm.originLinkSetOk': { en: a => `${a.name}: origin link ${a.originLink} ✓`,
+                                ja: a => `${a.name}: origin link ${a.originLink} ✓` },
+    'subasm.originLinkSetting': { en: a => `saving origin link: ${a.name} → ${a.originLink} ...`,
+                                  ja: a => `サブアセンブリ原点linkを保存中: ${a.name} → ${a.originLink} ...` },
+    'subasm.originLinkSetFail': { en: a => `origin link failed: ${a.e}`,
+                                  ja: a => `サブアセンブリ原点linkの保存に失敗: ${a.e}` },
     'subasm.backSubasm': { en: '← sub-assemblies', ja: '← サブアセンブリ' },
     'subasm.stateExpanded': { en: 'expanded', ja: '展開' },
     'subasm.stateKept': { en: 'kept as one link', ja: '1リンク保持' },
@@ -2898,6 +2907,79 @@ function bindSubassemblyParentChoices(root, ov) {
   });
 }
 
+function originLinkChoicesHtml(groupChoices) {
+  const choices = (groupChoices || []).filter(c =>
+    (c.groups || []).length > 1 || c.selected_origin_link);
+  if (!choices.length) { return ''; }
+  const rows = choices.map(c => {
+    const selected = c.selected_origin_link || '';
+    const opts = [`<option value=""${selected ? '' : ' selected'}>` +
+      `${t('subasm.originLinkAuto')}</option>`].concat((c.groups || []).map((g, i) => {
+      const label = `group ${i + 1} (${g.size || (g.links || []).length})`;
+      const originLink = g.origin_link || (g.links || [])[0] || '';
+      return `<option value="${htmlEsc(originLink)}"` +
+        `${selected === originLink ? ' selected' : ''}>` +
+        `${htmlEsc(label)} origin link: ${htmlEsc(originLink)}</option>`;
+    })).join('');
+    const groups = (c.groups || []).map((g, i) => {
+      const links = (g.links || []).slice(0, 4).map(htmlEsc).join(', ');
+      const more = (g.links || []).length > 4
+        ? `, +${(g.links || []).length - 4} more` : '';
+      return `<div style="color:#6b7480">group ${i + 1} links: ${links}${more}</div>`;
+    }).join('');
+    return `<div style="display:grid;grid-template-columns:minmax(110px,1fr) ` +
+      `minmax(120px,1.4fr);gap:6px;align-items:start;margin-top:5px">` +
+      `<div><div style="color:#cfe3ff">${htmlEsc(c.subassembly)}</div>` +
+      `<div style="color:#6b7480">${htmlEsc(c.link_name)}</div></div>` +
+      `<div><select class="subasm-origin-link-choice" ` +
+      `data-name="${htmlEsc(c.subassembly)}" data-prev="${htmlEsc(selected)}">` +
+      opts + `</select>${groups}</div></div>`;
+  }).join('');
+  return `<div style="border:1px solid #4d4536;background:#24231d;` +
+    `border-radius:4px;padding:6px 8px;margin:8px 0;font-size:11px">` +
+    `<div style="color:#d6c18c">${t('subasm.originLinkChoicesTitle')}</div>` +
+    rows + `</div>`;
+}
+
+async function setSubassemblyOriginLinkChoice(name, originLink, ov) {
+  const label = originLink || t('subasm.originLinkAuto');
+  op('subassembly_origin_link', { name, origin_link: originLink });
+  log(t('subasm.originLinkSetting', { name, originLink: label }));
+  try {
+    const resp = await fetch('/api/set_subassembly_origin_link', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, origin_link: originLink }) });
+    const r = await resp.json();
+    if (!resp.ok || r.error) { throw new Error(r.error ?? resp.status); }
+    log(t('subasm.originLinkSetOk', { name, originLink: label }), 'ok');
+    refreshHistory();
+    if (ov) {
+      await openSubassemblyPreview(ov);
+    }
+    if (viewer.robot && treeViewMode === 'subassembly') {
+      buildJointRows(viewer.robot);
+    }
+  } catch (e) {
+    log(t('subasm.originLinkSetFail', { e: e.message ?? e }), 'err');
+    if (ov) {
+      await openSubassemblyPreview(ov);
+    }
+  }
+}
+
+function bindSubassemblyOriginLinkChoices(root, ov) {
+  root.querySelectorAll('.subasm-origin-link-choice').forEach(sel => {
+    sel.addEventListener('change', () => {
+      const name = sel.dataset.name;
+      const originLink = sel.value;
+      root.querySelectorAll('.subasm-origin-link-choice')
+        .forEach(x => { x.disabled = true; });
+      setSubassemblyOriginLinkChoice(name, originLink, ov);
+    });
+  });
+}
+
 function pathBase(p) {
   const s = String(p ?? '');
   return s.split(/[\\/]/).pop() || s;
@@ -3049,7 +3131,8 @@ async function openSubassemblyPreview(ov) {
         pl: pc.links ?? 0, pj: pc.joints ?? 0,
       }) + '</div>' +
       validationIssuesHtml(r.validation) +
-      parentChoicesHtml(r.parent_choices);
+      parentChoicesHtml(r.parent_choices) +
+      originLinkChoicesHtml(r.group_choices);
     const rows = r.collapsed_subassemblies || [];
     if (!rows.length) {
       html += '<div style="color:#8a93a3">' + t('subasm.previewNone') + '</div>';
@@ -3091,6 +3174,7 @@ async function openSubassemblyPreview(ov) {
     }
     card.innerHTML = html;
     bindSubassemblyParentChoices(card, owned);
+    bindSubassemblyOriginLinkChoices(card, owned);
     const bar = document.createElement('div');
     bar.style.cssText = 'display:flex;gap:8px;margin-top:10px';
     const back = document.createElement('button');
@@ -3466,6 +3550,13 @@ async function renderSubassemblyTreeRows(robot, movable) {
       choices.innerHTML = choicesHtml;
       jointsEl.appendChild(choices);
       bindSubassemblyParentChoices(choices);
+    }
+    const groupChoices = originLinkChoicesHtml(r.group_choices);
+    if (groupChoices) {
+      const groups = document.createElement('div');
+      groups.innerHTML = groupChoices;
+      jointsEl.appendChild(groups);
+      bindSubassemblyOriginLinkChoices(groups);
     }
     const hint = document.createElement('div');
     hint.className = 'joint';

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -2850,7 +2850,7 @@ function parentChoicesHtml(parentChoices) {
       `<div><div style="color:#cfe3ff">${htmlEsc(c.subassembly)}</div>` +
       `<div style="color:#6b7480">${htmlEsc(c.link_name)}</div></div>` +
       `<div><select class="subasm-parent-choice" ` +
-      `data-name="${htmlEsc(c.subassembly)}" data-prev="${htmlEsc(selected)}">` +
+      `data-name="${htmlEsc(c.subassembly)}">` +
       opts + `</select>${joints}</div></div>`;
   }).join('');
   return `<div style="border:1px solid #3c4654;background:#1f242c;` +

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -2685,6 +2685,7 @@ let jointFilter = '';          // substring filter: when set, the tree collapses
                                // to exactly the matches (see buildJointRows)
 let treeViewMode = 'expanded'; // expanded = editable URDF tree; subassembly =
                                // read-only collapse_preview tree
+let robotViewMode = 'normal';  // normal | collapsed_preview
 let subasmTreeRequest = 0;     // discard stale async preview responses
 const playRows = new Map();    // joint name -> "move" mode slider record
 let playMode = false;          // movable-joints-only panel active
@@ -3661,19 +3662,26 @@ document.getElementById('masslistbtn').addEventListener('click', () => {
 });
 
 function syncTreeModeControls() {
-  const readonly = treeViewMode === 'subassembly';
+  const effectiveMode = robotViewMode === 'collapsed_preview'
+    ? 'subassembly' : treeViewMode;
+  const readonly = effectiveMode === 'subassembly';
   const treeMode = document.getElementById('treemode');
   if (treeMode) {
     treeMode.querySelector('option[value="expanded"]').textContent =
       t('tree.modeExpanded');
     treeMode.querySelector('option[value="subassembly"]').textContent =
       t('tree.modeSubassembly');
-    treeMode.value = treeViewMode;
+    treeMode.value = effectiveMode;
+    treeMode.disabled = robotViewMode === 'collapsed_preview';
   }
   for (const id of ['selall', 'bulktype', 'bulkset', 'bulkdel']) {
     const el = document.getElementById(id);
     if (el) { el.disabled = readonly; }
   }
+}
+
+function effectiveTreeViewMode() {
+  return robotViewMode === 'collapsed_preview' ? 'subassembly' : treeViewMode;
 }
 
 function previewTreeLinkSet(row) {
@@ -3697,7 +3705,9 @@ async function renderSubassemblyTreeRows(robot, movable) {
   try {
     const resp = await fetch('/api/collapse_preview');
     const r = await resp.json();
-    if (req !== subasmTreeRequest || treeViewMode !== 'subassembly') { return; }
+    if (req !== subasmTreeRequest || effectiveTreeViewMode() !== 'subassembly') {
+      return;
+    }
     if (!resp.ok || r.error) { throw new Error(r.error ?? resp.status); }
     const q = jointFilter.trim().toLowerCase();
     const allRows = r.tree_rows || [];
@@ -3778,7 +3788,9 @@ async function renderSubassemblyTreeRows(robot, movable) {
       jointsEl.appendChild(el);
     }
   } catch (e) {
-    if (req !== subasmTreeRequest || treeViewMode !== 'subassembly') { return; }
+    if (req !== subasmTreeRequest || effectiveTreeViewMode() !== 'subassembly') {
+      return;
+    }
     jointsEl.innerHTML = `<div class="joint" style="color:#ffb4b4">` +
       `${htmlEsc(t('tree.subasmUnavailable', { e: e.message ?? e }))}</div>`;
     if (countEl) { countEl.textContent = ''; }
@@ -3790,6 +3802,12 @@ function buildJointRows(robot) {
   jointsEl.innerHTML = '';
   rows.clear();
   syncTreeModeControls();
+  const movable = Object.values(robot?.joints ?? {})
+    .filter(j => j.jointType !== 'fixed').length;
+  if (effectiveTreeViewMode() === 'subassembly') {
+    renderSubassemblyTreeRows(robot, movable);
+    return movable;
+  }
   // kinematic tree: parent link -> [joint, ...]; root = never a child
   const linkOf = (j, tag) => [...(j.urdfNode?.children ?? [])]
     .find(el => el.tagName === tag)?.getAttribute('link') ?? '';
@@ -3805,15 +3823,6 @@ function buildJointRows(robot) {
     (a, b) => linkOf(a, 'child').localeCompare(linkOf(b, 'child'))));
   const roots = Object.keys(robot.links)
     .filter(n => !childLinks.has(n));
-  // total movable joints in the robot -- counted over the whole model so the
-  // status summary stays accurate regardless of collapse / filter view state.
-  const movable = Object.values(robot.joints)
-    .filter(j => j.jointType !== 'fixed').length;
-  if (treeViewMode === 'subassembly') {
-    renderSubassemblyTreeRows(robot, movable);
-    return movable;
-  }
-
   function jointRow(j, depth, flat) {
     const isMimic = !!j.mimicJoint;
     const isMov = j.jointType !== 'fixed';
@@ -8117,6 +8126,7 @@ function clearViewer() {
   const r = viewer.robot;
   if (r && r.parent) { r.parent.remove(r); }
   viewer.robot = null;
+  robotViewMode = 'normal';
   jointsEl.innerHTML = '';
   rows.clear();
   document.getElementById('selbar').style.display = 'none';
@@ -8141,6 +8151,7 @@ function loadRobot(info, { drop = false, keepPose = false,
   // fresh package -> drop the old actions/camera so they can't replay onto it
   if (!keepPose) { _resetSessionLogs(); }
   op('loadRobot', { name: info?.name, keepPose, drop, previewOnly });
+  robotViewMode = previewOnly ? 'collapsed_preview' : 'normal';
   cancelEndcoords();        // a rebuild invalidates any open placement session
   document.getElementById('emptyprompt').style.display = 'none';
   if (((keepPose || followCamera) && viewer.robot) || restoreAngles) {

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -2692,6 +2692,7 @@ let jointFilter = '';          // substring filter: when set, the tree collapses
 let treeViewMode = 'expanded'; // expanded = editable URDF tree; subassembly =
                                // read-only collapse_preview tree
 let robotViewMode = 'normal';  // normal | collapsed_preview
+let pendingRobotViewMode = null;
 let subasmTreeRequest = 0;     // discard stale async preview responses
 const playRows = new Map();    // joint name -> "move" mode slider record
 let playMode = false;          // movable-joints-only panel active
@@ -8038,6 +8039,10 @@ gridBtn.addEventListener('click', () => {
 });
 
 viewer.addEventListener('urdf-processed', () => {
+  if (pendingRobotViewMode) {
+    robotViewMode = pendingRobotViewMode;
+    pendingRobotViewMode = null;
+  }
   const n = buildJointRows(viewer.robot);
   if (playMode) { buildPlayRows(viewer.robot); }   // keep the move panel in sync
   log(t('urdf.parsed', { n: Object.keys(viewer.robot.links).length, m: n }), 'ok');
@@ -8139,6 +8144,7 @@ viewer.addEventListener('geometry-loaded', () => {
                          : t('status.summaryOk') });
 });
 viewer.addEventListener('urdf-error', e => {
+  pendingRobotViewMode = null;
   removeLoadCover();
   hideLoadbar();
   document.getElementById('loadbackdrop').style.display = 'none';
@@ -8207,6 +8213,7 @@ function clearViewer() {
   if (r && r.parent) { r.parent.remove(r); }
   viewer.robot = null;
   robotViewMode = 'normal';
+  pendingRobotViewMode = null;
   jointsEl.innerHTML = '';
   rows.clear();
   document.getElementById('selbar').style.display = 'none';
@@ -8231,7 +8238,7 @@ function loadRobot(info, { drop = false, keepPose = false,
   // fresh package -> drop the old actions/camera so they can't replay onto it
   if (!keepPose) { _resetSessionLogs(); }
   op('loadRobot', { name: info?.name, keepPose, drop, previewOnly });
-  robotViewMode = previewOnly ? 'collapsed_preview' : 'normal';
+  pendingRobotViewMode = previewOnly ? 'collapsed_preview' : 'normal';
   cancelEndcoords();        // a rebuild invalidates any open placement session
   document.getElementById('emptyprompt').style.display = 'none';
   if (((keepPose || followCamera) && viewer.robot) || restoreAngles) {

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -2909,10 +2909,15 @@ function bindSubassemblyParentChoices(root, ov) {
 
 function originLinkChoicesHtml(groupChoices) {
   const choices = (groupChoices || []).filter(c =>
-    (c.groups || []).length > 1 || c.selected_origin_link);
+    (c.groups || []).length > 1 || c.selected_origin_link ||
+    c.stale_origin_link);
   if (!choices.length) { return ''; }
   const rows = choices.map(c => {
     const selected = c.selected_origin_link || '';
+    const stale = c.stale_origin_link
+      ? `<div style="color:#d68c8c">stale saved link: ` +
+        `${htmlEsc(c.stale_origin_link)}</div>`
+      : '';
     const opts = [`<option value=""${selected ? '' : ' selected'}>` +
       `${t('subasm.originLinkAuto')}</option>`].concat((c.groups || []).map((g, i) => {
       const label = `group ${i + 1} (${g.size || (g.links || []).length})`;
@@ -2932,8 +2937,8 @@ function originLinkChoicesHtml(groupChoices) {
       `<div><div style="color:#cfe3ff">${htmlEsc(c.subassembly)}</div>` +
       `<div style="color:#6b7480">${htmlEsc(c.link_name)}</div></div>` +
       `<div><select class="subasm-origin-link-choice" ` +
-      `data-name="${htmlEsc(c.subassembly)}" data-prev="${htmlEsc(selected)}">` +
-      opts + `</select>${groups}</div></div>`;
+      `data-name="${htmlEsc(c.subassembly)}">` +
+      opts + `</select>${stale}${groups}</div></div>`;
   }).join('');
   return `<div style="border:1px solid #4d4536;background:#24231d;` +
     `border-radius:4px;padding:6px 8px;margin:8px 0;font-size:11px">` +
@@ -2964,6 +2969,9 @@ async function setSubassemblyOriginLinkChoice(name, originLink, ov) {
     log(t('subasm.originLinkSetFail', { e: e.message ?? e }), 'err');
     if (ov) {
       await openSubassemblyPreview(ov);
+    } else {
+      document.querySelectorAll('.subasm-origin-link-choice')
+        .forEach(x => { x.disabled = false; });
     }
   }
 }

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -3121,7 +3121,11 @@ async function loadCollapsedPreviewRobot() {
       ...currentInfo,
       name: `${currentInfo.name} collapsed preview`,
       urdf: r.urdf,
-    }, { keepPose: true, previewOnly: true });
+    }, {
+      keepPose: false,
+      previewOnly: true,
+      restoreAngles: captureJointAngles(viewer.robot),
+    });
     log(t('subasm.previewRobotOk'), 'ok');
   } catch (e) {
     log(t('subasm.previewRobotFail', { e: e.message ?? e }), 'err');
@@ -3130,7 +3134,7 @@ async function loadCollapsedPreviewRobot() {
 
 function loadNormalRobot() {
   if (!currentInfo) { log(t('common.openFirst'), 'wrn'); return; }
-  loadRobot(currentInfo, { keepPose: true });
+  loadRobot(currentInfo, { keepPose: false });
   log(t('subasm.normalRobotOk'), 'ok');
 }
 
@@ -7947,6 +7951,16 @@ let pendingRestore = null;   // {angles} saved across an edit-rebuild reload
 let loadCover = null;        // visual clone shown while the URDF reloads,
                              // so re-root / type edits never flash blank
 
+function captureJointAngles(robot) {
+  const angles = {};
+  for (const [n, j] of Object.entries(robot?.joints ?? {})) {
+    if (j.jointType !== 'fixed' && !j.mimicJoint) {
+      angles[n] = Number(j.angle);
+    }
+  }
+  return angles;
+}
+
 function removeLoadCover() {
   if (loadCover) {
     loadCover.removeFromParent();
@@ -8115,20 +8129,16 @@ document.getElementById('clearview').addEventListener('click', clearViewer);
 
 // ---- loading entry points -----------------------------------------------
 function loadRobot(info, { drop = false, keepPose = false,
-                           followCamera = false, previewOnly = false } = {}) {
+                           followCamera = false, previewOnly = false,
+                           restoreAngles = null } = {}) {
   // a keepPose reload is the SAME session (edit rebuild); anything else is a
   // fresh package -> drop the old actions/camera so they can't replay onto it
   if (!keepPose) { _resetSessionLogs(); }
   op('loadRobot', { name: info?.name, keepPose, drop, previewOnly });
   cancelEndcoords();        // a rebuild invalidates any open placement session
   document.getElementById('emptyprompt').style.display = 'none';
-  if ((keepPose || followCamera) && viewer.robot) {
-    const angles = {};
-    for (const [n, j] of Object.entries(viewer.robot.joints)) {
-      if (j.jointType !== 'fixed' && !j.mimicJoint) {
-        angles[n] = Number(j.angle);
-      }
-    }
+  if (((keepPose || followCamera) && viewer.robot) || restoreAngles) {
+    const angles = restoreAngles || captureJointAngles(viewer.robot);
     let linkWorlds = null;
     if (followCamera) {
       viewer.robot.updateMatrixWorld(true);

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -1075,6 +1075,15 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     'subasm.thMembers': { en: 'members', ja: '構成link' },
     'subasm.thDropped': { en: 'internal joints', ja: '内部joint' },
     'subasm.collapsedTag': { en: 'collapsed', ja: '畳み込み' },
+    'subasm.parentChoicesTitle': { en: 'Attach parent choices',
+                                   ja: '接続先parent候補' },
+    'subasm.parentAuto': { en: 'auto', ja: 'auto' },
+    'subasm.parentSetOk': { en: a => `${a.name}: attach parent ${a.parent} ✓`,
+                            ja: a => `${a.name}: attach parent ${a.parent} ✓` },
+    'subasm.parentSetting': { en: a => `saving attach parent: ${a.name} → ${a.parent} ...`,
+                              ja: a => `接続先parentを保存中: ${a.name} → ${a.parent} ...` },
+    'subasm.parentSetFail': { en: a => `attach parent failed: ${a.e}`,
+                              ja: a => `接続先parentの保存に失敗: ${a.e}` },
     'subasm.backSubasm': { en: '← sub-assemblies', ja: '← サブアセンブリ' },
     'subasm.stateExpanded': { en: 'expanded', ja: '展開' },
     'subasm.stateKept': { en: 'kept as one link', ja: '1リンク保持' },
@@ -2820,6 +2829,75 @@ function validationIssuesHtml(validation) {
     rows + more + `</div>`;
 }
 
+function parentChoicesHtml(parentChoices) {
+  const choices = (parentChoices || []).filter(c =>
+    (c.parents || []).length > 1 || c.selected_parent);
+  if (!choices.length) { return ''; }
+  const rows = choices.map(c => {
+    const selected = c.selected_parent || '';
+    const opts = [`<option value=""${selected ? '' : ' selected'}>` +
+      `${t('subasm.parentAuto')}</option>`].concat((c.parents || []).map(p =>
+      `<option value="${htmlEsc(p.link)}"${selected === p.link ? ' selected' : ''}>` +
+      `${htmlEsc(p.link)}</option>`)).join('');
+    const joints = (c.parents || []).map(p => {
+      const js = (p.joints || []).slice(0, 3).map(htmlEsc).join(', ');
+      const more = (p.joints || []).length > 3
+        ? `, +${(p.joints || []).length - 3} more` : '';
+      return `<div style="color:#6b7480">${htmlEsc(p.link)}: ${js}${more}</div>`;
+    }).join('');
+    return `<div style="display:grid;grid-template-columns:minmax(110px,1fr) ` +
+      `minmax(120px,1.4fr);gap:6px;align-items:start;margin-top:5px">` +
+      `<div><div style="color:#cfe3ff">${htmlEsc(c.subassembly)}</div>` +
+      `<div style="color:#6b7480">${htmlEsc(c.link_name)}</div></div>` +
+      `<div><select class="subasm-parent-choice" ` +
+      `data-name="${htmlEsc(c.subassembly)}" data-prev="${htmlEsc(selected)}">` +
+      opts + `</select>${joints}</div></div>`;
+  }).join('');
+  return `<div style="border:1px solid #3c4654;background:#1f242c;` +
+    `border-radius:4px;padding:6px 8px;margin:8px 0;font-size:11px">` +
+    `<div style="color:#9fb7de">${t('subasm.parentChoicesTitle')}</div>` +
+    rows + `</div>`;
+}
+
+async function setSubassemblyParentChoice(name, parent, ov) {
+  const label = parent || t('subasm.parentAuto');
+  op('subassembly_parent', { name, parent });
+  log(t('subasm.parentSetting', { name, parent: label }));
+  try {
+    const resp = await fetch('/api/set_subassembly_parent', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, parent }) });
+    const r = await resp.json();
+    if (!resp.ok || r.error) { throw new Error(r.error ?? resp.status); }
+    log(t('subasm.parentSetOk', { name, parent: label }), 'ok');
+    refreshHistory();
+    if (ov) {
+      await openSubassemblyPreview(ov);
+    }
+    if (viewer.robot && treeViewMode === 'subassembly') {
+      buildJointRows(viewer.robot);
+    }
+  } catch (e) {
+    log(t('subasm.parentSetFail', { e: e.message ?? e }), 'err');
+    if (ov) {
+      await openSubassemblyPreview(ov);
+    }
+  }
+}
+
+function bindSubassemblyParentChoices(root, ov) {
+  root.querySelectorAll('.subasm-parent-choice').forEach(sel => {
+    sel.addEventListener('change', () => {
+      const name = sel.dataset.name;
+      const parent = sel.value;
+      root.querySelectorAll('.subasm-parent-choice')
+        .forEach(x => { x.disabled = true; });
+      setSubassemblyParentChoice(name, parent, ov);
+    });
+  });
+}
+
 function pathBase(p) {
   const s = String(p ?? '');
   return s.split(/[\\/]/).pop() || s;
@@ -2970,7 +3048,8 @@ async function openSubassemblyPreview(ov) {
         cl: cc.links ?? 0, cj: cc.joints ?? 0,
         pl: pc.links ?? 0, pj: pc.joints ?? 0,
       }) + '</div>' +
-      validationIssuesHtml(r.validation);
+      validationIssuesHtml(r.validation) +
+      parentChoicesHtml(r.parent_choices);
     const rows = r.collapsed_subassemblies || [];
     if (!rows.length) {
       html += '<div style="color:#8a93a3">' + t('subasm.previewNone') + '</div>';
@@ -3011,6 +3090,7 @@ async function openSubassemblyPreview(ov) {
       html += '</tbody></table>';
     }
     card.innerHTML = html;
+    bindSubassemblyParentChoices(card, owned);
     const bar = document.createElement('div');
     bar.style.cssText = 'display:flex;gap:8px;margin-top:10px';
     const back = document.createElement('button');
@@ -3379,6 +3459,13 @@ async function renderSubassemblyTreeRows(robot, movable) {
       const warn = document.createElement('div');
       warn.innerHTML = validationHtml;
       jointsEl.appendChild(warn);
+    }
+    const choicesHtml = parentChoicesHtml(r.parent_choices);
+    if (choicesHtml) {
+      const choices = document.createElement('div');
+      choices.innerHTML = choicesHtml;
+      jointsEl.appendChild(choices);
+      bindSubassemblyParentChoices(choices);
     }
     const hint = document.createElement('div');
     hint.className = 'joint';

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -3668,8 +3668,10 @@ document.getElementById('masslistbtn').addEventListener('click', () => {
 });
 
 function syncTreeModeControls() {
+  const subassemblyModeAvailable = currentInfo?.mode !== 'urdf';
   const effectiveMode = robotViewMode === 'collapsed_preview'
-    ? 'subassembly' : treeViewMode;
+    ? 'subassembly'
+    : subassemblyModeAvailable ? treeViewMode : 'expanded';
   const readonly = effectiveMode === 'subassembly';
   const treeMode = document.getElementById('treemode');
   if (treeMode) {
@@ -3678,7 +3680,8 @@ function syncTreeModeControls() {
     treeMode.querySelector('option[value="subassembly"]').textContent =
       t('tree.modeSubassembly');
     treeMode.value = effectiveMode;
-    treeMode.disabled = robotViewMode === 'collapsed_preview';
+    treeMode.disabled = robotViewMode === 'collapsed_preview'
+      || !subassemblyModeAvailable;
   }
   for (const id of ['selall', 'bulktype', 'bulkset', 'bulkdel']) {
     const el = document.getElementById(id);
@@ -3687,7 +3690,8 @@ function syncTreeModeControls() {
 }
 
 function effectiveTreeViewMode() {
-  return robotViewMode === 'collapsed_preview' ? 'subassembly' : treeViewMode;
+  if (robotViewMode === 'collapsed_preview') { return 'subassembly'; }
+  return currentInfo?.mode === 'urdf' ? 'expanded' : treeViewMode;
 }
 
 function previewTreeLinkSet(row) {

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -1129,6 +1129,12 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
                                  ja: a => `畳み込みロボットpreviewに失敗: ${a.e}` },
     'subasm.normalRobotOk': { en: 'normal robot loaded',
                               ja: '通常ロボットを読み込みました' },
+    'subasm.previewSlidersTitle': { en: 'Collapsed preview joints',
+                                    ja: '畳み込みpreview joint' },
+    'subasm.previewSlidersHelp': { en: 'Preview-only controls for the currently displayed collapsed robot.',
+                                   ja: '表示中の畳み込みロボットだけを動かすpreview専用操作です。' },
+    'subasm.previewSlidersEmpty': { en: 'No movable preview joints.',
+                                    ja: '動かせるpreview jointがありません。' },
     'subasm.largeConfirm': {
       en: a => `${a.name} contains ${a.children} children and ${a.edges} mates. Changing a large sub-assembly can take a long time. Continue?`,
       ja: a => `${a.name} は子 ${a.children} 個、mate ${a.edges} 個を含みます。大きいサブアセンブリの切り替えには時間がかかることがあります。続行しますか？` },
@@ -3695,6 +3701,72 @@ function highlightPreviewTreeRow(row, on) {
   }
 }
 
+function collapsedPreviewSlidersHtml(plan) {
+  if (robotViewMode !== 'collapsed_preview') { return null; }
+  const seen = new Set();
+  const joints = [];
+  for (const row of (plan?.joints || [])) {
+    const name = row.name || '';
+    if (!name || seen.has(name)) { continue; }
+    seen.add(name);
+    const j = viewer.robot?.joints?.[name];
+    if (!j || j.jointType === 'fixed' || j.mimicJoint) { continue; }
+    joints.push({ row, joint: j });
+  }
+  const card = document.createElement('div');
+  card.className = 'joint';
+  card.style.cssText = 'border:1px solid #39465a;background:#1e2630;' +
+    'border-radius:4px;padding:6px 8px;margin:8px 0';
+  const title = document.createElement('div');
+  title.style.cssText = 'color:#cfe3ff;font-size:12px;margin-bottom:2px';
+  title.textContent = t('subasm.previewSlidersTitle');
+  card.appendChild(title);
+  const help = document.createElement('div');
+  help.style.cssText = 'color:#8a93a3;font-size:11px;margin-bottom:6px';
+  help.textContent = joints.length
+    ? t('subasm.previewSlidersHelp')
+    : t('subasm.previewSlidersEmpty');
+  card.appendChild(help);
+  for (const { row, joint } of joints) {
+    const [lo, hi] = _jointLimits(joint);
+    const um = _jointUnit(joint.jointType);
+    const fmtDisp = v => {
+      let d = um.toDisp(Number(v) || 0);
+      if (Object.is(d, -0) || Math.abs(d) < Math.pow(10, -um.dec) / 2) { d = 0; }
+      return d.toFixed(um.dec) + um.unit;
+    };
+    const item = document.createElement('div');
+    item.style.cssText = 'margin-top:6px';
+    const label = row.child || joint.name;
+    const source = row.source_joint || '';
+    const nativeStep = um.pris ? 0.0005 : 0.01;
+    item.innerHTML =
+      `<div class="row1">` +
+      `<span class="caret">·</span>` +
+      `<span class="jname" title="${htmlEsc(joint.name)}">${htmlEsc(label)}</span>` +
+      `<span class="jtype">${htmlEsc(joint.jointType)}</span>` +
+      `<span class="jval">${htmlEsc(fmtDisp(Number(joint.angle) || 0))}</span>` +
+      `</div>` +
+      `<div style="color:#6b7480;font-size:10px;overflow:hidden;` +
+      `text-overflow:ellipsis;white-space:nowrap;margin-left:17px">` +
+      `${htmlEsc(source || joint.name)}</div>` +
+      `<div class="jslider" style="margin-left:17px">` +
+      `<input type="range" min="${lo}" max="${hi}" step="${nativeStep}" ` +
+      `value="${Number(joint.angle) || 0}"></div>`;
+    const slider = item.querySelector('input[type=range]');
+    const val = item.querySelector('.jval');
+    slider.addEventListener('input', () => {
+      previewJoint(joint.name, parseFloat(slider.value));
+    });
+    item.querySelector('.jname')?.addEventListener('click', () => {
+      if (row.child && viewer.robot?.links?.[row.child]) { selectLink(row.child); }
+    });
+    rows.set(joint.name, { joint, row: item, slider, val, fmtDisp });
+    card.appendChild(item);
+  }
+  return card;
+}
+
 async function renderSubassemblyTreeRows(robot, movable) {
   const req = ++subasmTreeRequest;
   rows.clear();
@@ -3746,6 +3818,10 @@ async function renderSubassemblyTreeRows(robot, movable) {
       cycles.innerHTML = cycleChoices;
       jointsEl.appendChild(cycles);
       bindSubassemblyCycleBreakChoices(cycles);
+    }
+    const previewSliders = collapsedPreviewSlidersHtml(r.collapse_plan);
+    if (previewSliders) {
+      jointsEl.appendChild(previewSliders);
     }
     const hint = document.createElement('div');
     hint.className = 'joint';

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -1061,6 +1061,8 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     'subasm.thPath': { en: 'file', ja: 'ファイル' },
     'subasm.back': { en: '← rename list', ja: '← 改名リスト' },
     'subasm.previewBtn': { en: 'preview collapse', ja: '畳み込み preview' },
+    'subasm.previewRobotBtn': { en: 'preview robot', ja: 'ロボットpreview' },
+    'subasm.normalRobotBtn': { en: 'normal robot', ja: '通常ロボット' },
     'subasm.previewTitle': { en: 'Sub-assembly collapse preview',
                              ja: 'サブアセンブリ畳み込み preview' },
     'subasm.previewHelp': { en: 'Read-only preview from the canonical expanded tree. URDF output is not changed here.',
@@ -1119,6 +1121,14 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
                              ja: a => `${a.name}: ${a.mode} ✓ (preview更新・URDF/viewerは未変更)` },
     'subasm.setFail': { en: a => `sub-assembly mode failed: ${a.e}`,
                         ja: a => `サブアセンブリモード変更に失敗: ${a.e}` },
+    'subasm.previewRobotLoading': { en: 'building collapsed preview robot...',
+                                    ja: '畳み込みロボットpreviewを生成中...' },
+    'subasm.previewRobotOk': { en: 'collapsed preview robot loaded',
+                               ja: '畳み込みロボットpreviewを読み込みました' },
+    'subasm.previewRobotFail': { en: a => `collapsed preview robot failed: ${a.e}`,
+                                 ja: a => `畳み込みロボットpreviewに失敗: ${a.e}` },
+    'subasm.normalRobotOk': { en: 'normal robot loaded',
+                              ja: '通常ロボットを読み込みました' },
     'subasm.largeConfirm': {
       en: a => `${a.name} contains ${a.children} children and ${a.edges} mates. Changing a large sub-assembly can take a long time. Continue?`,
       ja: a => `${a.name} は子 ${a.children} 個、mate ${a.edges} 個を含みます。大きいサブアセンブリの切り替えには時間がかかることがあります。続行しますか？` },
@@ -3100,6 +3110,30 @@ function bindSubassemblyCycleBreakChoices(root, ov) {
   });
 }
 
+async function loadCollapsedPreviewRobot() {
+  if (!currentInfo) { log(t('common.openFirst'), 'wrn'); return; }
+  log(t('subasm.previewRobotLoading'));
+  try {
+    const resp = await fetch('/api/collapsed_preview_urdf');
+    const r = await resp.json();
+    if (!resp.ok || r.error) { throw new Error(r.error ?? resp.status); }
+    loadRobot({
+      ...currentInfo,
+      name: `${currentInfo.name} collapsed preview`,
+      urdf: r.urdf,
+    }, { keepPose: true, previewOnly: true });
+    log(t('subasm.previewRobotOk'), 'ok');
+  } catch (e) {
+    log(t('subasm.previewRobotFail', { e: e.message ?? e }), 'err');
+  }
+}
+
+function loadNormalRobot() {
+  if (!currentInfo) { log(t('common.openFirst'), 'wrn'); return; }
+  loadRobot(currentInfo, { keepPose: true });
+  log(t('subasm.normalRobotOk'), 'ok');
+}
+
 function pathBase(p) {
   const s = String(p ?? '');
   return s.split(/[\\/]/).pop() || s;
@@ -3302,10 +3336,16 @@ async function openSubassemblyPreview(ov) {
     const back = document.createElement('button');
     back.textContent = t('subasm.backSubasm');
     back.addEventListener('click', () => openSubassemblyList(owned));
+    const previewRobot = document.createElement('button');
+    previewRobot.textContent = t('subasm.previewRobotBtn');
+    previewRobot.addEventListener('click', () => loadCollapsedPreviewRobot());
+    const normalRobot = document.createElement('button');
+    normalRobot.textContent = t('subasm.normalRobotBtn');
+    normalRobot.addEventListener('click', () => loadNormalRobot());
     const close = document.createElement('button');
     close.textContent = t('common.close');
     close.addEventListener('click', () => owned.remove());
-    bar.append(back, close);
+    bar.append(back, previewRobot, normalRobot, close);
     card.appendChild(bar);
     owned.replaceChildren(card);
     if (!owned.parentElement) {
@@ -8075,11 +8115,11 @@ document.getElementById('clearview').addEventListener('click', clearViewer);
 
 // ---- loading entry points -----------------------------------------------
 function loadRobot(info, { drop = false, keepPose = false,
-                           followCamera = false } = {}) {
+                           followCamera = false, previewOnly = false } = {}) {
   // a keepPose reload is the SAME session (edit rebuild); anything else is a
   // fresh package -> drop the old actions/camera so they can't replay onto it
   if (!keepPose) { _resetSessionLogs(); }
-  op('loadRobot', { name: info?.name, keepPose, drop });
+  op('loadRobot', { name: info?.name, keepPose, drop, previewOnly });
   cancelEndcoords();        // a rebuild invalidates any open placement session
   document.getElementById('emptyprompt').style.display = 'none';
   if ((keepPose || followCamera) && viewer.robot) {
@@ -8100,8 +8140,15 @@ function loadRobot(info, { drop = false, keepPose = false,
     pendingRestore = { angles, linkWorlds };
   }
   dropMode = drop;
-  if (!drop) { viewer.urlModifierFunc = null; currentInfo = info; }
-  else { currentInfo = null; }
+  if (drop) {
+    currentInfo = null;
+    viewer.urlModifierFunc = null;
+  } else {
+    viewer.urlModifierFunc = null;
+    if (!previewOnly) {
+      currentInfo = info;
+    }
+  }
   refreshExportName();          // export field placeholder follows the open pkg
   // cover the reload gap with a display-only clone of the current robot
   // (same world pose -> the swap is pixel-invisible); geometry/materials
@@ -8129,7 +8176,7 @@ function loadRobot(info, { drop = false, keepPose = false,
   document.getElementById('linkinfo').style.display = 'none';
   document.getElementById('title').textContent = info.name;
   document.title = `${info.name} — sw2robot`;
-  if (!drop) {
+  if (!drop && !previewOnly) {
     refreshRootBox({ resetBaseline: true });
     refreshCompMeta();
   }

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -1096,8 +1096,9 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     'subasm.cycleBreakChoicesTitle': { en: 'Cycle break joints',
                                        ja: 'cycle解消joint' },
     'subasm.cycleBreakAuto': { en: 'auto', ja: 'auto' },
-    'subasm.cycleBreakResolved': { en: 'resolved by selected drop',
-                                   ja: '選択したdropで解消済み' },
+    'subasm.cycleBreakStale': {
+      en: 'saved drop is not on an active cycle; reset to auto if no longer needed',
+      ja: '保存済みdropは現在のcycle候補にありません。不要ならautoに戻してください' },
     'subasm.cycleBreakSetOk': { en: a => `cycle break ${a.sourceJoint} ✓`,
                                 ja: a => `cycle break ${a.sourceJoint} ✓` },
     'subasm.cycleBreakSetting': { en: a => `saving cycle break: ${a.sourceJoint} ...`,
@@ -3005,6 +3006,7 @@ function cycleBreakChoicesHtml(cycleChoices) {
   if (!choices.length) { return ''; }
   const rows = choices.map((c, i) => {
     const selected = c.selected_source_joint || '';
+    const stale = !!c.stale;
     const seen = new Set();
     const opts = [`<option value=""${selected ? '' : ' selected'}>` +
       `${t('subasm.cycleBreakAuto')}</option>`].concat((c.candidates || [])
@@ -3021,10 +3023,10 @@ function cycleBreakChoicesHtml(cycleChoices) {
           `${selected === source ? ' selected' : ''}>` +
           `drop: ${htmlEsc(edge)}</option>`;
       })).join('');
-    const path = (c.links || []).length
-      ? `<div style="color:#6b7480">links: ` +
-        `${(c.links || []).map(htmlEsc).join(' → ')}</div>`
-      : `<div style="color:#6b7480">${t('subasm.cycleBreakResolved')}</div>`;
+    const path = stale
+      ? `<div style="color:#d6c18c">${t('subasm.cycleBreakStale')}</div>`
+      : `<div style="color:#6b7480">links: ` +
+        `${(c.links || []).map(htmlEsc).join(' → ')}</div>`;
     const joints = (c.candidates || []).map(j => {
       const source = j.source_joint || j.joint || '';
       const edge = j.parent && j.child ? `${j.parent} → ${j.child}` : '';
@@ -3033,7 +3035,7 @@ function cycleBreakChoicesHtml(cycleChoices) {
     }).join('');
     return `<div style="display:grid;grid-template-columns:minmax(80px,0.6fr) ` +
       `minmax(150px,1.8fr);gap:6px;align-items:start;margin-top:5px">` +
-      `<div><div style="color:#cfe3ff">cycle ${i + 1}</div>` +
+      `<div><div style="color:#cfe3ff">${stale ? 'saved drop' : `cycle ${i + 1}`}</div>` +
       path + `</div>` +
       `<div><select class="subasm-cycle-break-choice" ` +
       `data-prev="${htmlEsc(selected)}">` + opts +
@@ -3068,6 +3070,9 @@ async function setSubassemblyCycleBreakChoice(sourceJoint, previousSourceJoint, 
     refreshHistory();
     if (ov) {
       await openSubassemblyPreview(ov);
+    } else {
+      document.querySelectorAll('.subasm-cycle-break-choice')
+        .forEach(x => { x.disabled = false; });
     }
     if (viewer.robot && treeViewMode === 'subassembly') {
       buildJointRows(viewer.robot);
@@ -3076,6 +3081,9 @@ async function setSubassemblyCycleBreakChoice(sourceJoint, previousSourceJoint, 
     log(t('subasm.cycleBreakSetFail', { e: e.message ?? e }), 'err');
     if (ov) {
       await openSubassemblyPreview(ov);
+    } else {
+      document.querySelectorAll('.subasm-cycle-break-choice')
+        .forEach(x => { x.disabled = false; });
     }
   }
 }

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -1093,6 +1093,17 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
                                   ja: a => `サブアセンブリ原点linkを保存中: ${a.name} → ${a.originLink} ...` },
     'subasm.originLinkSetFail': { en: a => `origin link failed: ${a.e}`,
                                   ja: a => `サブアセンブリ原点linkの保存に失敗: ${a.e}` },
+    'subasm.cycleBreakChoicesTitle': { en: 'Cycle break joints',
+                                       ja: 'cycle解消joint' },
+    'subasm.cycleBreakAuto': { en: 'auto', ja: 'auto' },
+    'subasm.cycleBreakResolved': { en: 'resolved by selected drop',
+                                   ja: '選択したdropで解消済み' },
+    'subasm.cycleBreakSetOk': { en: a => `cycle break ${a.sourceJoint} ✓`,
+                                ja: a => `cycle break ${a.sourceJoint} ✓` },
+    'subasm.cycleBreakSetting': { en: a => `saving cycle break: ${a.sourceJoint} ...`,
+                                  ja: a => `cycle解消jointを保存中: ${a.sourceJoint} ...` },
+    'subasm.cycleBreakSetFail': { en: a => `cycle break failed: ${a.e}`,
+                                  ja: a => `cycle解消jointの保存に失敗: ${a.e}` },
     'subasm.backSubasm': { en: '← sub-assemblies', ja: '← サブアセンブリ' },
     'subasm.stateExpanded': { en: 'expanded', ja: '展開' },
     'subasm.stateKept': { en: 'kept as one link', ja: '1リンク保持' },
@@ -2988,6 +2999,99 @@ function bindSubassemblyOriginLinkChoices(root, ov) {
   });
 }
 
+function cycleBreakChoicesHtml(cycleChoices) {
+  const choices = (cycleChoices || []).filter(c =>
+    (c.candidates || []).length || c.selected_source_joint);
+  if (!choices.length) { return ''; }
+  const rows = choices.map((c, i) => {
+    const selected = c.selected_source_joint || '';
+    const seen = new Set();
+    const opts = [`<option value=""${selected ? '' : ' selected'}>` +
+      `${t('subasm.cycleBreakAuto')}</option>`].concat((c.candidates || [])
+      .filter(j => {
+        const source = j.source_joint || j.joint || '';
+        if (!source || seen.has(source)) { return false; }
+        seen.add(source);
+        return true;
+      }).map(j => {
+        const source = j.source_joint || j.joint || '';
+        const edge = j.parent && j.child
+          ? `${j.parent} → ${j.child}` : source;
+        return `<option value="${htmlEsc(source)}"` +
+          `${selected === source ? ' selected' : ''}>` +
+          `drop: ${htmlEsc(edge)}</option>`;
+      })).join('');
+    const path = (c.links || []).length
+      ? `<div style="color:#6b7480">links: ` +
+        `${(c.links || []).map(htmlEsc).join(' → ')}</div>`
+      : `<div style="color:#6b7480">${t('subasm.cycleBreakResolved')}</div>`;
+    const joints = (c.candidates || []).map(j => {
+      const source = j.source_joint || j.joint || '';
+      const edge = j.parent && j.child ? `${j.parent} → ${j.child}` : '';
+      return `<div style="color:#6b7480">${htmlEsc(source)}` +
+        `${edge ? `: ${htmlEsc(edge)}` : ''}</div>`;
+    }).join('');
+    return `<div style="display:grid;grid-template-columns:minmax(80px,0.6fr) ` +
+      `minmax(150px,1.8fr);gap:6px;align-items:start;margin-top:5px">` +
+      `<div><div style="color:#cfe3ff">cycle ${i + 1}</div>` +
+      path + `</div>` +
+      `<div><select class="subasm-cycle-break-choice" ` +
+      `data-prev="${htmlEsc(selected)}">` + opts +
+      `</select>${joints}</div></div>`;
+  }).join('');
+  return `<div style="border:1px solid #5a3940;background:#271e22;` +
+    `border-radius:4px;padding:6px 8px;margin:8px 0;font-size:11px">` +
+    `<div style="color:#e2a6b1">${t('subasm.cycleBreakChoicesTitle')}</div>` +
+    rows + `</div>`;
+}
+
+async function setSubassemblyCycleBreakChoice(sourceJoint, previousSourceJoint, ov) {
+  const label = sourceJoint || t('subasm.cycleBreakAuto');
+  const target = sourceJoint || previousSourceJoint;
+  op('subassembly_cycle_break', {
+    source_joint: sourceJoint,
+    previous_source_joint: previousSourceJoint,
+  });
+  log(t('subasm.cycleBreakSetting', { sourceJoint: label }));
+  try {
+    const resp = await fetch('/api/set_subassembly_cycle_break', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        source_joint: sourceJoint,
+        previous_source_joint: previousSourceJoint,
+        drop: !!sourceJoint,
+      }) });
+    const r = await resp.json();
+    if (!resp.ok || r.error) { throw new Error(r.error ?? resp.status); }
+    log(t('subasm.cycleBreakSetOk', { sourceJoint: target || label }), 'ok');
+    refreshHistory();
+    if (ov) {
+      await openSubassemblyPreview(ov);
+    }
+    if (viewer.robot && treeViewMode === 'subassembly') {
+      buildJointRows(viewer.robot);
+    }
+  } catch (e) {
+    log(t('subasm.cycleBreakSetFail', { e: e.message ?? e }), 'err');
+    if (ov) {
+      await openSubassemblyPreview(ov);
+    }
+  }
+}
+
+function bindSubassemblyCycleBreakChoices(root, ov) {
+  root.querySelectorAll('.subasm-cycle-break-choice').forEach(sel => {
+    sel.addEventListener('change', () => {
+      const sourceJoint = sel.value;
+      const previousSourceJoint = sel.dataset.prev || '';
+      root.querySelectorAll('.subasm-cycle-break-choice')
+        .forEach(x => { x.disabled = true; });
+      setSubassemblyCycleBreakChoice(sourceJoint, previousSourceJoint, ov);
+    });
+  });
+}
+
 function pathBase(p) {
   const s = String(p ?? '');
   return s.split(/[\\/]/).pop() || s;
@@ -3140,7 +3244,8 @@ async function openSubassemblyPreview(ov) {
       }) + '</div>' +
       validationIssuesHtml(r.validation) +
       parentChoicesHtml(r.parent_choices) +
-      originLinkChoicesHtml(r.group_choices);
+      originLinkChoicesHtml(r.group_choices) +
+      cycleBreakChoicesHtml(r.cycle_break_choices);
     const rows = r.collapsed_subassemblies || [];
     if (!rows.length) {
       html += '<div style="color:#8a93a3">' + t('subasm.previewNone') + '</div>';
@@ -3183,6 +3288,7 @@ async function openSubassemblyPreview(ov) {
     card.innerHTML = html;
     bindSubassemblyParentChoices(card, owned);
     bindSubassemblyOriginLinkChoices(card, owned);
+    bindSubassemblyCycleBreakChoices(card, owned);
     const bar = document.createElement('div');
     bar.style.cssText = 'display:flex;gap:8px;margin-top:10px';
     const back = document.createElement('button');
@@ -3565,6 +3671,13 @@ async function renderSubassemblyTreeRows(robot, movable) {
       groups.innerHTML = groupChoices;
       jointsEl.appendChild(groups);
       bindSubassemblyOriginLinkChoices(groups);
+    }
+    const cycleChoices = cycleBreakChoicesHtml(r.cycle_break_choices);
+    if (cycleChoices) {
+      const cycles = document.createElement('div');
+      cycles.innerHTML = cycleChoices;
+      jointsEl.appendChild(cycles);
+      bindSubassemblyCycleBreakChoices(cycles);
     }
     const hint = document.createElement('div');
     hint.className = 'joint';

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -3126,6 +3126,12 @@ async function loadCollapsedPreviewRobot() {
       previewOnly: true,
       restoreAngles: captureJointAngles(viewer.robot),
     });
+    const meshIssues = (r.mesh_report || []).filter(x =>
+      Number(x.missing_count || 0) || Number(x.visuals || 0) === 0);
+    for (const issue of meshIssues.slice(0, 5)) {
+      log(`collapsed mesh: ${issue.link} visuals=${issue.visuals} ` +
+          `missing=${issue.missing_count}`, 'wrn');
+    }
     log(t('subasm.previewRobotOk'), 'ok');
   } catch (e) {
     log(t('subasm.previewRobotFail', { e: e.message ?? e }), 'err');

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1873,6 +1873,206 @@ def _tree_rows_from_collapse_plan(plan):
     return _tree_rows_payload(plan.get("base_link"), links, joints)
 
 
+def _urdf_vec(s, n=3):
+    vals = [float(x) for x in str(s or "").split()]
+    return vals if len(vals) == n else [0.0] * n
+
+
+def _urdf_origin_matrix(elem):
+    import numpy as _np
+
+    from sw2robot.exporter.geometry import matrix_from_rpy
+
+    xyz = _urdf_vec(elem.get("xyz"), 3) if elem is not None else [0, 0, 0]
+    rpy = _urdf_vec(elem.get("rpy"), 3) if elem is not None else [0, 0, 0]
+    M = matrix_from_rpy(rpy)
+    M[:3, 3] = _np.asarray(xyz, float)
+    return M
+
+
+def _set_urdf_origin(elem, T):
+    import xml.etree.ElementTree as _ET
+
+    from sw2robot.exporter.geometry import matrix_to_xyz_rpy
+    from sw2robot.exporter.urdf_writer import _fmt
+
+    origin = elem.find("origin")
+    if origin is None:
+        origin = _ET.Element("origin")
+        elem.insert(0, origin)
+    xyz, rpy = matrix_to_xyz_rpy(T)
+    origin.set("xyz", _fmt(xyz))
+    origin.set("rpy", _fmt(rpy))
+
+
+def _urdf_link_world_poses(root):
+    """Zero-position link poses from URDF joint origins."""
+    import numpy as _np
+
+    links = {ln.get("name") for ln in root.findall("link") if ln.get("name")}
+    child_links, by_parent = set(), {}
+    for j in root.findall("joint"):
+        p = j.find("parent")
+        c = j.find("child")
+        parent = p.get("link") if p is not None else ""
+        child = c.get("link") if c is not None else ""
+        if not parent or not child:
+            continue
+        by_parent.setdefault(parent, []).append((child, j))
+        child_links.add(child)
+    poses = {}
+
+    def walk(link, T):
+        if link in poses:
+            return
+        poses[link] = T
+        for child, joint in by_parent.get(link, []):
+            walk(child, T @ _urdf_origin_matrix(joint.find("origin")))
+
+    roots = sorted(links - child_links)
+    for root_link in roots:
+        walk(root_link, _np.eye(4))
+    for link in sorted(links):
+        if link not in poses:
+            walk(link, _np.eye(4))
+    return poses
+
+
+def _collapse_plan_name_map(plan, link_elems):
+    """Map plan link names to the current URDF names where they differ."""
+    names = set(link_elems)
+    mapping = {}
+    base = plan.get("base_link")
+    if base and base not in names and "base_link" in names:
+        mapping[base] = "base_link"
+    return mapping
+
+
+def _collapsed_preview_urdf_text(urdf_text, plan, robot_name=None):
+    """Build a dry-run URDF from a collapse_plan without touching normal export.
+
+    This is intentionally conservative: it preserves the current URDF's mesh
+    elements and rewires only the links/joints selected by the preview plan.
+    """
+    import copy as _copy
+    import xml.etree.ElementTree as _ET
+
+    import numpy as _np
+
+    from sw2robot.exporter.geometry import relative_matrix
+
+    if not plan.get("ready_for_urdf"):
+        raise ValueError("collapse plan is not ready for URDF output")
+    root = _ET.fromstring(urdf_text)
+    if robot_name:
+        root.set("name", robot_name)
+    link_elems = {ln.get("name"): ln for ln in root.findall("link")
+                  if ln.get("name")}
+    joint_elems = {j.get("name"): j for j in root.findall("joint")
+                   if j.get("name")}
+    name_map = _collapse_plan_name_map(plan, link_elems)
+
+    def nm(name):
+        return name_map.get(name, name)
+
+    link_poses = _urdf_link_world_poses(root)
+
+    def collapsed_pose(plan_link):
+        selected = plan_link.get("selected_origin_link")
+        candidates = ([selected] if selected else []) + \
+            list(plan_link.get("member_links") or [])
+        for cand in candidates:
+            mapped = nm(cand)
+            if mapped in link_poses:
+                return link_poses[mapped]
+        return link_poses.get(nm(plan_link.get("link")), _np.eye(4))
+
+    plan_links = list(plan.get("links") or [])
+    out_root = _ET.Element("robot", {"name": root.get("name") or "robot"})
+    out_poses = {}
+    for plan_link in plan_links:
+        link_name = nm(plan_link.get("link"))
+        src = link_elems.get(link_name)
+        out_link = _copy.deepcopy(src) if src is not None \
+            else _ET.Element("link", {"name": link_name})
+        out_link.set("name", link_name)
+        if plan_link.get("kind") == "collapsed_subassembly":
+            out_poses[link_name] = collapsed_pose(plan_link)
+            for child in list(out_link):
+                if child.tag in ("visual", "collision", "inertial"):
+                    out_link.remove(child)
+            target_T = out_poses[link_name]
+            for member in plan_link.get("member_links") or []:
+                member_name = nm(member)
+                member_el = link_elems.get(member_name)
+                member_T = link_poses.get(member_name)
+                if member_el is None or member_T is None:
+                    continue
+                for child in member_el:
+                    if child.tag not in ("visual", "collision"):
+                        continue
+                    moved = _copy.deepcopy(child)
+                    old_origin = moved.find("origin")
+                    visual_T = _urdf_origin_matrix(old_origin)
+                    _set_urdf_origin(
+                        moved, relative_matrix(target_T, member_T @ visual_T))
+                    out_link.append(moved)
+        else:
+            out_poses[link_name] = link_poses.get(link_name, _np.eye(4))
+        out_root.append(out_link)
+
+    for row in plan.get("joints") or []:
+        source = row.get("source_joint") or row.get("name")
+        src = joint_elems.get(source)
+        if src is None:
+            src = joint_elems.get(row.get("name"))
+        joint = _copy.deepcopy(src) if src is not None else _ET.Element("joint")
+        joint.set("name", row.get("name") or source or "")
+        joint.set("type", row.get("type") or joint.get("type") or "fixed")
+        parent = nm(row.get("parent"))
+        child = nm(row.get("child"))
+        pe = joint.find("parent")
+        if pe is None:
+            pe = _ET.Element("parent")
+            joint.insert(1, pe)
+        pe.set("link", parent)
+        ce = joint.find("child")
+        if ce is None:
+            ce = _ET.Element("child")
+            joint.insert(2, ce)
+        ce.set("link", child)
+        parent_T = out_poses.get(parent, link_poses.get(parent, _np.eye(4)))
+        child_T = out_poses.get(child, link_poses.get(child, _np.eye(4)))
+        _set_urdf_origin(joint, relative_matrix(parent_T, child_T))
+        out_root.append(joint)
+
+    try:
+        _ET.indent(out_root, space="  ")
+    except AttributeError:
+        pass
+    return '<?xml version="1.0"?>\n' + \
+        _ET.tostring(out_root, encoding="unicode") + "\n"
+
+
+def _write_collapsed_preview_urdf(pkg_dir, urdf_rel, plan):
+    """Write a hidden dry-run collapsed URDF and return (abs_path, rel_path)."""
+    stem = os.path.splitext(os.path.basename(urdf_rel))[0]
+    out_rel = posixpath.join(posixpath.dirname(urdf_rel),
+                             f".{stem}.collapsed-preview.urdf")
+    in_path = os.path.join(pkg_dir, *urdf_rel.split("/"))
+    out_path = os.path.join(pkg_dir, *out_rel.split("/"))
+    with open(in_path, encoding="utf-8") as f:
+        text = f.read()
+    out_text = _collapsed_preview_urdf_text(
+        text, plan, robot_name=f"{stem}_collapsed_preview")
+    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+    tmp = out_path + ".tmp"
+    with open(tmp, "w", encoding="utf-8", newline="\n") as f:
+        f.write(out_text)
+    os.replace(tmp, out_path)
+    return out_path, out_rel
+
+
 def _tree_rows_payload(base_link, links, joints):
     """Flatten a link/joint tree into display rows for preview UIs."""
     link_info = {l["link_name"]: l for l in links}
@@ -3480,6 +3680,46 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 payload = _collapse_preview_payload(gs, txt)
                 payload["mode"] = "cad"
                 return self._send_json(payload)
+            if path == "/api/collapsed_preview_urdf":
+                cls = type(self)
+                if not cls.pkg_dir:
+                    return self._send_json({"error": "no package open"}, 400)
+                if not _cad_mode(cls.pkg_dir):
+                    return self._send_json(
+                        {"error": "collapsed preview URDF needs the CAD "
+                                  "graph.json"},
+                        400)
+                from sw2robot.exporter.state import GraphState
+                gs = GraphState.load(os.path.join(cls.pkg_dir, "graph.json"))
+                name = os.path.splitext(os.path.basename(cls.urdf_rel))[0]
+                yml = os.path.join(cls.pkg_dir, name + ".joints.yaml")
+                txt = open(yml, encoding="utf-8").read() \
+                    if os.path.exists(yml) else ""
+                preview = _collapse_preview_payload(gs, txt)
+                plan = preview.get("collapse_plan") or {}
+                if not plan.get("ready_for_urdf"):
+                    return self._send_json({
+                        "error": "collapse plan has unresolved validation "
+                                 "issues",
+                        "validation": preview.get("validation"),
+                        "collapse_plan": plan,
+                    }, 400)
+                try:
+                    out_path, out_rel = _write_collapsed_preview_urdf(
+                        cls.pkg_dir, cls.urdf_rel, plan)
+                except ValueError as e:
+                    return self._send_json({"error": str(e)}, 400)
+                except Exception as e:
+                    return self._send_json({"error": repr(e)}, 500)
+                return self._send_json({
+                    "ok": True,
+                    "preview_only": True,
+                    "rebuilt": False,
+                    "path": out_path,
+                    "urdf": "/pkg/" + out_rel,
+                    "collapse_plan": plan,
+                    "preview_counts": preview.get("preview_counts"),
+                })
             if path == "/api/fs":
                 # tiny server-side file browser: the OS file dialog cannot
                 # hand a PATH to the page, so the page browses through us

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1220,6 +1220,34 @@ def _subassembly_cycle_break_joints(yml_txt):
     return {str(x) for x in raw if x is not None}
 
 
+def _subassembly_driver_joints(yml_txt):
+    """Preview-only source joints that drive collapsed CAD sub-assemblies."""
+    import yaml as _yaml
+
+    try:
+        cfg = _yaml.safe_load(yml_txt) or {}
+        if not isinstance(cfg, dict):
+            return {}
+    except Exception:
+        return {}
+    raw = cfg.get("subassembly_driver_joints") or {}
+    if not isinstance(raw, dict):
+        return {}
+    return {str(k): str(v) for k, v in raw.items() if v is not None}
+
+
+def _set_subassembly_driver_joint_yaml(txt, graph, name, source_joint):
+    """Set/reset one preview-only collapsed sub-assembly driver joint."""
+    names = _subassembly_names(graph)
+    if name not in names:
+        raise ValueError(f"no CAD sub-assembly '{name}'")
+    if source_joint:
+        return _upsert_yaml_map(
+            txt, "subassembly_driver_joints", name,
+            _yaml_scalar(source_joint))
+    return _remove_yaml_map_entry(txt, "subassembly_driver_joints", name)
+
+
 def _set_subassembly_cycle_break_joint_yaml(
         txt, source_joint, drop, previous_source_joint=""):
     """Set/reset one preview-only source joint dropped for cycle breaking."""
@@ -1313,6 +1341,7 @@ def _collapse_preview_payload(graph, yml_txt=""):
     parent_overrides = _subassembly_parent_overrides(yml_txt)
     origin_links = _subassembly_origin_links(yml_txt)
     cycle_break_joints = _subassembly_cycle_break_joints(yml_txt)
+    driver_joints = _subassembly_driver_joints(yml_txt)
     by_sub = {s["name"]: s for s in canonical["subassemblies"]}
     collapse_link = {}
     collapsed = []
@@ -1333,6 +1362,7 @@ def _collapse_preview_payload(graph, yml_txt=""):
             "boundary_joints": sub["boundary_joints"],
             "selected_parent": "",
             "selected_origin_link": origin_links.get(row["name"], ""),
+            "selected_driver_joint": driver_joints.get(row["name"], ""),
         }
         collapsed.append(info)
         for link in sub["member_links"]:
@@ -1358,6 +1388,8 @@ def _collapse_preview_payload(graph, yml_txt=""):
         stale = choice.get("stale_origin_link", "")
         if stale:
             sub["stale_origin_link"] = stale
+    driver_choices = _collapse_driver_joint_choices(
+        collapsed, collapse_link, driver_joints)
 
     links = []
     inserted = set()
@@ -1421,7 +1453,8 @@ def _collapse_preview_payload(graph, yml_txt=""):
                                           collapse_link)
     collapse_plan = _collapse_plan_payload(
         base, links, joints, collapsed, collapse_link, dropped,
-        dropped_parent_override, dropped_cycle_joints, validation)
+        dropped_parent_override, dropped_cycle_joints, validation,
+        driver_choices)
     return {
         "base_link": base,
         "links": links,
@@ -1434,6 +1467,7 @@ def _collapse_preview_payload(graph, yml_txt=""):
         "collapsed_subassemblies": collapsed,
         "parent_choices": parent_choices,
         "group_choices": group_choices,
+        "driver_joint_choices": driver_choices,
         "cycle_break_choices": cycle_break_choices,
         "canonical_counts": {
             "links": len(canonical["links"]),
@@ -1565,6 +1599,99 @@ def _collapse_group_choices(collapsed, origin_links):
                 {"origin_link": g[0], "links": g, "size": len(g)}
                 for g in groups
             ],
+        })
+    return choices
+
+
+def _collapse_driver_joint_choices(collapsed, collapse_link, driver_joints):
+    """List source-joint candidates that can drive collapsed sub-assemblies.
+
+    The selected driver is preview-only metadata for now.  It records which
+    joint from the fully-expanded robot should represent motion of the
+    collapsed sub-assembly in later preview/URDF steps.
+    """
+    driver_joints = driver_joints or {}
+    role_order = {
+        "incoming_boundary": 0,
+        "outgoing_boundary": 1,
+        "internal_motion": 2,
+        "boundary": 3,
+        "stale": 9,
+    }
+    choices = []
+    for sub in collapsed:
+        link_name = sub.get("link_name")
+        selected = driver_joints.get(sub.get("name"), "")
+        seen = set()
+        candidates = []
+
+        def add_candidate(joint, role):
+            source = _joint_source_name(joint)
+            if not source or source in seen:
+                return
+            seen.add(source)
+            parent = collapse_link.get(joint.get("parent"), joint.get("parent"))
+            child = collapse_link.get(joint.get("child"), joint.get("child"))
+            jtype = joint.get("type") or "fixed"
+            candidates.append({
+                "source_joint": source,
+                "joint": joint.get("name"),
+                "parent": parent,
+                "child": child,
+                "source_parent": joint.get("parent"),
+                "source_child": joint.get("child"),
+                "type": jtype,
+                "role": role,
+                "movable": jtype not in ("fixed", ""),
+            })
+
+        for joint in sub.get("boundary_joints") or []:
+            parent = collapse_link.get(joint.get("parent"), joint.get("parent"))
+            child = collapse_link.get(joint.get("child"), joint.get("child"))
+            if child == link_name and parent != child:
+                add_candidate(joint, "incoming_boundary")
+            elif parent == link_name and parent != child:
+                add_candidate(joint, "outgoing_boundary")
+            elif parent != child:
+                add_candidate(joint, "boundary")
+
+        for joint in sub.get("internal_joints") or []:
+            if (joint.get("type") or "fixed") != "fixed":
+                add_candidate(joint, "internal_motion")
+
+        if selected and selected not in seen:
+            candidates.append({
+                "source_joint": selected,
+                "joint": selected,
+                "parent": "",
+                "child": "",
+                "source_parent": "",
+                "source_child": "",
+                "type": "",
+                "role": "stale",
+                "movable": False,
+            })
+
+        candidates.sort(key=lambda c: (
+            role_order.get(c.get("role"), 8),
+            0 if c.get("movable") else 1,
+            c.get("source_joint") or "",
+        ))
+        auto = next((c.get("source_joint") for c in candidates
+                     if c.get("role") == "incoming_boundary"
+                     and c.get("movable")), "")
+        if not auto:
+            auto = next((c.get("source_joint") for c in candidates
+                         if c.get("role") == "incoming_boundary"), "")
+        if not auto:
+            auto = next((c.get("source_joint") for c in candidates
+                         if c.get("movable")), "")
+        choices.append({
+            "subassembly": sub.get("name"),
+            "link_name": link_name,
+            "selected_driver_joint": selected,
+            "auto_driver_joint": auto,
+            "candidates": candidates,
         })
     return choices
 
@@ -1829,9 +1956,12 @@ def _validate_collapsed_tree(base_link, links, joints, collapsed,
 
 def _collapse_plan_payload(base_link, links, joints, collapsed, collapse_link,
                            dropped_internal, dropped_parent_override,
-                           dropped_cycle, validation):
+                           dropped_cycle, validation, driver_choices=None):
     """Stable preview IR shared by the UI and future collapsed URDF output."""
     sub_by_link = {s.get("link_name"): s for s in collapsed}
+    driver_by_sub = {
+        c.get("subassembly"): c for c in (driver_choices or [])
+    }
 
     def plan_link(row):
         link = row.get("link_name")
@@ -1847,6 +1977,7 @@ def _collapse_plan_payload(base_link, links, joints, collapsed, collapse_link,
             "member_components": list(sub.get("member_components") or []),
             "selected_parent": sub.get("selected_parent", ""),
             "selected_origin_link": sub.get("selected_origin_link", ""),
+            "selected_driver_joint": sub.get("selected_driver_joint", ""),
         }
 
     def plan_joint(row, decision=None):
@@ -1887,7 +2018,13 @@ def _collapse_plan_payload(base_link, links, joints, collapsed, collapse_link,
             "member_components": list(s.get("member_components") or []),
             "selected_parent": s.get("selected_parent", ""),
             "selected_origin_link": s.get("selected_origin_link", ""),
+            "selected_driver_joint": s.get("selected_driver_joint", ""),
+            "auto_driver_joint": driver_by_sub.get(
+                s.get("name"), {}).get("auto_driver_joint", ""),
+            "driver_joint_candidates": driver_by_sub.get(
+                s.get("name"), {}).get("candidates", []),
         } for s in collapsed],
+        "driver_joint_choices": list(driver_choices or []),
         "link_replacements": [
             {"source_link": src, "collapsed_link": dst}
             for src, dst in sorted(collapse_link.items())
@@ -4840,6 +4977,69 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                                 "preview_only": True,
                                 "rebuilt": False})
                 print(f"[sw2robot.web] set_subassembly_origin_link: "
+                      f"{name_in} -> {label} (preview only)")
+                return self._send_json(payload)
+            if parsed.path == "/api/set_subassembly_driver_joint":
+                cls = type(self)
+                n = int(self.headers.get("Content-Length", 0))
+                body = json.loads(self.rfile.read(n) or b"{}")
+                name_in = (body.get("name") or "").strip()
+                source_joint = (body.get("source_joint") or "").strip()
+                if source_joint == "auto":
+                    source_joint = ""
+                if not cls.pkg_dir:
+                    return self._send_json({"error": "no package open"}, 400)
+                if not _cad_mode(cls.pkg_dir):
+                    return self._send_json(
+                        {"error": "sub-assembly driver joints need the CAD "
+                                  "graph.json"},
+                        400)
+                if not name_in:
+                    return self._send_json({"error": "name required"}, 400)
+                from sw2robot.exporter.state import GraphState
+                graph = GraphState.load(os.path.join(cls.pkg_dir, "graph.json"))
+                name = os.path.splitext(os.path.basename(cls.urdf_rel))[0]
+                yml = os.path.join(cls.pkg_dir, name + ".joints.yaml")
+                if not os.path.exists(yml):
+                    return self._send_json(
+                        {"error": "joints.yaml not found -- re-extract once"},
+                        400)
+                with open(yml, encoding="utf-8") as f:
+                    txt = f.read()
+                try:
+                    preview = _collapse_preview_payload_cached(
+                        cls.pkg_dir, graph, yml, txt)
+                    choices = {
+                        c.get("subassembly"): c
+                        for c in preview.get("driver_joint_choices", [])
+                    }
+                    if source_joint:
+                        allowed = {
+                            c.get("source_joint")
+                            for c in choices.get(name_in, {}).get(
+                                "candidates", [])
+                        }
+                        if source_joint not in allowed:
+                            return self._send_json(
+                                {"error": f"'{source_joint}' is not a driver "
+                                          f"joint candidate for {name_in}"},
+                                400)
+                    txt = _set_subassembly_driver_joint_yaml(
+                        txt, graph, name_in, source_joint)
+                except ValueError as e:
+                    return self._send_json({"error": str(e)}, 400)
+                label = source_joint or "auto"
+                _snapshot(cls.pkg_dir, yml,
+                          f"sub-assembly driver joint {name_in} -> {label}")
+                with open(yml, "w", encoding="utf-8") as f:
+                    f.write(txt)
+                payload = _collapse_preview_payload_cached(
+                    cls.pkg_dir, graph, yml, txt)
+                payload.update({"ok": True, "name": name_in,
+                                "source_joint": source_joint,
+                                "preview_only": True,
+                                "rebuilt": False})
+                print(f"[sw2robot.web] set_subassembly_driver_joint: "
                       f"{name_in} -> {label} (preview only)")
                 return self._send_json(payload)
             if parsed.path == "/api/set_subassembly_cycle_break":

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -2134,7 +2134,9 @@ def _collapsed_preview_urdf_text(urdf_text, plan, robot_name=None):
 
 
 def _expanded_preview_source_urdf_text(pkg_dir, urdf_rel, graph, yml_txt):
-    """Build an all-expanded hidden URDF source for collapsed-preview meshes."""
+    """Build an all-expanded temporary URDF for collapsed-preview meshes."""
+    import tempfile as _tempfile
+
     import yaml as _yaml
 
     from sw2robot.exporter import model as _M
@@ -2142,28 +2144,36 @@ def _expanded_preview_source_urdf_text(pkg_dir, urdf_rel, graph, yml_txt):
 
     try:
         cfg = _yaml.safe_load(yml_txt) or {}
-        if not isinstance(cfg, dict):
-            cfg = {}
-    except Exception:
-        cfg = {}
+    except _yaml.YAMLError as e:
+        raise ValueError(f"invalid joints.yaml: {e}") from e
+    if not isinstance(cfg, dict):
+        raise ValueError("invalid joints.yaml: document root must be a mapping")
     full_cfg = dict(cfg)
     full_cfg["expand"] = [""]
     full_cfg["no_expand"] = []
     model = _M.build_model(graph, config=full_cfg)
 
     stem = os.path.splitext(os.path.basename(urdf_rel))[0]
-    src_rel = posixpath.join(posixpath.dirname(urdf_rel),
-                             f".{stem}.expanded-preview-source.urdf")
-    src_path = os.path.join(pkg_dir, *src_rel.split("/"))
-    os.makedirs(os.path.dirname(src_path), exist_ok=True)
+    urdf_dir = os.path.join(pkg_dir, *posixpath.dirname(urdf_rel).split("/"))
+    os.makedirs(urdf_dir, exist_ok=True)
     kwargs = {}
     if cfg.get("density") is not None:
         kwargs["density"] = float(cfg.get("density"))
     kwargs["link_overrides"] = cfg.get("link_names") or {}
     kwargs["joint_overrides"] = cfg.get("joint_names") or {}
-    write_urdf(model, src_path, **kwargs)
-    with open(src_path, encoding="utf-8") as f:
-        return f.read()
+    fd, src_path = _tempfile.mkstemp(
+        prefix=f".{stem}.", suffix=".expanded-preview-source.urdf",
+        dir=urdf_dir)
+    os.close(fd)
+    try:
+        write_urdf(model, src_path, **kwargs)
+        with open(src_path, encoding="utf-8") as f:
+            return f.read()
+    finally:
+        try:
+            os.unlink(src_path)
+        except FileNotFoundError:
+            pass
 
 
 def _collapsed_preview_mesh_report(urdf_text, plan):

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1261,7 +1261,7 @@ def _collapse_preview_payload(graph, yml_txt=""):
             "member_components": sub["member_components"],
             "internal_joints": sub["internal_joints"],
             "boundary_joints": sub["boundary_joints"],
-            "selected_parent": parent_overrides.get(row["name"], ""),
+            "selected_parent": "",
         }
         collapsed.append(info)
         for link in sub["member_links"]:
@@ -1269,6 +1269,13 @@ def _collapse_preview_payload(graph, yml_txt=""):
 
     parent_choices = _collapse_parent_choices(
         collapsed, collapse_link, parent_overrides)
+    selected_parent_by_subassembly = {
+        c.get("subassembly"): c.get("selected_parent", "")
+        for c in parent_choices
+    }
+    for sub in collapsed:
+        sub["selected_parent"] = selected_parent_by_subassembly.get(
+            sub["name"], "")
 
     links = []
     inserted = set()
@@ -1348,7 +1355,8 @@ def _collapse_parent_choices(collapsed, collapse_link, parent_overrides):
             child = collapse_link.get(j["child"], j["child"])
             if child == link_name and parent != child:
                 by_parent.setdefault(parent, []).append(j.get("name"))
-        selected = parent_overrides.get(sub.get("name"), "")
+        raw_selected = parent_overrides.get(sub.get("name"), "")
+        selected = raw_selected if raw_selected in by_parent else ""
         if len(by_parent) <= 1 and not selected:
             continue
         choices.append({

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1167,6 +1167,34 @@ def _set_subassembly_parent_override_yaml(txt, graph, name, parent):
     return _remove_yaml_map_entry(txt, "subassembly_parent_overrides", name)
 
 
+def _subassembly_origin_links(yml_txt):
+    """Preview-only representative member links for collapsed sub-assemblies."""
+    import yaml as _yaml
+
+    try:
+        cfg = _yaml.safe_load(yml_txt) or {}
+        if not isinstance(cfg, dict):
+            return {}
+    except Exception:
+        return {}
+    raw = cfg.get("subassembly_origin_links") or {}
+    if not isinstance(raw, dict):
+        return {}
+    return {str(k): str(v) for k, v in raw.items() if v is not None}
+
+
+def _set_subassembly_origin_link_yaml(txt, graph, name, origin_link):
+    """Set/reset one preview-only collapsed sub-assembly origin link."""
+    names = _subassembly_names(graph)
+    if name not in names:
+        raise ValueError(f"no CAD sub-assembly '{name}'")
+    if origin_link:
+        return _upsert_yaml_map(
+            txt, "subassembly_origin_links", name,
+            _yaml_scalar(origin_link))
+    return _remove_yaml_map_entry(txt, "subassembly_origin_links", name)
+
+
 def _canonical_tree_payload(graph, yml_txt=""):
     """Fully-expanded tree plus CAD sub-assembly membership.
 
@@ -1243,6 +1271,7 @@ def _collapse_preview_payload(graph, yml_txt=""):
     canonical = _canonical_tree_payload(graph, yml_txt)
     states = _subassemblies_payload(graph, yml_txt)
     parent_overrides = _subassembly_parent_overrides(yml_txt)
+    origin_links = _subassembly_origin_links(yml_txt)
     by_sub = {s["name"]: s for s in canonical["subassemblies"]}
     collapse_link = {}
     collapsed = []
@@ -1262,6 +1291,7 @@ def _collapse_preview_payload(graph, yml_txt=""):
             "internal_joints": sub["internal_joints"],
             "boundary_joints": sub["boundary_joints"],
             "selected_parent": "",
+            "selected_origin_link": origin_links.get(row["name"], ""),
         }
         collapsed.append(info)
         for link in sub["member_links"]:
@@ -1276,6 +1306,7 @@ def _collapse_preview_payload(graph, yml_txt=""):
     for sub in collapsed:
         sub["selected_parent"] = selected_parent_by_subassembly.get(
             sub["name"], "")
+    group_choices = _collapse_group_choices(collapsed, origin_links)
 
     links = []
     inserted = set()
@@ -1327,6 +1358,7 @@ def _collapse_preview_payload(graph, yml_txt=""):
         "dropped_internal_joints": dropped,
         "collapsed_subassemblies": collapsed,
         "parent_choices": parent_choices,
+        "group_choices": group_choices,
         "canonical_counts": {
             "links": len(canonical["links"]),
             "joints": len(canonical["joints"]),
@@ -1364,6 +1396,56 @@ def _collapse_parent_choices(collapsed, collapse_link, parent_overrides):
             "parents": [
                 {"link": p, "joints": sorted(x for x in js if x)}
                 for p, js in sorted(by_parent.items())
+            ],
+        })
+    return choices
+
+
+def _subassembly_member_groups(sub):
+    """Connected components of a collapsed sub-assembly's expanded members."""
+    members = list(sub.get("member_links") or [])
+    if not members:
+        return []
+    member_set = set(members)
+    internal_adj = {m: set() for m in members}
+    for j in sub.get("internal_joints") or []:
+        p, c = j.get("parent"), j.get("child")
+        if p in member_set and c in member_set:
+            internal_adj[p].add(c)
+            internal_adj[c].add(p)
+    comps = []
+    todo = set(members)
+    while todo:
+        start = todo.pop()
+        comp = [start]
+        q = [start]
+        while q:
+            cur = q.pop()
+            for nxt in internal_adj.get(cur, ()):
+                if nxt in todo:
+                    todo.remove(nxt)
+                    comp.append(nxt)
+                    q.append(nxt)
+        comps.append(sorted(comp))
+    comps.sort(key=lambda x: (x[0] if x else "", len(x)))
+    return comps
+
+
+def _collapse_group_choices(collapsed, origin_links):
+    """List origin link candidates for disconnected collapsed member groups."""
+    choices = []
+    for sub in collapsed:
+        groups = _subassembly_member_groups(sub)
+        selected = origin_links.get(sub.get("name"), "")
+        if len(groups) <= 1 and not selected:
+            continue
+        choices.append({
+            "subassembly": sub.get("name"),
+            "link_name": sub.get("link_name"),
+            "selected_origin_link": selected,
+            "groups": [
+                {"origin_link": g[0], "links": g, "size": len(g)}
+                for g in groups
             ],
         })
     return choices
@@ -1427,35 +1509,25 @@ def _validate_collapsed_tree(base_link, links, joints, collapsed,
             dfs(root)
 
     for sub in collapsed:
-        members = list(sub.get("member_links") or [])
-        if len(members) <= 1:
+        comps = _subassembly_member_groups(sub)
+        if len(comps) <= 1:
             continue
-        member_set = set(members)
-        internal_adj = {m: set() for m in members}
-        for j in sub.get("internal_joints") or []:
-            p, c = j.get("parent"), j.get("child")
-            if p in member_set and c in member_set:
-                internal_adj[p].add(c)
-                internal_adj[c].add(p)
-        comps = []
-        todo = set(members)
-        while todo:
-            start = todo.pop()
-            comp = [start]
-            q = [start]
-            while q:
-                cur = q.pop()
-                for nxt in internal_adj.get(cur, ()):
-                    if nxt in todo:
-                        todo.remove(nxt)
-                        comp.append(nxt)
-                        q.append(nxt)
-            comps.append(sorted(comp))
-        # ``todo`` is a set, so the discovery order of the groups is not
-        # deterministic across platforms/hash seeds -- sort the groups (each
-        # already sorted internally) so the payload is stable.
-        comps.sort()
-        if len(comps) > 1:
+        selected_origin_link = sub.get("selected_origin_link")
+        if selected_origin_link and any(selected_origin_link in comp for comp in comps):
+            pass
+        elif selected_origin_link:
+            issues.append({
+                "severity": "warning",
+                "code": "invalid_origin_link",
+                "subassembly": sub.get("name"),
+                "link": sub.get("link_name"),
+                "origin_link": selected_origin_link,
+                "components": comps,
+                "message": (
+                    f"{sub.get('name')} uses stale origin link "
+                    f"{selected_origin_link}"),
+            })
+        else:
             issues.append({
                 "severity": "warning",
                 "code": "disconnected_members",
@@ -3998,6 +4070,67 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                                 "parent": parent, "preview_only": True,
                                 "rebuilt": False})
                 print(f"[sw2robot.web] set_subassembly_parent: "
+                      f"{name_in} -> {label} (preview only)")
+                return self._send_json(payload)
+            if parsed.path == "/api/set_subassembly_origin_link":
+                cls = type(self)
+                n = int(self.headers.get("Content-Length", 0))
+                body = json.loads(self.rfile.read(n) or b"{}")
+                name_in = (body.get("name") or "").strip()
+                origin_link = (body.get("origin_link") or "").strip()
+                if origin_link == "auto":
+                    origin_link = ""
+                if not cls.pkg_dir:
+                    return self._send_json({"error": "no package open"}, 400)
+                if not _cad_mode(cls.pkg_dir):
+                    return self._send_json(
+                        {"error": "sub-assembly origin links need the CAD "
+                                  "graph.json"},
+                        400)
+                if not name_in:
+                    return self._send_json({"error": "name required"}, 400)
+                from sw2robot.exporter.state import GraphState
+                graph = GraphState.load(os.path.join(cls.pkg_dir, "graph.json"))
+                name = os.path.splitext(os.path.basename(cls.urdf_rel))[0]
+                yml = os.path.join(cls.pkg_dir, name + ".joints.yaml")
+                if not os.path.exists(yml):
+                    return self._send_json(
+                        {"error": "joints.yaml not found -- re-extract once"},
+                        400)
+                with open(yml, encoding="utf-8") as f:
+                    txt = f.read()
+                try:
+                    preview = _collapse_preview_payload(graph, txt)
+                    choices = {
+                        c.get("subassembly"): c
+                        for c in preview.get("group_choices", [])
+                    }
+                    if origin_link:
+                        allowed = {
+                            link
+                            for group in choices.get(name_in, {}).get("groups", [])
+                            for link in group.get("links", [])
+                        }
+                        if origin_link not in allowed:
+                            return self._send_json(
+                                {"error": f"'{origin_link}' is not a member "
+                                          f"origin link candidate for {name_in}"},
+                                400)
+                    txt = _set_subassembly_origin_link_yaml(
+                        txt, graph, name_in, origin_link)
+                except ValueError as e:
+                    return self._send_json({"error": str(e)}, 400)
+                label = origin_link or "auto"
+                _snapshot(cls.pkg_dir, yml,
+                          f"sub-assembly origin link {name_in} -> {label}")
+                with open(yml, "w", encoding="utf-8") as f:
+                    f.write(txt)
+                payload = _collapse_preview_payload(graph, txt)
+                payload.update({"ok": True, "name": name_in,
+                                "origin_link": origin_link,
+                                "preview_only": True,
+                                "rebuilt": False})
+                print(f"[sw2robot.web] set_subassembly_origin_link: "
                       f"{name_in} -> {label} (preview only)")
                 return self._send_json(payload)
             if parsed.path == "/api/set_base":

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1632,6 +1632,56 @@ def _validate_collapsed_tree(base_link, links, joints, collapsed,
     """Report structural hazards in a collapsed preview tree."""
     collapse_link = collapse_link or {}
     issues = []
+    link_names = {row.get("link_name") for row in links
+                  if row.get("link_name")}
+
+    children = {j.get("child") for j in joints
+                if j.get("child") in link_names}
+    roots = sorted(link_names - children)
+    if base_link not in link_names:
+        issues.append({
+            "severity": "error",
+            "code": "invalid_base_link",
+            "base_link": base_link,
+            "message": f"collapsed tree base link {base_link} does not exist",
+        })
+    if roots != [base_link]:
+        issues.append({
+            "severity": "error",
+            "code": "invalid_roots",
+            "base_link": base_link,
+            "roots": roots,
+            "message": (
+                "collapsed tree must have exactly one root matching "
+                f"base_link; found {len(roots)} root(s)"),
+        })
+
+    reachable = set()
+    if base_link in link_names:
+        by_parent = {}
+        for joint in joints:
+            parent = joint.get("parent")
+            child = joint.get("child")
+            if parent in link_names and child in link_names:
+                by_parent.setdefault(parent, []).append(child)
+        todo = [base_link]
+        while todo:
+            link = todo.pop()
+            if link in reachable:
+                continue
+            reachable.add(link)
+            todo.extend(by_parent.get(link, []))
+    unreachable = sorted(link_names - reachable)
+    if unreachable:
+        issues.append({
+            "severity": "error",
+            "code": "unreachable_links",
+            "base_link": base_link,
+            "links": unreachable,
+            "message": (
+                f"{len(unreachable)} collapsed tree link(s) are not reachable "
+                f"from {base_link}"),
+        })
 
     incoming = {}
     for j in joints:
@@ -1781,10 +1831,7 @@ def _collapse_plan_payload(base_link, links, joints, collapsed, collapse_link,
     return {
         "version": 1,
         "base_link": base_link,
-        "ready_for_urdf": (
-            bool(validation.get("ok")) and
-            int(validation.get("issue_count") or 0) == 0
-        ),
+        "ready_for_urdf": int(validation.get("issue_count") or 0) == 0,
         "links": [plan_link(row) for row in links],
         "joints": [plan_joint(row) for row in joints],
         "dropped_joints": dropped_joints,

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -23,6 +23,7 @@ sw2robot.exporter already requires.
 import argparse
 import contextlib
 import copy
+import hashlib
 import http.server
 import json
 import os
@@ -62,6 +63,10 @@ def _app_data_dir():
 
 # repo root in a checkout; %TEMP%\sw2robot in a frozen .exe
 _DATA_DIR = _app_data_dir()
+
+_COLLAPSE_PREVIEW_CACHE = {}
+_COLLAPSE_PREVIEW_CACHE_LOCK = threading.Lock()
+_COLLAPSE_PREVIEW_CACHE_MAX = 8
 
 
 def _default_root():
@@ -1439,6 +1444,41 @@ def _collapse_preview_payload(graph, yml_txt=""):
             "joints": len(joints),
         },
     }
+
+
+def _file_signature(path):
+    try:
+        st = os.stat(path)
+        return (os.path.abspath(path), int(st.st_mtime_ns), int(st.st_size))
+    except OSError:
+        return (os.path.abspath(path), None, None)
+
+
+def _collapse_preview_cache_key(pkg_dir, yml_path, yml_txt):
+    graph_path = os.path.join(pkg_dir, "graph.json")
+    digest = hashlib.sha256((yml_txt or "").encode("utf-8")).hexdigest()
+    return (_file_signature(graph_path), os.path.abspath(yml_path), digest)
+
+
+def _collapse_preview_payload_cached(pkg_dir, graph, yml_path, yml_txt=""):
+    """Cached collapse preview for HTTP calls that repeat the same input.
+
+    The canonical expanded tree is the expensive part.  The preview panel,
+    right-hand subassembly tree, and collapsed robot preview can all request it
+    in quick succession with identical graph/yaml input, so keep a tiny
+    process-local cache keyed by graph.json + joints.yaml content.
+    """
+    key = _collapse_preview_cache_key(pkg_dir, yml_path, yml_txt)
+    with _COLLAPSE_PREVIEW_CACHE_LOCK:
+        cached = _COLLAPSE_PREVIEW_CACHE.get(key)
+        if cached is not None:
+            return copy.deepcopy(cached)
+    payload = _collapse_preview_payload(graph, yml_txt)
+    with _COLLAPSE_PREVIEW_CACHE_LOCK:
+        if len(_COLLAPSE_PREVIEW_CACHE) >= _COLLAPSE_PREVIEW_CACHE_MAX:
+            _COLLAPSE_PREVIEW_CACHE.pop(next(iter(_COLLAPSE_PREVIEW_CACHE)))
+        _COLLAPSE_PREVIEW_CACHE[key] = copy.deepcopy(payload)
+    return payload
 
 
 def _collapse_parent_choices(collapsed, collapse_link, parent_overrides):
@@ -3677,7 +3717,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 yml = os.path.join(cls.pkg_dir, name + ".joints.yaml")
                 txt = open(yml, encoding="utf-8").read() \
                     if os.path.exists(yml) else ""
-                payload = _collapse_preview_payload(gs, txt)
+                payload = _collapse_preview_payload_cached(
+                    cls.pkg_dir, gs, yml, txt)
                 payload["mode"] = "cad"
                 return self._send_json(payload)
             if path == "/api/collapsed_preview_urdf":
@@ -3695,7 +3736,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 yml = os.path.join(cls.pkg_dir, name + ".joints.yaml")
                 txt = open(yml, encoding="utf-8").read() \
                     if os.path.exists(yml) else ""
-                preview = _collapse_preview_payload(gs, txt)
+                preview = _collapse_preview_payload_cached(
+                    cls.pkg_dir, gs, yml, txt)
                 plan = preview.get("collapse_plan") or {}
                 if not plan.get("ready_for_urdf"):
                     return self._send_json({
@@ -4582,7 +4624,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 with open(yml, encoding="utf-8") as f:
                     txt = f.read()
                 try:
-                    preview = _collapse_preview_payload(graph, txt)
+                    preview = _collapse_preview_payload_cached(
+                        cls.pkg_dir, graph, yml, txt)
                     choices = {
                         c.get("subassembly"): c
                         for c in preview.get("parent_choices", [])
@@ -4606,7 +4649,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                           f"sub-assembly parent {name_in} -> {label}")
                 with open(yml, "w", encoding="utf-8") as f:
                     f.write(txt)
-                payload = _collapse_preview_payload(graph, txt)
+                payload = _collapse_preview_payload_cached(
+                    cls.pkg_dir, graph, yml, txt)
                 payload.update({"ok": True, "name": name_in,
                                 "parent": parent, "preview_only": True,
                                 "rebuilt": False})
@@ -4641,7 +4685,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 with open(yml, encoding="utf-8") as f:
                     txt = f.read()
                 try:
-                    preview = _collapse_preview_payload(graph, txt)
+                    preview = _collapse_preview_payload_cached(
+                        cls.pkg_dir, graph, yml, txt)
                     choices = {
                         c.get("subassembly"): c
                         for c in preview.get("group_choices", [])
@@ -4666,7 +4711,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                           f"sub-assembly origin link {name_in} -> {label}")
                 with open(yml, "w", encoding="utf-8") as f:
                     f.write(txt)
-                payload = _collapse_preview_payload(graph, txt)
+                payload = _collapse_preview_payload_cached(
+                    cls.pkg_dir, graph, yml, txt)
                 payload.update({"ok": True, "name": name_in,
                                 "origin_link": origin_link,
                                 "preview_only": True,
@@ -4704,7 +4750,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 with open(yml, encoding="utf-8") as f:
                     txt = f.read()
                 try:
-                    preview = _collapse_preview_payload(graph, txt)
+                    preview = _collapse_preview_payload_cached(
+                        cls.pkg_dir, graph, yml, txt)
                     selected = _subassembly_cycle_break_joints(txt)
                     allowed = set(selected)
                     for choice in preview.get("cycle_break_choices", []):
@@ -4725,7 +4772,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                           f"sub-assembly cycle break {target} -> {label}")
                 with open(yml, "w", encoding="utf-8") as f:
                     f.write(txt)
-                payload = _collapse_preview_payload(graph, txt)
+                payload = _collapse_preview_payload_cached(
+                    cls.pkg_dir, graph, yml, txt)
                 payload.update({"ok": True, "source_joint": source_joint,
                                 "previous_source_joint": previous_source_joint,
                                 "drop": drop, "preview_only": True,

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1945,6 +1945,28 @@ def _set_urdf_origin(elem, T):
     origin.set("rpy", _fmt(rpy))
 
 
+def _set_urdf_axis(joint, axis):
+    import xml.etree.ElementTree as _ET
+
+    import numpy as _np
+
+    from sw2robot.exporter.urdf_writer import _fmt
+
+    if axis is None:
+        return
+    axis = _np.asarray(axis, float)
+    n = float(_np.linalg.norm(axis))
+    if n <= 1e-12:
+        return
+    axis = axis / n
+    elem = joint.find("axis")
+    if elem is None:
+        elem = _ET.Element("axis")
+        insert_at = 3
+        joint.insert(min(insert_at, len(list(joint))), elem)
+    elem.set("xyz", _fmt(axis))
+
+
 def _urdf_link_world_poses(root):
     """Zero-position link poses from URDF joint origins."""
     import numpy as _np
@@ -2061,13 +2083,22 @@ def _collapsed_preview_urdf_text(urdf_text, plan, robot_name=None):
             out_poses[link_name] = link_poses.get(link_name, _np.eye(4))
         out_root.append(out_link)
 
+    used_joint_names = set()
     for row in plan.get("joints") or []:
         source = row.get("source_joint") or row.get("name")
         src = joint_elems.get(source)
         if src is None:
             src = joint_elems.get(row.get("name"))
         joint = _copy.deepcopy(src) if src is not None else _ET.Element("joint")
-        joint.set("name", row.get("name") or source or "")
+        desired_name = source or row.get("name") or ""
+        if desired_name in used_joint_names:
+            desired_name = row.get("name") or desired_name
+        i, base_name = 1, desired_name
+        while desired_name in used_joint_names:
+            i += 1
+            desired_name = f"{base_name}_{i}"
+        used_joint_names.add(desired_name)
+        joint.set("name", desired_name)
         joint.set("type", row.get("type") or joint.get("type") or "fixed")
         parent = nm(row.get("parent"))
         child = nm(row.get("child"))
@@ -2084,6 +2115,16 @@ def _collapsed_preview_urdf_text(urdf_text, plan, robot_name=None):
         parent_T = out_poses.get(parent, link_poses.get(parent, _np.eye(4)))
         child_T = out_poses.get(child, link_poses.get(child, _np.eye(4)))
         _set_urdf_origin(joint, relative_matrix(parent_T, child_T))
+        axis_elem = joint.find("axis")
+        src_child = ""
+        if src is not None:
+            src_ce = src.find("child")
+            src_child = src_ce.get("link") if src_ce is not None else ""
+        src_child_T = link_poses.get(src_child)
+        if axis_elem is not None and src_child_T is not None:
+            axis = _np.asarray(_urdf_vec(axis_elem.get("xyz"), 3), float)
+            world_axis = src_child_T[:3, :3] @ axis
+            _set_urdf_axis(joint, child_T[:3, :3].T @ world_axis)
         out_root.append(joint)
 
     try:

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -2090,9 +2090,7 @@ def _collapsed_preview_urdf_text(urdf_text, plan, robot_name=None):
         if src is None:
             src = joint_elems.get(row.get("name"))
         joint = _copy.deepcopy(src) if src is not None else _ET.Element("joint")
-        desired_name = source or row.get("name") or ""
-        if desired_name in used_joint_names:
-            desired_name = row.get("name") or desired_name
+        desired_name = row.get("name") or source or ""
         i, base_name = 1, desired_name
         while desired_name in used_joint_names:
             i += 1
@@ -2135,15 +2133,85 @@ def _collapsed_preview_urdf_text(urdf_text, plan, robot_name=None):
         _ET.tostring(out_root, encoding="unicode") + "\n"
 
 
-def _write_collapsed_preview_urdf(pkg_dir, urdf_rel, plan):
+def _expanded_preview_source_urdf_text(pkg_dir, urdf_rel, graph, yml_txt):
+    """Build an all-expanded hidden URDF source for collapsed-preview meshes."""
+    import yaml as _yaml
+
+    from sw2robot.exporter import model as _M
+    from sw2robot.exporter.urdf_writer import write_urdf
+
+    try:
+        cfg = _yaml.safe_load(yml_txt) or {}
+        if not isinstance(cfg, dict):
+            cfg = {}
+    except Exception:
+        cfg = {}
+    full_cfg = dict(cfg)
+    full_cfg["expand"] = [""]
+    full_cfg["no_expand"] = []
+    model = _M.build_model(graph, config=full_cfg)
+
+    stem = os.path.splitext(os.path.basename(urdf_rel))[0]
+    src_rel = posixpath.join(posixpath.dirname(urdf_rel),
+                             f".{stem}.expanded-preview-source.urdf")
+    src_path = os.path.join(pkg_dir, *src_rel.split("/"))
+    os.makedirs(os.path.dirname(src_path), exist_ok=True)
+    kwargs = {}
+    if cfg.get("density") is not None:
+        kwargs["density"] = float(cfg.get("density"))
+    kwargs["link_overrides"] = cfg.get("link_names") or {}
+    kwargs["joint_overrides"] = cfg.get("joint_names") or {}
+    write_urdf(model, src_path, **kwargs)
+    with open(src_path, encoding="utf-8") as f:
+        return f.read()
+
+
+def _collapsed_preview_mesh_report(urdf_text, plan):
+    import xml.etree.ElementTree as _ET
+
+    root = _ET.fromstring(urdf_text)
+    link_elems = {ln.get("name"): ln for ln in root.findall("link")
+                  if ln.get("name")}
+    report = []
+    for row in plan.get("links") or []:
+        if row.get("kind") != "collapsed_subassembly":
+            continue
+        members = list(row.get("member_links") or [])
+        missing = [m for m in members if m not in link_elems]
+        visual = 0
+        collision = 0
+        for member in members:
+            elem = link_elems.get(member)
+            if elem is None:
+                continue
+            visual += len(elem.findall("visual"))
+            collision += len(elem.findall("collision"))
+        report.append({
+            "link": row.get("link"),
+            "source_subassembly": row.get("source_subassembly", ""),
+            "members": len(members),
+            "missing_links": missing[:20],
+            "missing_count": len(missing),
+            "visuals": visual,
+            "collisions": collision,
+        })
+    return report
+
+
+def _write_collapsed_preview_urdf(pkg_dir, urdf_rel, plan,
+                                  graph=None, yml_txt=""):
     """Write a hidden dry-run collapsed URDF and return (abs_path, rel_path)."""
     stem = os.path.splitext(os.path.basename(urdf_rel))[0]
     out_rel = posixpath.join(posixpath.dirname(urdf_rel),
                              f".{stem}.collapsed-preview.urdf")
     in_path = os.path.join(pkg_dir, *urdf_rel.split("/"))
     out_path = os.path.join(pkg_dir, *out_rel.split("/"))
-    with open(in_path, encoding="utf-8") as f:
-        text = f.read()
+    if graph is not None:
+        text = _expanded_preview_source_urdf_text(
+            pkg_dir, urdf_rel, graph, yml_txt)
+    else:
+        with open(in_path, encoding="utf-8") as f:
+            text = f.read()
     out_text = _collapsed_preview_urdf_text(
         text, plan, robot_name=f"{stem}_collapsed_preview")
     os.makedirs(os.path.dirname(out_path), exist_ok=True)
@@ -2151,7 +2219,7 @@ def _write_collapsed_preview_urdf(pkg_dir, urdf_rel, plan):
     with open(tmp, "w", encoding="utf-8", newline="\n") as f:
         f.write(out_text)
     os.replace(tmp, out_path)
-    return out_path, out_rel
+    return out_path, out_rel, _collapsed_preview_mesh_report(text, plan)
 
 
 def _tree_rows_payload(base_link, links, joints):
@@ -3788,8 +3856,10 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                         "collapse_plan": plan,
                     }, 400)
                 try:
-                    out_path, out_rel = _write_collapsed_preview_urdf(
-                        cls.pkg_dir, cls.urdf_rel, plan)
+                    out_path, out_rel, mesh_report = \
+                        _write_collapsed_preview_urdf(
+                            cls.pkg_dir, cls.urdf_rel, plan,
+                            graph=gs, yml_txt=txt)
                 except ValueError as e:
                     return self._send_json({"error": str(e)}, 400)
                 except Exception as e:
@@ -3801,6 +3871,7 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                     "path": out_path,
                     "urdf": "/pkg/" + out_rel,
                     "collapse_plan": plan,
+                    "mesh_report": mesh_report,
                     "preview_counts": preview.get("preview_counts"),
                 })
             if path == "/api/fs":

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1199,6 +1199,37 @@ def _set_subassembly_origin_link_yaml(txt, graph, name, origin_link):
     return _remove_yaml_map_entry(txt, "subassembly_origin_links", name)
 
 
+def _subassembly_cycle_break_joints(yml_txt):
+    """Preview-only source joints dropped to break collapsed-tree cycles."""
+    import yaml as _yaml
+
+    try:
+        cfg = _yaml.safe_load(yml_txt) or {}
+        if not isinstance(cfg, dict):
+            return set()
+    except Exception:
+        return set()
+    raw = cfg.get("subassembly_cycle_break_joints") or []
+    if not isinstance(raw, list):
+        return set()
+    return {str(x) for x in raw if x is not None}
+
+
+def _set_subassembly_cycle_break_joint_yaml(
+        txt, source_joint, drop, previous_source_joint=""):
+    """Set/reset one preview-only source joint dropped for cycle breaking."""
+    source_joint = str(source_joint or "").strip()
+    previous_source_joint = str(previous_source_joint or "").strip()
+    target = source_joint or previous_source_joint
+    if not target:
+        raise ValueError("source_joint required")
+    remove = [x for x in (previous_source_joint, source_joint) if x]
+    add = [source_joint] if drop and source_joint else []
+    new_txt, _members = _set_yaml_list_block(
+        txt, "subassembly_cycle_break_joints", add=add, remove=remove)
+    return new_txt
+
+
 def _canonical_tree_payload(graph, yml_txt=""):
     """Fully-expanded tree plus CAD sub-assembly membership.
 
@@ -1276,6 +1307,7 @@ def _collapse_preview_payload(graph, yml_txt=""):
     states = _subassemblies_payload(graph, yml_txt)
     parent_overrides = _subassembly_parent_overrides(yml_txt)
     origin_links = _subassembly_origin_links(yml_txt)
+    cycle_break_joints = _subassembly_cycle_break_joints(yml_txt)
     by_sub = {s["name"]: s for s in canonical["subassemblies"]}
     collapse_link = {}
     collapsed = []
@@ -1361,6 +1393,18 @@ def _collapse_preview_payload(graph, yml_txt=""):
         joints.append(out)
 
     base = collapse_link.get(canonical["base_link"], canonical["base_link"])
+    cycle_break_choices = _collapse_cycle_break_choices(
+        base, links, joints, cycle_break_joints)
+    dropped_cycle_joints = []
+    if cycle_break_joints:
+        kept = []
+        for j in joints:
+            if _joint_source_name(j) in cycle_break_joints:
+                dropped_cycle_joints.append(j)
+            else:
+                kept.append(j)
+        joints = kept
+
     validation = _validate_collapsed_tree(base, links, joints, collapsed,
                                           collapse_link)
     return {
@@ -1370,9 +1414,11 @@ def _collapse_preview_payload(graph, yml_txt=""):
         "tree_rows": _tree_rows_payload(base, links, joints),
         "validation": validation,
         "dropped_internal_joints": dropped,
+        "dropped_cycle_joints": dropped_cycle_joints,
         "collapsed_subassemblies": collapsed,
         "parent_choices": parent_choices,
         "group_choices": group_choices,
+        "cycle_break_choices": cycle_break_choices,
         "canonical_counts": {
             "links": len(canonical["links"]),
             "joints": len(canonical["joints"]),
@@ -1472,11 +1518,109 @@ def _collapse_group_choices(collapsed, origin_links):
     return choices
 
 
+def _joint_source_name(joint):
+    return str(joint.get("source_name") or joint.get("name") or "")
+
+
+def _directed_cycle_reports(base_link, links, joints):
+    """Return directed cycles with the preview joints that form them."""
+    link_names = {l["link_name"] for l in links}
+    by_parent = {}
+    for j in joints:
+        by_parent.setdefault(j.get("parent"), []).append(j)
+    for rows in by_parent.values():
+        rows.sort(key=lambda j: (j.get("child", ""), j.get("name", "")))
+
+    reports, seen_cycles, colour = [], set(), {}
+    stack_links, stack_edges = [], []
+
+    def add_cycle(child, back_edge):
+        try:
+            i = stack_links.index(child)
+        except ValueError:
+            return
+        cycle_links = [*stack_links[i:], child]
+        cycle_edges = [*stack_edges[i:], back_edge]
+        key = tuple(_joint_source_name(j) for j in cycle_edges) or \
+            tuple(cycle_links)
+        if key in seen_cycles:
+            return
+        seen_cycles.add(key)
+        candidates = [{
+            "joint": j.get("name"),
+            "source_joint": _joint_source_name(j),
+            "parent": j.get("parent"),
+            "child": j.get("child"),
+        } for j in cycle_edges]
+        reports.append({
+            "links": cycle_links,
+            "joints": [j.get("name") for j in cycle_edges],
+            "source_joints": [_joint_source_name(j) for j in cycle_edges],
+            "candidates": candidates,
+        })
+
+    def dfs(node):
+        colour[node] = "gray"
+        stack_links.append(node)
+        for j in by_parent.get(node, []):
+            child = j.get("child")
+            if child not in link_names:
+                continue
+            if colour.get(child) == "gray":
+                add_cycle(child, j)
+            elif colour.get(child) != "black":
+                stack_edges.append(j)
+                dfs(child)
+                stack_edges.pop()
+        stack_links.pop()
+        colour[node] = "black"
+
+    roots = [base_link] if base_link in link_names else []
+    roots.extend(sorted(link_names - set(roots)))
+    for root in roots:
+        if colour.get(root) is None:
+            dfs(root)
+    return reports
+
+
+def _collapse_cycle_break_choices(base_link, links, joints, selected_sources):
+    """List preview source-joint candidates that can break active cycles."""
+    selected_sources = set(selected_sources or [])
+    choices = []
+    active_sources = set()
+    for cycle in _directed_cycle_reports(base_link, links, joints):
+        candidates = cycle.get("candidates", [])
+        for c in candidates:
+            if c.get("source_joint"):
+                active_sources.add(c["source_joint"])
+        selected = next((c.get("source_joint") for c in candidates
+                         if c.get("source_joint") in selected_sources), "")
+        choices.append({
+            **cycle,
+            "selected_source_joint": selected,
+            "resolved": False,
+        })
+    for source in sorted(selected_sources - active_sources):
+        choices.append({
+            "links": [],
+            "joints": [],
+            "source_joints": [source],
+            "selected_source_joint": source,
+            "resolved": True,
+            "candidates": [{
+                "joint": source,
+                "source_joint": source,
+                "parent": "",
+                "child": "",
+            }],
+        })
+    return choices
+
+
 def _validate_collapsed_tree(base_link, links, joints, collapsed,
                              collapse_link=None):
     """Report structural hazards in a collapsed preview tree."""
     collapse_link = collapse_link or {}
-    link_names = {l["link_name"] for l in links}
     issues = []
 
     incoming = {}
@@ -1497,37 +1641,16 @@ def _validate_collapsed_tree(base_link, links, joints, collapsed,
                     "sub-assembly collapse"),
             })
 
-    adj = {}
-    for j in joints:
-        adj.setdefault(j["parent"], []).append(j["child"])
-    seen_cycles, colour, stack = set(), {}, []
-
-    def dfs(node):
-        colour[node] = "gray"
-        stack.append(node)
-        for child in adj.get(node, []):
-            if colour.get(child) == "gray":
-                i = stack.index(child)
-                cyc = [*stack[i:], child]
-                key = tuple(cyc)
-                if key not in seen_cycles:
-                    seen_cycles.add(key)
-                    issues.append({
-                        "severity": "error",
-                        "code": "cycle",
-                        "links": cyc,
-                        "message": "collapsed tree contains a directed cycle",
-                    })
-            elif colour.get(child) != "black":
-                dfs(child)
-        stack.pop()
-        colour[node] = "black"
-
-    roots = [base_link] if base_link in link_names else []
-    roots.extend(sorted(link_names - set(roots)))
-    for root in roots:
-        if colour.get(root) is None:
-            dfs(root)
+    for cycle in _directed_cycle_reports(base_link, links, joints):
+        issues.append({
+            "severity": "error",
+            "code": "cycle",
+            "links": cycle["links"],
+            "joints": cycle["joints"],
+            "source_joints": cycle["source_joints"],
+            "candidates": cycle["candidates"],
+            "message": "collapsed tree contains a directed cycle",
+        })
 
     for sub in collapsed:
         comps = _subassembly_member_groups(sub)
@@ -4164,6 +4287,65 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                                 "rebuilt": False})
                 print(f"[sw2robot.web] set_subassembly_origin_link: "
                       f"{name_in} -> {label} (preview only)")
+                return self._send_json(payload)
+            if parsed.path == "/api/set_subassembly_cycle_break":
+                cls = type(self)
+                n = int(self.headers.get("Content-Length", 0))
+                body = json.loads(self.rfile.read(n) or b"{}")
+                source_joint = (body.get("source_joint") or "").strip()
+                previous_source_joint = (
+                    body.get("previous_source_joint") or "").strip()
+                drop = bool(body.get("drop", True))
+                target = source_joint or previous_source_joint
+                if not cls.pkg_dir:
+                    return self._send_json({"error": "no package open"}, 400)
+                if not _cad_mode(cls.pkg_dir):
+                    return self._send_json(
+                        {"error": "sub-assembly cycle breaks need the CAD "
+                                  "graph.json"},
+                        400)
+                if not target:
+                    return self._send_json(
+                        {"error": "source_joint required"}, 400)
+                from sw2robot.exporter.state import GraphState
+                graph = GraphState.load(os.path.join(cls.pkg_dir, "graph.json"))
+                name = os.path.splitext(os.path.basename(cls.urdf_rel))[0]
+                yml = os.path.join(cls.pkg_dir, name + ".joints.yaml")
+                if not os.path.exists(yml):
+                    return self._send_json(
+                        {"error": "joints.yaml not found -- re-extract once"},
+                        400)
+                with open(yml, encoding="utf-8") as f:
+                    txt = f.read()
+                try:
+                    preview = _collapse_preview_payload(graph, txt)
+                    selected = _subassembly_cycle_break_joints(txt)
+                    allowed = set(selected)
+                    for choice in preview.get("cycle_break_choices", []):
+                        for cand in choice.get("candidates", []):
+                            if cand.get("source_joint"):
+                                allowed.add(cand["source_joint"])
+                    if target not in allowed:
+                        return self._send_json(
+                            {"error": f"'{target}' is not a cycle-break "
+                                      "candidate"},
+                            400)
+                    txt = _set_subassembly_cycle_break_joint_yaml(
+                        txt, source_joint, drop, previous_source_joint)
+                except ValueError as e:
+                    return self._send_json({"error": str(e)}, 400)
+                label = source_joint if drop else "auto"
+                _snapshot(cls.pkg_dir, yml,
+                          f"sub-assembly cycle break {target} -> {label}")
+                with open(yml, "w", encoding="utf-8") as f:
+                    f.write(txt)
+                payload = _collapse_preview_payload(graph, txt)
+                payload.update({"ok": True, "source_joint": source_joint,
+                                "previous_source_joint": previous_source_joint,
+                                "drop": drop, "preview_only": True,
+                                "rebuilt": False})
+                print(f"[sw2robot.web] set_subassembly_cycle_break: "
+                      f"{target} -> {label} (preview only)")
                 return self._send_json(payload)
             if parsed.path == "/api/set_base":
                 cls = type(self)

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1393,8 +1393,6 @@ def _collapse_preview_payload(graph, yml_txt=""):
         joints.append(out)
 
     base = collapse_link.get(canonical["base_link"], canonical["base_link"])
-    cycle_break_choices = _collapse_cycle_break_choices(
-        base, links, joints, cycle_break_joints)
     dropped_cycle_joints = []
     if cycle_break_joints:
         kept = []
@@ -1404,6 +1402,8 @@ def _collapse_preview_payload(graph, yml_txt=""):
             else:
                 kept.append(j)
         joints = kept
+    cycle_break_choices = _collapse_cycle_break_choices(
+        base, links, joints, cycle_break_joints)
 
     validation = _validate_collapsed_tree(base, links, joints, collapsed,
                                           collapse_link)
@@ -1541,8 +1541,7 @@ def _directed_cycle_reports(base_link, links, joints):
             return
         cycle_links = [*stack_links[i:], child]
         cycle_edges = [*stack_edges[i:], back_edge]
-        key = tuple(_joint_source_name(j) for j in cycle_edges) or \
-            tuple(cycle_links)
+        key = tuple(_joint_source_name(j) for j in cycle_edges)
         if key in seen_cycles:
             return
         seen_cycles.add(key)
@@ -1598,7 +1597,7 @@ def _collapse_cycle_break_choices(base_link, links, joints, selected_sources):
         choices.append({
             **cycle,
             "selected_source_joint": selected,
-            "resolved": False,
+            "stale": False,
         })
     for source in sorted(selected_sources - active_sources):
         choices.append({
@@ -1606,7 +1605,7 @@ def _collapse_cycle_break_choices(base_link, links, joints, selected_sources):
             "joints": [],
             "source_joints": [source],
             "selected_source_joint": source,
-            "resolved": True,
+            "stale": True,
             "candidates": [{
                 "joint": source,
                 "source_joint": source,

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1168,7 +1168,11 @@ def _set_subassembly_parent_override_yaml(txt, graph, name, parent):
 
 
 def _subassembly_origin_links(yml_txt):
-    """Preview-only representative member links for collapsed sub-assemblies."""
+    """Preview-only representative member links for collapsed sub-assemblies.
+
+    The build/export path does not consume this yet; it only documents the
+    user's intended anchor for collapsed preview diagnostics.
+    """
     import yaml as _yaml
 
     try:
@@ -1307,6 +1311,16 @@ def _collapse_preview_payload(graph, yml_txt=""):
         sub["selected_parent"] = selected_parent_by_subassembly.get(
             sub["name"], "")
     group_choices = _collapse_group_choices(collapsed, origin_links)
+    origin_choice_by_subassembly = {
+        c.get("subassembly"): c
+        for c in group_choices
+    }
+    for sub in collapsed:
+        choice = origin_choice_by_subassembly.get(sub["name"], {})
+        sub["selected_origin_link"] = choice.get("selected_origin_link", "")
+        stale = choice.get("stale_origin_link", "")
+        if stale:
+            sub["stale_origin_link"] = stale
 
     links = []
     inserted = set()
@@ -1436,13 +1450,20 @@ def _collapse_group_choices(collapsed, origin_links):
     choices = []
     for sub in collapsed:
         groups = _subassembly_member_groups(sub)
-        selected = origin_links.get(sub.get("name"), "")
-        if len(groups) <= 1 and not selected:
+        members = set(sub.get("member_links") or [])
+        raw_selected = origin_links.get(sub.get("name"), "")
+        selected = raw_selected if raw_selected in members else ""
+        stale = (
+            raw_selected
+            if raw_selected and raw_selected not in members
+            else "")
+        if len(groups) <= 1 and not selected and not stale:
             continue
         choices.append({
             "subassembly": sub.get("name"),
             "link_name": sub.get("link_name"),
             "selected_origin_link": selected,
+            "stale_origin_link": stale,
             "groups": [
                 {"origin_link": g[0], "links": g, "size": len(g)}
                 for g in groups
@@ -1510,22 +1531,33 @@ def _validate_collapsed_tree(base_link, links, joints, collapsed,
 
     for sub in collapsed:
         comps = _subassembly_member_groups(sub)
-        if len(comps) <= 1:
-            continue
-        selected_origin_link = sub.get("selected_origin_link")
-        if selected_origin_link and any(selected_origin_link in comp for comp in comps):
-            pass
-        elif selected_origin_link:
+        stale_origin_link = sub.get("stale_origin_link")
+        if stale_origin_link:
             issues.append({
                 "severity": "warning",
                 "code": "invalid_origin_link",
                 "subassembly": sub.get("name"),
                 "link": sub.get("link_name"),
-                "origin_link": selected_origin_link,
+                "origin_link": stale_origin_link,
                 "components": comps,
                 "message": (
                     f"{sub.get('name')} uses stale origin link "
-                    f"{selected_origin_link}"),
+                    f"{stale_origin_link}"),
+            })
+        selected_origin_link = sub.get("selected_origin_link")
+        if len(comps) <= 1:
+            continue
+        if selected_origin_link:
+            issues.append({
+                "severity": "info",
+                "code": "disconnected_members",
+                "subassembly": sub.get("name"),
+                "link": sub.get("link_name"),
+                "origin_link": selected_origin_link,
+                "components": comps,
+                "message": (
+                    f"{sub.get('name')} maps to {len(comps)} disconnected "
+                    f"member groups; anchored at {selected_origin_link}"),
             })
         else:
             issues.append({

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1300,7 +1300,7 @@ def _collapse_preview_payload(graph, yml_txt=""):
         for c in parent_choices
         if c.get("selected_parent")
     }
-    joints, dropped, dropped_parent_override = [], [], []
+    joints, dropped = [], []
     for j in canonical["joints"]:
         parent = collapse_link.get(j["parent"], j["parent"])
         child = collapse_link.get(j["child"], j["child"])
@@ -1311,7 +1311,6 @@ def _collapse_preview_payload(graph, yml_txt=""):
             continue
         selected = selected_by_link.get(child)
         if selected and parent != selected:
-            dropped_parent_override.append(out)
             continue
         out["name"] = f"{parent}__{child}"
         joints.append(out)
@@ -1326,7 +1325,6 @@ def _collapse_preview_payload(graph, yml_txt=""):
         "tree_rows": _tree_rows_payload(base, links, joints),
         "validation": validation,
         "dropped_internal_joints": dropped,
-        "dropped_parent_override_joints": dropped_parent_override,
         "collapsed_subassemblies": collapsed,
         "parent_choices": parent_choices,
         "canonical_counts": {

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1682,10 +1682,10 @@ def _collapse_driver_joint_choices(collapsed, collapse_link, driver_joints):
                      and c.get("movable")), "")
         if not auto:
             auto = next((c.get("source_joint") for c in candidates
-                         if c.get("role") == "incoming_boundary"), "")
+                         if c.get("movable")), "")
         if not auto:
             auto = next((c.get("source_joint") for c in candidates
-                         if c.get("movable")), "")
+                         if c.get("role") == "incoming_boundary"), "")
         choices.append({
             "subassembly": sub.get("name"),
             "link_name": link_name,

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1828,10 +1828,15 @@ def _collapse_plan_payload(base_link, links, joints, collapsed, collapse_link,
     for row in dropped_cycle:
         dropped_joints.append(plan_joint(row, "dropped_cycle_break"))
 
+    blocking_issue_count = sum(
+        issue.get("severity") != "info"
+        for issue in (validation.get("issues") or []))
+
     return {
         "version": 1,
         "base_link": base_link,
-        "ready_for_urdf": int(validation.get("issue_count") or 0) == 0,
+        "ready_for_urdf": blocking_issue_count == 0,
+        "blocking_issue_count": blocking_issue_count,
         "links": [plan_link(row) for row in links],
         "joints": [plan_joint(row) for row in joints],
         "dropped_joints": dropped_joints,

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1377,19 +1377,25 @@ def _collapse_preview_payload(graph, yml_txt=""):
         for c in parent_choices
         if c.get("selected_parent")
     }
-    joints, dropped = [], []
+    joints, dropped, dropped_parent_override = [], [], []
     for j in canonical["joints"]:
         parent = collapse_link.get(j["parent"], j["parent"])
         child = collapse_link.get(j["child"], j["child"])
         out = {**j, "source_name": j["name"],
                "parent": parent, "child": child}
+        collapsed_endpoint = parent != j["parent"] or child != j["child"]
         if parent == child:
+            out["decision"] = "dropped_internal_to_collapsed_subassembly"
             dropped.append(out)
             continue
         selected = selected_by_link.get(child)
         if selected and parent != selected:
+            out["decision"] = "dropped_parent_override"
+            dropped_parent_override.append(out)
             continue
         out["name"] = f"{parent}__{child}"
+        out["decision"] = "kept_boundary" if collapsed_endpoint \
+            else "kept_expanded"
         joints.append(out)
 
     base = collapse_link.get(canonical["base_link"], canonical["base_link"])
@@ -1398,6 +1404,7 @@ def _collapse_preview_payload(graph, yml_txt=""):
         kept = []
         for j in joints:
             if _joint_source_name(j) in cycle_break_joints:
+                j["decision"] = "dropped_cycle_break"
                 dropped_cycle_joints.append(j)
             else:
                 kept.append(j)
@@ -1407,11 +1414,15 @@ def _collapse_preview_payload(graph, yml_txt=""):
 
     validation = _validate_collapsed_tree(base, links, joints, collapsed,
                                           collapse_link)
+    collapse_plan = _collapse_plan_payload(
+        base, links, joints, collapsed, collapse_link, dropped,
+        dropped_parent_override, dropped_cycle_joints, validation)
     return {
         "base_link": base,
         "links": links,
         "joints": joints,
-        "tree_rows": _tree_rows_payload(base, links, joints),
+        "tree_rows": _tree_rows_from_collapse_plan(collapse_plan),
+        "collapse_plan": collapse_plan,
         "validation": validation,
         "dropped_internal_joints": dropped,
         "dropped_cycle_joints": dropped_cycle_joints,
@@ -1724,6 +1735,90 @@ def _validate_collapsed_tree(base_link, links, joints, collapsed,
         "issue_count": len(issues),
         "issues": issues,
     }
+
+
+def _collapse_plan_payload(base_link, links, joints, collapsed, collapse_link,
+                           dropped_internal, dropped_parent_override,
+                           dropped_cycle, validation):
+    """Stable preview IR shared by the UI and future collapsed URDF output."""
+    sub_by_link = {s.get("link_name"): s for s in collapsed}
+
+    def plan_link(row):
+        link = row.get("link_name")
+        sub = sub_by_link.get(link, {})
+        collapsed_row = bool(row.get("collapsed"))
+        return {
+            "link": link,
+            "name": row.get("name", link),
+            "kind": "collapsed_subassembly" if collapsed_row
+                    else "expanded_link",
+            "source_subassembly": sub.get("name", "") if collapsed_row else "",
+            "member_links": list(row.get("member_links") or []),
+            "member_components": list(sub.get("member_components") or []),
+            "selected_parent": sub.get("selected_parent", ""),
+            "selected_origin_link": sub.get("selected_origin_link", ""),
+        }
+
+    def plan_joint(row, decision=None):
+        return {
+            "name": row.get("name"),
+            "parent": row.get("parent"),
+            "child": row.get("child"),
+            "type": row.get("type"),
+            "source_joint": _joint_source_name(row),
+            "decision": decision or row.get("decision", ""),
+        }
+
+    dropped_joints = []
+    for row in dropped_internal:
+        dropped_joints.append(plan_joint(
+            row, "dropped_internal_to_collapsed_subassembly"))
+    for row in dropped_parent_override:
+        dropped_joints.append(plan_joint(row, "dropped_parent_override"))
+    for row in dropped_cycle:
+        dropped_joints.append(plan_joint(row, "dropped_cycle_break"))
+
+    return {
+        "version": 1,
+        "base_link": base_link,
+        "ready_for_urdf": (
+            bool(validation.get("ok")) and
+            int(validation.get("issue_count") or 0) == 0
+        ),
+        "links": [plan_link(row) for row in links],
+        "joints": [plan_joint(row) for row in joints],
+        "dropped_joints": dropped_joints,
+        "collapsed_subassemblies": [{
+            "name": s.get("name"),
+            "link": s.get("link_name"),
+            "member_links": list(s.get("member_links") or []),
+            "member_components": list(s.get("member_components") or []),
+            "selected_parent": s.get("selected_parent", ""),
+            "selected_origin_link": s.get("selected_origin_link", ""),
+        } for s in collapsed],
+        "link_replacements": [
+            {"source_link": src, "collapsed_link": dst}
+            for src, dst in sorted(collapse_link.items())
+        ],
+    }
+
+
+def _tree_rows_from_collapse_plan(plan):
+    """Flatten a collapse plan into the existing preview tree row shape."""
+    links = [{
+        "link_name": row.get("link"),
+        "name": row.get("name"),
+        "collapsed": row.get("kind") == "collapsed_subassembly",
+        "member_links": row.get("member_links") or [],
+    } for row in plan.get("links", [])]
+    joints = [{
+        "name": row.get("name"),
+        "parent": row.get("parent"),
+        "child": row.get("child"),
+        "type": row.get("type"),
+        "source_name": row.get("source_joint"),
+    } for row in plan.get("joints", [])]
+    return _tree_rows_payload(plan.get("base_link"), links, joints)
 
 
 def _tree_rows_payload(base_link, links, joints):

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1140,6 +1140,33 @@ def _set_subassembly_mode_yaml(txt, graph, name, mode):
     return txt, {"expand": exp_members, "no_expand": noexp_members}
 
 
+def _subassembly_parent_overrides(yml_txt):
+    """Preview-only parent choices for collapsed CAD sub-assemblies."""
+    import yaml as _yaml
+
+    try:
+        cfg = _yaml.safe_load(yml_txt) or {}
+        if not isinstance(cfg, dict):
+            return {}
+    except Exception:
+        return {}
+    raw = cfg.get("subassembly_parent_overrides") or {}
+    if not isinstance(raw, dict):
+        return {}
+    return {str(k): str(v) for k, v in raw.items() if v is not None}
+
+
+def _set_subassembly_parent_override_yaml(txt, graph, name, parent):
+    """Set/reset one preview-only collapsed sub-assembly parent choice."""
+    names = _subassembly_names(graph)
+    if name not in names:
+        raise ValueError(f"no CAD sub-assembly '{name}'")
+    if parent:
+        return _upsert_yaml_map(
+            txt, "subassembly_parent_overrides", name, _yaml_scalar(parent))
+    return _remove_yaml_map_entry(txt, "subassembly_parent_overrides", name)
+
+
 def _canonical_tree_payload(graph, yml_txt=""):
     """Fully-expanded tree plus CAD sub-assembly membership.
 
@@ -1215,6 +1242,7 @@ def _collapse_preview_payload(graph, yml_txt=""):
     """
     canonical = _canonical_tree_payload(graph, yml_txt)
     states = _subassemblies_payload(graph, yml_txt)
+    parent_overrides = _subassembly_parent_overrides(yml_txt)
     by_sub = {s["name"]: s for s in canonical["subassemblies"]}
     collapse_link = {}
     collapsed = []
@@ -1233,10 +1261,14 @@ def _collapse_preview_payload(graph, yml_txt=""):
             "member_components": sub["member_components"],
             "internal_joints": sub["internal_joints"],
             "boundary_joints": sub["boundary_joints"],
+            "selected_parent": parent_overrides.get(row["name"], ""),
         }
         collapsed.append(info)
         for link in sub["member_links"]:
             collapse_link[link] = row["link_name"]
+
+    parent_choices = _collapse_parent_choices(
+        collapsed, collapse_link, parent_overrides)
 
     links = []
     inserted = set()
@@ -1256,7 +1288,12 @@ def _collapse_preview_payload(graph, yml_txt=""):
             continue
         links.append({**link, "collapsed": False})
 
-    joints, dropped = [], []
+    selected_by_link = {
+        c["link_name"]: c.get("selected_parent", "")
+        for c in parent_choices
+        if c.get("selected_parent")
+    }
+    joints, dropped, dropped_parent_override = [], [], []
     for j in canonical["joints"]:
         parent = collapse_link.get(j["parent"], j["parent"])
         child = collapse_link.get(j["child"], j["child"])
@@ -1264,6 +1301,10 @@ def _collapse_preview_payload(graph, yml_txt=""):
                "parent": parent, "child": child}
         if parent == child:
             dropped.append(out)
+            continue
+        selected = selected_by_link.get(child)
+        if selected and parent != selected:
+            dropped_parent_override.append(out)
             continue
         out["name"] = f"{parent}__{child}"
         joints.append(out)
@@ -1278,7 +1319,9 @@ def _collapse_preview_payload(graph, yml_txt=""):
         "tree_rows": _tree_rows_payload(base, links, joints),
         "validation": validation,
         "dropped_internal_joints": dropped,
+        "dropped_parent_override_joints": dropped_parent_override,
         "collapsed_subassemblies": collapsed,
+        "parent_choices": parent_choices,
         "canonical_counts": {
             "links": len(canonical["links"]),
             "joints": len(canonical["joints"]),
@@ -1288,6 +1331,36 @@ def _collapse_preview_payload(graph, yml_txt=""):
             "joints": len(joints),
         },
     }
+
+
+def _collapse_parent_choices(collapsed, collapse_link, parent_overrides):
+    """List attach-parent candidates for collapsed sub-assemblies.
+
+    The candidates are computed before any override is applied so the UI can
+    still change an existing choice after it resolves the validation warning.
+    """
+    choices = []
+    for sub in collapsed:
+        by_parent = {}
+        link_name = sub.get("link_name")
+        for j in sub.get("boundary_joints") or []:
+            parent = collapse_link.get(j["parent"], j["parent"])
+            child = collapse_link.get(j["child"], j["child"])
+            if child == link_name and parent != child:
+                by_parent.setdefault(parent, []).append(j.get("name"))
+        selected = parent_overrides.get(sub.get("name"), "")
+        if len(by_parent) <= 1 and not selected:
+            continue
+        choices.append({
+            "subassembly": sub.get("name"),
+            "link_name": link_name,
+            "selected_parent": selected,
+            "parents": [
+                {"link": p, "joints": sorted(x for x in js if x)}
+                for p, js in sorted(by_parent.items())
+            ],
+        })
+    return choices
 
 
 def _validate_collapsed_tree(base_link, links, joints, collapsed,
@@ -1389,9 +1462,12 @@ def _validate_collapsed_tree(base_link, links, joints, collapsed,
             })
 
         incoming_boundary = []
+        selected_parent = sub.get("selected_parent")
         for j in sub.get("boundary_joints") or []:
             parent = collapse_link.get(j["parent"], j["parent"])
             child = collapse_link.get(j["child"], j["child"])
+            if selected_parent and parent != selected_parent:
+                continue
             if child == sub.get("link_name") and parent != child:
                 incoming_boundary.append({
                     "parent": parent,
@@ -3858,6 +3934,65 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                                 **members})
                 print(f"[sw2robot.web] set_subassembly_mode: "
                       f"{name_in} -> {mode} (preview only)")
+                return self._send_json(payload)
+            if parsed.path == "/api/set_subassembly_parent":
+                cls = type(self)
+                n = int(self.headers.get("Content-Length", 0))
+                body = json.loads(self.rfile.read(n) or b"{}")
+                name_in = (body.get("name") or "").strip()
+                parent = (body.get("parent") or "").strip()
+                if parent == "auto":
+                    parent = ""
+                if not cls.pkg_dir:
+                    return self._send_json({"error": "no package open"}, 400)
+                if not _cad_mode(cls.pkg_dir):
+                    return self._send_json(
+                        {"error": "sub-assembly parent choices need the CAD "
+                                  "graph.json"},
+                        400)
+                if not name_in:
+                    return self._send_json({"error": "name required"}, 400)
+                from sw2robot.exporter.state import GraphState
+                graph = GraphState.load(os.path.join(cls.pkg_dir, "graph.json"))
+                name = os.path.splitext(os.path.basename(cls.urdf_rel))[0]
+                yml = os.path.join(cls.pkg_dir, name + ".joints.yaml")
+                if not os.path.exists(yml):
+                    return self._send_json(
+                        {"error": "joints.yaml not found -- re-extract once"},
+                        400)
+                with open(yml, encoding="utf-8") as f:
+                    txt = f.read()
+                try:
+                    preview = _collapse_preview_payload(graph, txt)
+                    choices = {
+                        c.get("subassembly"): c
+                        for c in preview.get("parent_choices", [])
+                    }
+                    if parent:
+                        allowed = {
+                            p.get("link")
+                            for p in choices.get(name_in, {}).get("parents", [])
+                        }
+                        if parent not in allowed:
+                            return self._send_json(
+                                {"error": f"'{parent}' is not a parent "
+                                          f"candidate for {name_in}"},
+                                400)
+                    txt = _set_subassembly_parent_override_yaml(
+                        txt, graph, name_in, parent)
+                except ValueError as e:
+                    return self._send_json({"error": str(e)}, 400)
+                label = parent or "auto"
+                _snapshot(cls.pkg_dir, yml,
+                          f"sub-assembly parent {name_in} -> {label}")
+                with open(yml, "w", encoding="utf-8") as f:
+                    f.write(txt)
+                payload = _collapse_preview_payload(graph, txt)
+                payload.update({"ok": True, "name": name_in,
+                                "parent": parent, "preview_only": True,
+                                "rebuilt": False})
+                print(f"[sw2robot.web] set_subassembly_parent: "
+                      f"{name_in} -> {label} (preview only)")
                 return self._send_json(payload)
             if parsed.path == "/api/set_base":
                 cls = type(self)

--- a/tests/test_cad_mode_webserver.py
+++ b/tests/test_cad_mode_webserver.py
@@ -240,6 +240,23 @@ def test_collapsed_preview_urdf_endpoint_is_preview_only(server):
     assert {l.get("name") for l in preview.findall("link")} == {
         l.get("name") for l in normal.findall("link")}
     assert (pkg / "urdf" / "fingertip.urdf").is_file()
+    assert not list((pkg / "urdf").glob(
+        ".*.expanded-preview-source.urdf"))
+
+
+def test_collapsed_preview_urdf_rejects_invalid_joints_yaml(server):
+    base, pkg = server
+    (pkg / "fingertip.joints.yaml").write_text(
+        "joints: [unterminated\n", encoding="utf-8")
+
+    with pytest.raises(urllib.error.HTTPError) as caught:
+        urllib.request.urlopen(base + "/api/collapsed_preview_urdf")
+
+    assert caught.value.code == 400
+    payload = json.loads(caught.value.read().decode("utf-8"))
+    assert "invalid joints.yaml" in payload["error"]
+    assert not list((pkg / "urdf").glob(
+        ".*.expanded-preview-source.urdf"))
 
 
 def test_set_mimic_reflected_without_rebuild(server):

--- a/tests/test_cad_mode_webserver.py
+++ b/tests/test_cad_mode_webserver.py
@@ -223,6 +223,25 @@ def test_mass_only_folds_in_merged_view_matching_export(server):
     assert FIXED_JOINT not in {j.get("name") for j in merged.findall("joint")}
 
 
+def test_collapsed_preview_urdf_endpoint_is_preview_only(server):
+    base, pkg = server
+
+    r = _get_json(base, "/api/collapsed_preview_urdf")
+    assert r["ok"] is True
+    assert r["preview_only"] is True
+    assert r["rebuilt"] is False
+    assert r["urdf"].endswith(".collapsed-preview.urdf")
+    assert Path(r["path"]).is_file()
+    assert Path(r["path"]).name.startswith(".")
+
+    preview = ET.fromstring(_get(base, r["urdf"]))
+    normal = _served_urdf(base)
+    assert preview.get("name").endswith("_collapsed_preview")
+    assert {l.get("name") for l in preview.findall("link")} == {
+        l.get("name") for l in normal.findall("link")}
+    assert (pkg / "urdf" / "fingertip.urdf").is_file()
+
+
 def test_set_mimic_reflected_without_rebuild(server):
     base, pkg = server
     # make the fixed joint movable first (set_types still uses build() in CAD --

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -252,6 +252,44 @@ def test_collapse_preview_replaces_no_expand_subassembly_members():
     ]
 
 
+def test_collapse_preview_lists_subassembly_driver_joint_candidates():
+    from sw2robot.editor.webserver import (
+        _collapse_preview_payload,
+        _set_subassembly_driver_joint_yaml,
+        _subassembly_driver_joints,
+    )
+
+    graph = make_graph()
+    txt = "base: plate-1\nno_expand:\n- servo\n"
+    payload = _collapse_preview_payload(graph, txt)
+    choices = payload["driver_joint_choices"]
+    assert choices[0]["subassembly"] == "servo-1"
+    assert choices[0]["auto_driver_joint"] == \
+        "plate_1__servo_1__case_1"
+    assert [(c["source_joint"], c["role"], c["type"])
+            for c in choices[0]["candidates"]] == [
+        ("plate_1__servo_1__case_1", "incoming_boundary", "fixed"),
+        ("servo_1__case_1__servo_1__horn_1",
+         "internal_motion", "revolute"),
+    ]
+
+    txt = _set_subassembly_driver_joint_yaml(
+        txt, graph, "servo-1", "servo_1__case_1__servo_1__horn_1")
+    assert _subassembly_driver_joints(txt) == {
+        "servo-1": "servo_1__case_1__servo_1__horn_1"
+    }
+    payload = _collapse_preview_payload(graph, txt)
+    assert payload["driver_joint_choices"][0]["selected_driver_joint"] == \
+        "servo_1__case_1__servo_1__horn_1"
+    plan_sub = payload["collapse_plan"]["collapsed_subassemblies"][0]
+    assert plan_sub["selected_driver_joint"] == \
+        "servo_1__case_1__servo_1__horn_1"
+    assert [c["source_joint"] for c in plan_sub["driver_joint_candidates"]] == [
+        "plate_1__servo_1__case_1",
+        "servo_1__case_1__servo_1__horn_1",
+    ]
+
+
 def test_collapse_preview_keeps_expanded_override():
     from sw2robot.editor.webserver import _collapse_preview_payload
 

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -757,6 +757,38 @@ def test_collapsed_preview_urdf_lumps_member_visuals():
     assert sub_out.find("origin").get("xyz") == "0 2 3"
 
 
+def test_collapse_preview_http_cache_reuses_identical_input(tmp_path, monkeypatch):
+    from sw2robot.editor import webserver
+
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "graph.json").write_text("{}", encoding="utf-8")
+    yml = pkg / "robot.joints.yaml"
+    yml.write_text("base: a\n", encoding="utf-8")
+    calls = {"n": 0}
+
+    def fake_payload(_graph, txt):
+        calls["n"] += 1
+        return {"txt": txt, "calls": calls["n"]}
+
+    monkeypatch.setattr(webserver, "_collapse_preview_payload", fake_payload)
+    webserver._COLLAPSE_PREVIEW_CACHE.clear()
+
+    first = webserver._collapse_preview_payload_cached(
+        str(pkg), object(), str(yml), yml.read_text(encoding="utf-8"))
+    second = webserver._collapse_preview_payload_cached(
+        str(pkg), object(), str(yml), yml.read_text(encoding="utf-8"))
+
+    assert calls["n"] == 1
+    assert first == second == {"txt": "base: a\n", "calls": 1}
+
+    yml.write_text("base: b\n", encoding="utf-8")
+    third = webserver._collapse_preview_payload_cached(
+        str(pkg), object(), str(yml), yml.read_text(encoding="utf-8"))
+    assert calls["n"] == 2
+    assert third == {"txt": "base: b\n", "calls": 2}
+
+
 def test_validate_collapsed_tree_reports_disconnected_members():
     from sw2robot.editor.webserver import _validate_collapsed_tree
 

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -230,6 +230,25 @@ def test_collapse_preview_replaces_no_expand_subassembly_members():
     ]
     assert payload["tree_rows"][1]["member_links"] == [
         "servo_1__case_1", "servo_1__horn_1"]
+    plan = payload["collapse_plan"]
+    assert plan["ready_for_urdf"] is True
+    assert plan["collapsed_subassemblies"] == [{
+        "name": "servo-1",
+        "link": "servo_1",
+        "member_links": ["servo_1__case_1", "servo_1__horn_1"],
+        "member_components": ["servo-1/case-1", "servo-1/horn-1"],
+        "selected_parent": "",
+        "selected_origin_link": "",
+    }]
+    assert plan["link_replacements"] == [
+        {"source_link": "servo_1__case_1", "collapsed_link": "servo_1"},
+        {"source_link": "servo_1__horn_1", "collapsed_link": "servo_1"},
+    ]
+    assert [(j["source_joint"], j["decision"])
+            for j in plan["dropped_joints"]] == [
+        ("servo_1__case_1__servo_1__horn_1",
+         "dropped_internal_to_collapsed_subassembly"),
+    ]
 
 
 def test_collapse_preview_keeps_expanded_override():
@@ -453,9 +472,9 @@ joints:
         i["code"] for i in payload["validation"]["issues"]
     }
     plan = payload["collapse_plan"]
-    assert plan["ready_for_urdf"] is True
+    assert plan["ready_for_urdf"] is False
     servo_link = next(l for l in plan["links"] if l["link"] == "servo_1")
-    assert servo_link["selected_origin_link"] == "servo_1__horn_1"
+    assert servo_link["selected_origin_link"] == ""
 
 
 def test_collapse_preview_can_reset_subassembly_parent_override_to_auto():
@@ -548,6 +567,11 @@ def test_collapse_preview_applies_cycle_break_before_choices(monkeypatch):
         "subassemblies": [],
     })
 
+    unresolved = webserver._collapse_preview_payload(object(), "")
+    assert any(i["code"] == "cycle"
+               for i in unresolved["validation"]["issues"])
+    assert unresolved["collapse_plan"]["ready_for_urdf"] is False
+
     payload = webserver._collapse_preview_payload(
         object(), "subassembly_cycle_break_joints:\n- arm__base\n")
 
@@ -567,6 +591,36 @@ def test_collapse_preview_applies_cycle_break_before_choices(monkeypatch):
             "child": "",
         }],
     }]
+    assert payload["collapse_plan"]["ready_for_urdf"] is True
+    assert [(j["source_joint"], j["decision"])
+            for j in payload["collapse_plan"]["dropped_joints"]] == [
+        ("arm__base", "dropped_cycle_break"),
+    ]
+
+
+def test_collapse_plan_rejects_unreachable_second_root(monkeypatch):
+    from sw2robot.editor import webserver
+
+    monkeypatch.setattr(webserver, "_canonical_tree_payload", lambda *_: {
+        "base_link": "base",
+        "links": [{"name": n, "link_name": n}
+                  for n in ("base", "arm", "orphan")],
+        "joints": [{
+            "name": "base__arm", "parent": "base", "child": "arm",
+            "type": "fixed",
+        }],
+        "subassemblies": [],
+    })
+    monkeypatch.setattr(webserver, "_subassemblies_payload", lambda *_: {
+        "subassemblies": [],
+    })
+
+    payload = webserver._collapse_preview_payload(object(), "")
+
+    issues = {i["code"]: i for i in payload["validation"]["issues"]}
+    assert issues["invalid_roots"]["roots"] == ["base", "orphan"]
+    assert issues["unreachable_links"]["links"] == ["orphan"]
+    assert payload["collapse_plan"]["ready_for_urdf"] is False
 
 
 def test_subassembly_cycle_break_yaml_adds_and_resets_source_joint():

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -225,6 +225,7 @@ def test_collapse_preview_keeps_expanded_override():
 def test_collapse_preview_applies_subassembly_parent_override():
     from sw2robot.editor.webserver import (
         _collapse_preview_payload,
+        _set_subassembly_origin_link_yaml,
         _set_subassembly_parent_override_yaml,
     )
 
@@ -252,7 +253,8 @@ joints:
         "bracket_1", "plate_1"]
     assert {
         i["code"] for i in payload["validation"]["issues"]
-    } >= {"multiple_parents", "multiple_boundary_parents"}
+    } >= {"multiple_parents", "multiple_boundary_parents",
+          "disconnected_members"}
 
     txt = _set_subassembly_parent_override_yaml(
         txt, graph, "servo-1", "bracket_1")
@@ -263,6 +265,21 @@ joints:
         ("plate_1", "bracket_1"),
     ]
     assert "multiple_boundary_parents" not in {
+        i["code"] for i in payload["validation"]["issues"]
+    }
+    assert payload["group_choices"][0]["subassembly"] == "servo-1"
+    assert [g["origin_link"] for g in payload["group_choices"][0]["groups"]] == [
+        "servo_1__case_1", "servo_1__horn_1"]
+    assert "disconnected_members" in {
+        i["code"] for i in payload["validation"]["issues"]
+    }
+
+    txt = _set_subassembly_origin_link_yaml(
+        txt, graph, "servo-1", "servo_1__horn_1")
+    payload = _collapse_preview_payload(graph, txt)
+    assert payload["group_choices"][0]["selected_origin_link"] == \
+        "servo_1__horn_1"
+    assert "disconnected_members" not in {
         i["code"] for i in payload["validation"]["issues"]
     }
 

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -676,6 +676,85 @@ def test_cycle_break_shared_candidate_resolves_two_cycles():
 
     kept = [j for j in joints if j["source_name"] != "shared"]
     assert _directed_cycle_reports("base", links, kept) == []
+def test_collapsed_preview_urdf_lumps_member_visuals():
+    import xml.etree.ElementTree as ET
+
+    from sw2robot.editor.webserver import _collapsed_preview_urdf_text
+
+    urdf = """<?xml version="1.0"?>
+<robot name="demo">
+  <link name="base"/>
+  <link name="sub_a">
+    <visual><origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry><mesh filename="../meshes/a.stl"/></geometry></visual>
+  </link>
+  <link name="sub_b">
+    <visual><origin xyz="0 0 0.5" rpy="0 0 0"/>
+      <geometry><mesh filename="../meshes/b.stl"/></geometry></visual>
+  </link>
+  <link name="outside"/>
+  <joint name="base__sub_a" type="fixed">
+    <origin xyz="1 0 0" rpy="0 0 0"/>
+    <parent link="base"/><child link="sub_a"/>
+  </joint>
+  <joint name="sub_a__sub_b" type="fixed">
+    <origin xyz="0 2 0" rpy="0 0 0"/>
+    <parent link="sub_a"/><child link="sub_b"/>
+  </joint>
+  <joint name="sub_b__outside" type="fixed">
+    <origin xyz="0 0 3" rpy="0 0 0"/>
+    <parent link="sub_b"/><child link="outside"/>
+  </joint>
+</robot>
+"""
+    plan = {
+        "version": 1,
+        "base_link": "base",
+        "ready_for_urdf": True,
+        "links": [
+            {"link": "base", "name": "base", "kind": "expanded_link"},
+            {"link": "sub", "name": "sub", "kind": "collapsed_subassembly",
+             "member_links": ["sub_a", "sub_b"],
+             "selected_origin_link": "sub_a"},
+            {"link": "outside", "name": "outside", "kind": "expanded_link"},
+        ],
+        "joints": [
+            {"name": "base__sub", "parent": "base", "child": "sub",
+             "type": "fixed", "source_joint": "base__sub_a",
+             "decision": "kept_boundary"},
+            {"name": "sub__outside", "parent": "sub", "child": "outside",
+             "type": "fixed", "source_joint": "sub_b__outside",
+             "decision": "kept_boundary"},
+        ],
+        "dropped_joints": [
+            {"name": "sub_a__sub_b", "parent": "sub", "child": "sub",
+             "type": "fixed", "source_joint": "sub_a__sub_b",
+             "decision": "dropped_internal_to_collapsed_subassembly"},
+        ],
+        "collapsed_subassemblies": [],
+        "link_replacements": [
+            {"source_link": "sub_a", "collapsed_link": "sub"},
+            {"source_link": "sub_b", "collapsed_link": "sub"},
+        ],
+    }
+    root = ET.fromstring(_collapsed_preview_urdf_text(urdf, plan))
+
+    assert {x.get("name") for x in root.findall("link")} == {
+        "base", "sub", "outside"}
+    assert {x.get("name") for x in root.findall("joint")} == {
+        "base__sub", "sub__outside"}
+    sub = next(x for x in root.findall("link") if x.get("name") == "sub")
+    visuals = sub.findall("visual")
+    assert len(visuals) == 2
+    meshes = [v.find(".//mesh").get("filename") for v in visuals]
+    assert meshes == ["../meshes/a.stl", "../meshes/b.stl"]
+    assert visuals[0].find("origin").get("xyz") == "0 0 0"
+    assert visuals[1].find("origin").get("xyz") == "0 2 0.5"
+    sub_out = next(j for j in root.findall("joint")
+                   if j.get("name") == "sub__outside")
+    assert sub_out.find("parent").get("link") == "sub"
+    assert sub_out.find("child").get("link") == "outside"
+    assert sub_out.find("origin").get("xyz") == "0 2 3"
 
 
 def test_validate_collapsed_tree_reports_disconnected_members():

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -271,6 +271,81 @@ joints:
     }
 
 
+def test_collapse_preview_ignores_stale_subassembly_parent_override():
+    from sw2robot.editor.webserver import _collapse_preview_payload
+
+    graph = make_graph()
+    graph.components.append(_comp("bracket-1", "bracket_1", xyz=(0, 0.1, 0)))
+    txt = """
+base: plate-1
+no_expand:
+- servo
+subassembly_parent_overrides:
+  servo-1: missing_parent
+joints:
+  - parent: plate-1
+    child:  servo-1/case-1
+    type:   fixed
+  - parent: bracket-1
+    child:  servo-1/horn-1
+    type:   fixed
+  - parent: plate-1
+    child:  bracket-1
+    type:   fixed
+"""
+    payload = _collapse_preview_payload(graph, txt)
+    assert payload["parent_choices"][0]["selected_parent"] == ""
+    assert payload["collapsed_subassemblies"][0]["selected_parent"] == ""
+    assert {
+        (j["parent"], j["child"]) for j in payload["joints"]
+    } >= {
+        ("plate_1", "servo_1"),
+        ("bracket_1", "servo_1"),
+    }
+    assert "multiple_boundary_parents" in {
+        i["code"] for i in payload["validation"]["issues"]
+    }
+
+
+def test_collapse_preview_can_reset_subassembly_parent_override_to_auto():
+    from sw2robot.editor.webserver import (
+        _collapse_preview_payload,
+        _set_subassembly_parent_override_yaml,
+        _subassembly_parent_overrides,
+    )
+
+    graph = make_graph()
+    graph.components.append(_comp("bracket-1", "bracket_1", xyz=(0, 0.1, 0)))
+    txt = """
+base: plate-1
+no_expand:
+- servo
+joints:
+  - parent: plate-1
+    child:  servo-1/case-1
+    type:   fixed
+  - parent: bracket-1
+    child:  servo-1/horn-1
+    type:   fixed
+  - parent: plate-1
+    child:  bracket-1
+    type:   fixed
+"""
+    txt = _set_subassembly_parent_override_yaml(
+        txt, graph, "servo-1", "bracket_1")
+    txt = _set_subassembly_parent_override_yaml(txt, graph, "servo-1", "")
+    assert _subassembly_parent_overrides(txt) == {}
+
+    payload = _collapse_preview_payload(graph, txt)
+    assert payload["parent_choices"][0]["selected_parent"] == ""
+    assert {
+        (j["parent"], j["child"]) for j in payload["joints"]
+    } >= {
+        ("plate_1", "servo_1"),
+        ("bracket_1", "servo_1"),
+    }
+
+
 def test_validate_collapsed_tree_reports_multiple_parents_and_cycles():
     from sw2robot.editor.webserver import _validate_collapsed_tree
 

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -222,6 +222,55 @@ def test_collapse_preview_keeps_expanded_override():
     ]
 
 
+def test_collapse_preview_applies_subassembly_parent_override():
+    from sw2robot.editor.webserver import (
+        _collapse_preview_payload,
+        _set_subassembly_parent_override_yaml,
+    )
+
+    graph = make_graph()
+    graph.components.append(_comp("bracket-1", "bracket_1", xyz=(0, 0.1, 0)))
+    txt = """
+base: plate-1
+no_expand:
+- servo
+joints:
+  - parent: plate-1
+    child:  servo-1/case-1
+    type:   fixed
+  - parent: bracket-1
+    child:  servo-1/horn-1
+    type:   fixed
+  - parent: plate-1
+    child:  bracket-1
+    type:   fixed
+"""
+    payload = _collapse_preview_payload(graph, txt)
+    choices = payload["parent_choices"]
+    assert choices[0]["subassembly"] == "servo-1"
+    assert [p["link"] for p in choices[0]["parents"]] == [
+        "bracket_1", "plate_1"]
+    assert {
+        i["code"] for i in payload["validation"]["issues"]
+    } >= {"multiple_parents", "multiple_boundary_parents"}
+
+    txt = _set_subassembly_parent_override_yaml(
+        txt, graph, "servo-1", "bracket_1")
+    payload = _collapse_preview_payload(graph, txt)
+    assert payload["parent_choices"][0]["selected_parent"] == "bracket_1"
+    assert [(j["parent"], j["child"]) for j in payload["joints"]] == [
+        ("bracket_1", "servo_1"),
+        ("plate_1", "bracket_1"),
+    ]
+    assert [j["source_name"]
+            for j in payload["dropped_parent_override_joints"]] == [
+        "plate_1__servo_1__case_1"
+    ]
+    assert "multiple_boundary_parents" not in {
+        i["code"] for i in payload["validation"]["issues"]
+    }
+
+
 def test_validate_collapsed_tree_reports_multiple_parents_and_cycles():
     from sw2robot.editor.webserver import _validate_collapsed_tree
 

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -491,7 +491,46 @@ def test_validate_collapsed_tree_reports_multiple_parents_and_cycles():
     assert multi["source_joints"] == ["j1", "j2"]
     cycle = next(i for i in payload["issues"] if i["code"] == "cycle")
     assert cycle["links"] == ["base", "arm", "base"]
+    assert cycle["source_joints"] == ["j1", "j3"]
+    assert cycle["candidates"] == [
+        {"joint": "base__arm", "source_joint": "j1",
+         "parent": "base", "child": "arm"},
+        {"joint": "arm__base", "source_joint": "j3",
+         "parent": "arm", "child": "base"},
+    ]
     assert payload["ok"] is False
+
+
+def test_subassembly_cycle_break_choices_drop_source_joint():
+    from sw2robot.editor.webserver import (
+        _collapse_cycle_break_choices,
+        _set_subassembly_cycle_break_joint_yaml,
+        _subassembly_cycle_break_joints,
+        _validate_collapsed_tree,
+    )
+
+    links = [{"link_name": n} for n in ("base", "arm")]
+    joints = [
+        {"name": "base__arm", "parent": "base", "child": "arm",
+         "type": "fixed", "source_name": "j1"},
+        {"name": "arm__base", "parent": "arm", "child": "base",
+         "type": "fixed", "source_name": "j2"},
+    ]
+    choices = _collapse_cycle_break_choices("base", links, joints, set())
+    assert len(choices) == 1
+    assert choices[0]["links"] == ["base", "arm", "base"]
+    assert [c["source_joint"] for c in choices[0]["candidates"]] == [
+        "j1", "j2"]
+
+    txt = _set_subassembly_cycle_break_joint_yaml("", "j2", True)
+    drops = _subassembly_cycle_break_joints(txt)
+    assert drops == {"j2"}
+    kept = [j for j in joints if j["source_name"] not in drops]
+    assert _validate_collapsed_tree(
+        "base", links, kept, [])["ok"] is True
+
+    txt = _set_subassembly_cycle_break_joint_yaml(txt, "", False, "j2")
+    assert _subassembly_cycle_break_joints(txt) == set()
 
 
 def test_validate_collapsed_tree_reports_disconnected_members():

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -742,7 +742,7 @@ def test_collapsed_preview_urdf_lumps_member_visuals():
     assert {x.get("name") for x in root.findall("link")} == {
         "base", "sub", "outside"}
     assert {x.get("name") for x in root.findall("joint")} == {
-        "base__sub_a", "sub_b__outside"}
+        "base__sub", "sub__outside"}
     sub = next(x for x in root.findall("link") if x.get("name") == "sub")
     visuals = sub.findall("visual")
     assert len(visuals) == 2
@@ -751,7 +751,7 @@ def test_collapsed_preview_urdf_lumps_member_visuals():
     assert visuals[0].find("origin").get("xyz") == "0 0 0"
     assert visuals[1].find("origin").get("xyz") == "0 2 0.5"
     sub_out = next(j for j in root.findall("joint")
-                   if j.get("name") == "sub_b__outside")
+                   if j.get("name") == "sub__outside")
     assert sub_out.find("parent").get("link") == "sub"
     assert sub_out.find("child").get("link") == "outside"
     assert sub_out.find("origin").get("xyz") == "0 2 3"

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -742,7 +742,7 @@ def test_collapsed_preview_urdf_lumps_member_visuals():
     assert {x.get("name") for x in root.findall("link")} == {
         "base", "sub", "outside"}
     assert {x.get("name") for x in root.findall("joint")} == {
-        "base__sub", "sub__outside"}
+        "base__sub_a", "sub_b__outside"}
     sub = next(x for x in root.findall("link") if x.get("name") == "sub")
     visuals = sub.findall("visual")
     assert len(visuals) == 2
@@ -751,7 +751,7 @@ def test_collapsed_preview_urdf_lumps_member_visuals():
     assert visuals[0].find("origin").get("xyz") == "0 0 0"
     assert visuals[1].find("origin").get("xyz") == "0 2 0.5"
     sub_out = next(j for j in root.findall("joint")
-                   if j.get("name") == "sub__outside")
+                   if j.get("name") == "sub_b__outside")
     assert sub_out.find("parent").get("link") == "sub"
     assert sub_out.find("child").get("link") == "outside"
     assert sub_out.find("origin").get("xyz") == "0 2 3"

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -232,6 +232,7 @@ def test_collapse_preview_replaces_no_expand_subassembly_members():
         "servo_1__case_1", "servo_1__horn_1"]
     plan = payload["collapse_plan"]
     assert plan["ready_for_urdf"] is True
+    assert plan["blocking_issue_count"] == 0
     assert plan["collapsed_subassemblies"] == [{
         "name": "servo-1",
         "link": "servo_1",
@@ -316,6 +317,7 @@ joints:
     assert plan["version"] == 1
     assert plan["base_link"] == payload["base_link"]
     assert plan["ready_for_urdf"] is False
+    assert plan["blocking_issue_count"] == 1
     servo_link = next(l for l in plan["links"] if l["link"] == "servo_1")
     assert servo_link["kind"] == "collapsed_subassembly"
     assert servo_link["source_subassembly"] == "servo-1"
@@ -351,6 +353,9 @@ joints:
         if i["code"] == "disconnected_members")
     assert anchored["severity"] == "info"
     assert anchored["origin_link"] == "servo_1__horn_1"
+    plan = payload["collapse_plan"]
+    assert plan["ready_for_urdf"] is True
+    assert plan["blocking_issue_count"] == 0
 
 
 def test_collapse_preview_reports_stale_subassembly_origin_link():

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -2,6 +2,12 @@
 graph: a 'servo unit' sub-assembly whose horn turns inside, mounted on a
 base plate.  Expansion must splice the children in, keep the internal
 revolute, and re-attach the mounting mate to the owning child."""
+import json
+import socket
+import threading
+import urllib.error
+import urllib.request
+
 import numpy as np
 import pytest
 from test_classify_geo import O, Z, coinc_planes, conc, dup
@@ -63,6 +69,25 @@ def make_graph():
                       components=[plate, inst], edges=[mount],
                       ground=["plate-1"],
                       subassemblies={"X:/fake/servo_unit.SLDASM": sub})
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def _post_json(base, path, body):
+    req = urllib.request.Request(
+        base + path, data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"}, method="POST")
+    try:
+        with urllib.request.urlopen(req) as r:
+            return r.status, json.loads(r.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read().decode("utf-8"))
 
 
 def test_expand_splices_children():
@@ -279,9 +304,95 @@ joints:
     payload = _collapse_preview_payload(graph, txt)
     assert payload["group_choices"][0]["selected_origin_link"] == \
         "servo_1__horn_1"
-    assert "disconnected_members" not in {
-        i["code"] for i in payload["validation"]["issues"]
-    }
+    anchored = next(
+        i for i in payload["validation"]["issues"]
+        if i["code"] == "disconnected_members")
+    assert anchored["severity"] == "info"
+    assert anchored["origin_link"] == "servo_1__horn_1"
+
+
+def test_collapse_preview_reports_stale_subassembly_origin_link():
+    from sw2robot.editor.webserver import _collapse_preview_payload
+
+    txt = """
+base: plate-1
+no_expand:
+- servo
+subassembly_origin_links:
+  servo-1: missing_link
+"""
+    payload = _collapse_preview_payload(make_graph(), txt)
+    choices = payload["group_choices"]
+    assert choices[0]["subassembly"] == "servo-1"
+    assert choices[0]["selected_origin_link"] == ""
+    assert choices[0]["stale_origin_link"] == "missing_link"
+    assert payload["collapsed_subassemblies"][0]["selected_origin_link"] == ""
+    assert payload["collapsed_subassemblies"][0]["stale_origin_link"] == \
+        "missing_link"
+    issue = next(
+        i for i in payload["validation"]["issues"]
+        if i["code"] == "invalid_origin_link")
+    assert issue["origin_link"] == "missing_link"
+
+
+def test_set_subassembly_origin_link_rejects_non_candidate(tmp_path):
+    from sw2robot.editor import webserver
+
+    graph = make_graph()
+    graph.components.append(_comp("bracket-1", "bracket_1", xyz=(0, 0.1, 0)))
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "urdf").mkdir()
+    graph.save(pkg / "graph.json")
+    yml = pkg / "t.joints.yaml"
+    yml.write_text("""
+base: plate-1
+no_expand:
+- servo
+joints:
+  - parent: plate-1
+    child:  servo-1/case-1
+    type:   fixed
+  - parent: bracket-1
+    child:  servo-1/horn-1
+    type:   fixed
+  - parent: plate-1
+    child:  bracket-1
+    type:   fixed
+""", encoding="utf-8")
+
+    old_state = (
+        webserver._Handler.pkg_dir,
+        webserver._Handler.urdf_rel,
+        webserver._Handler.robot_name,
+        webserver._Handler.root_dir,
+    )
+    webserver._Handler.pkg_dir = str(pkg)
+    webserver._Handler.urdf_rel = "urdf/t.urdf"
+    webserver._Handler.robot_name = "t"
+    webserver._Handler.root_dir = str(pkg)
+    httpd, port = webserver._bind_free_port(
+        webserver._Handler, _free_port())
+    httpd.daemon_threads = True
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    try:
+        code, payload = _post_json(
+            f"http://127.0.0.1:{port}",
+            "/api/set_subassembly_origin_link",
+            {"name": "servo-1", "origin_link": "not_a_member"})
+        assert code == 400
+        assert "not a member origin link candidate" in payload["error"]
+        assert "subassembly_origin_links" not in yml.read_text(
+            encoding="utf-8")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        (
+            webserver._Handler.pkg_dir,
+            webserver._Handler.urdf_rel,
+            webserver._Handler.robot_name,
+            webserver._Handler.root_dir,
+        ) = old_state
 
 
 def test_collapse_preview_ignores_stale_subassembly_parent_override():

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -262,10 +262,6 @@ joints:
         ("bracket_1", "servo_1"),
         ("plate_1", "bracket_1"),
     ]
-    assert [j["source_name"]
-            for j in payload["dropped_parent_override_joints"]] == [
-        "plate_1__servo_1__case_1"
-    ]
     assert "multiple_boundary_parents" not in {
         i["code"] for i in payload["validation"]["issues"]
     }

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -252,6 +252,7 @@ def test_collapse_preview_applies_subassembly_parent_override():
         _collapse_preview_payload,
         _set_subassembly_origin_link_yaml,
         _set_subassembly_parent_override_yaml,
+        _tree_rows_from_collapse_plan,
     )
 
     graph = make_graph()
@@ -292,6 +293,28 @@ joints:
     assert "multiple_boundary_parents" not in {
         i["code"] for i in payload["validation"]["issues"]
     }
+    plan = payload["collapse_plan"]
+    assert plan["version"] == 1
+    assert plan["base_link"] == payload["base_link"]
+    assert plan["ready_for_urdf"] is False
+    servo_link = next(l for l in plan["links"] if l["link"] == "servo_1")
+    assert servo_link["kind"] == "collapsed_subassembly"
+    assert servo_link["source_subassembly"] == "servo-1"
+    assert servo_link["selected_parent"] == "bracket_1"
+    assert servo_link["member_links"] == [
+        "servo_1__case_1", "servo_1__horn_1"]
+    assert [(j["parent"], j["child"], j["source_joint"], j["decision"])
+            for j in plan["joints"]] == [
+        ("bracket_1", "servo_1", "bracket_1__servo_1__horn_1",
+         "kept_boundary"),
+        ("plate_1", "bracket_1", "plate_1__bracket_1",
+         "kept_expanded"),
+    ]
+    assert [(j["source_joint"], j["decision"])
+            for j in plan["dropped_joints"]] == [
+        ("plate_1__servo_1__case_1", "dropped_parent_override")
+    ]
+    assert payload["tree_rows"] == _tree_rows_from_collapse_plan(plan)
     assert payload["group_choices"][0]["subassembly"] == "servo-1"
     assert [g["origin_link"] for g in payload["group_choices"][0]["groups"]] == [
         "servo_1__case_1", "servo_1__horn_1"]
@@ -429,6 +452,10 @@ joints:
     assert "multiple_boundary_parents" in {
         i["code"] for i in payload["validation"]["issues"]
     }
+    plan = payload["collapse_plan"]
+    assert plan["ready_for_urdf"] is True
+    servo_link = next(l for l in plan["links"] if l["link"] == "servo_1")
+    assert servo_link["selected_origin_link"] == "servo_1__horn_1"
 
 
 def test_collapse_preview_can_reset_subassembly_parent_override_to_auto():

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -501,13 +501,8 @@ def test_validate_collapsed_tree_reports_multiple_parents_and_cycles():
     assert payload["ok"] is False
 
 
-def test_subassembly_cycle_break_choices_drop_source_joint():
-    from sw2robot.editor.webserver import (
-        _collapse_cycle_break_choices,
-        _set_subassembly_cycle_break_joint_yaml,
-        _subassembly_cycle_break_joints,
-        _validate_collapsed_tree,
-    )
+def test_collapse_preview_applies_cycle_break_before_choices(monkeypatch):
+    from sw2robot.editor import webserver
 
     links = [{"link_name": n} for n in ("base", "arm")]
     joints = [
@@ -516,21 +511,85 @@ def test_subassembly_cycle_break_choices_drop_source_joint():
         {"name": "arm__base", "parent": "arm", "child": "base",
          "type": "fixed", "source_name": "j2"},
     ]
-    choices = _collapse_cycle_break_choices("base", links, joints, set())
-    assert len(choices) == 1
-    assert choices[0]["links"] == ["base", "arm", "base"]
-    assert [c["source_joint"] for c in choices[0]["candidates"]] == [
-        "j1", "j2"]
+    monkeypatch.setattr(webserver, "_canonical_tree_payload", lambda *_: {
+        "base_link": "base",
+        "links": links,
+        "joints": joints,
+        "subassemblies": [],
+    })
+    monkeypatch.setattr(webserver, "_subassemblies_payload", lambda *_: {
+        "subassemblies": [],
+    })
+
+    payload = webserver._collapse_preview_payload(
+        object(), "subassembly_cycle_break_joints:\n- arm__base\n")
+
+    assert [j["source_name"] for j in payload["joints"]] == ["base__arm"]
+    assert not any(i["code"] == "cycle"
+                   for i in payload["validation"]["issues"])
+    assert payload["cycle_break_choices"] == [{
+        "links": [],
+        "joints": [],
+        "source_joints": ["arm__base"],
+        "selected_source_joint": "arm__base",
+        "stale": True,
+        "candidates": [{
+            "joint": "arm__base",
+            "source_joint": "arm__base",
+            "parent": "",
+            "child": "",
+        }],
+    }]
+
+
+def test_subassembly_cycle_break_yaml_adds_and_resets_source_joint():
+    from sw2robot.editor.webserver import (
+        _set_subassembly_cycle_break_joint_yaml,
+        _subassembly_cycle_break_joints,
+    )
 
     txt = _set_subassembly_cycle_break_joint_yaml("", "j2", True)
-    drops = _subassembly_cycle_break_joints(txt)
-    assert drops == {"j2"}
-    kept = [j for j in joints if j["source_name"] not in drops]
-    assert _validate_collapsed_tree(
-        "base", links, kept, [])["ok"] is True
+    assert _subassembly_cycle_break_joints(txt) == {"j2"}
 
     txt = _set_subassembly_cycle_break_joint_yaml(txt, "", False, "j2")
     assert _subassembly_cycle_break_joints(txt) == set()
+
+
+def test_directed_cycle_reports_self_loop():
+    from sw2robot.editor.webserver import _directed_cycle_reports
+
+    reports = _directed_cycle_reports(
+        "base", [{"link_name": "base"}], [{
+            "name": "base__base", "parent": "base", "child": "base",
+            "type": "fixed", "source_name": "self_joint",
+        }])
+
+    assert len(reports) == 1
+    assert reports[0]["links"] == ["base", "base"]
+    assert reports[0]["source_joints"] == ["self_joint"]
+
+
+def test_cycle_break_shared_candidate_resolves_two_cycles():
+    from sw2robot.editor.webserver import _directed_cycle_reports
+
+    links = [{"link_name": n} for n in ("base", "arm", "tip")]
+    joints = [
+        {"name": "base__arm", "parent": "base", "child": "arm",
+         "source_name": "shared"},
+        {"name": "arm__base", "parent": "arm", "child": "base",
+         "source_name": "short_return"},
+        {"name": "arm__tip", "parent": "arm", "child": "tip",
+         "source_name": "to_tip"},
+        {"name": "tip__base", "parent": "tip", "child": "base",
+         "source_name": "long_return"},
+    ]
+
+    reports = _directed_cycle_reports("base", links, joints)
+    assert len(reports) == 2
+    assert all("shared" in r["source_joints"] for r in reports)
+
+    kept = [j for j in joints if j["source_name"] != "shared"]
+    assert _directed_cycle_reports("base", links, kept) == []
 
 
 def test_validate_collapsed_tree_reports_disconnected_members():

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -90,6 +90,11 @@ def _post_json(base, path, body):
         return e.code, json.loads(e.read().decode("utf-8"))
 
 
+def _get_json(base, path):
+    with urllib.request.urlopen(base + path) as response:
+        return response.status, json.loads(response.read().decode("utf-8"))
+
+
 def test_expand_splices_children():
     comps, adj, ground = from_graph(make_graph())
     names = {c.name for c in comps}
@@ -233,14 +238,22 @@ def test_collapse_preview_replaces_no_expand_subassembly_members():
     plan = payload["collapse_plan"]
     assert plan["ready_for_urdf"] is True
     assert plan["blocking_issue_count"] == 0
-    assert plan["collapsed_subassemblies"] == [{
+    assert len(plan["collapsed_subassemblies"]) == 1
+    plan_sub = plan["collapsed_subassemblies"][0]
+    assert {key: plan_sub[key] for key in (
+        "name", "link", "member_links", "member_components",
+        "selected_parent", "selected_origin_link",
+    )} == {
         "name": "servo-1",
         "link": "servo_1",
         "member_links": ["servo_1__case_1", "servo_1__horn_1"],
         "member_components": ["servo-1/case-1", "servo-1/horn-1"],
         "selected_parent": "",
         "selected_origin_link": "",
-    }]
+    }
+    assert plan_sub["selected_driver_joint"] == ""
+    assert plan_sub["auto_driver_joint"] == \
+        "servo_1__case_1__servo_1__horn_1"
     assert plan["link_replacements"] == [
         {"source_link": "servo_1__case_1", "collapsed_link": "servo_1"},
         {"source_link": "servo_1__horn_1", "collapsed_link": "servo_1"},
@@ -265,7 +278,7 @@ def test_collapse_preview_lists_subassembly_driver_joint_candidates():
     choices = payload["driver_joint_choices"]
     assert choices[0]["subassembly"] == "servo-1"
     assert choices[0]["auto_driver_joint"] == \
-        "plate_1__servo_1__case_1"
+        "servo_1__case_1__servo_1__horn_1"
     assert [(c["source_joint"], c["role"], c["type"])
             for c in choices[0]["candidates"]] == [
         ("plate_1__servo_1__case_1", "incoming_boundary", "fixed"),
@@ -288,6 +301,80 @@ def test_collapse_preview_lists_subassembly_driver_joint_candidates():
         "plate_1__servo_1__case_1",
         "servo_1__case_1__servo_1__horn_1",
     ]
+
+
+def test_set_subassembly_driver_joint_validates_resets_and_saves(tmp_path):
+    from sw2robot.editor import webserver
+
+    graph = make_graph()
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "urdf").mkdir()
+    graph.save(pkg / "graph.json")
+    yml = pkg / "t.joints.yaml"
+    yml.write_text("""
+base: plate-1
+no_expand:
+- servo
+subassembly_driver_joints:
+  servo-1: removed_joint
+""", encoding="utf-8")
+
+    old_state = (
+        webserver._Handler.pkg_dir,
+        webserver._Handler.urdf_rel,
+        webserver._Handler.robot_name,
+        webserver._Handler.root_dir,
+    )
+    webserver._Handler.pkg_dir = str(pkg)
+    webserver._Handler.urdf_rel = "urdf/t.urdf"
+    webserver._Handler.robot_name = "t"
+    webserver._Handler.root_dir = str(pkg)
+    httpd, port = webserver._bind_free_port(
+        webserver._Handler, _free_port())
+    httpd.daemon_threads = True
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{port}"
+    try:
+        code, payload = _get_json(base, "/api/collapse_preview")
+        assert code == 200
+        choice = payload["driver_joint_choices"][0]
+        assert choice["selected_driver_joint"] == "removed_joint"
+        stale = next(c for c in choice["candidates"]
+                     if c["source_joint"] == "removed_joint")
+        assert stale["role"] == "stale"
+
+        code, payload = _post_json(
+            base, "/api/set_subassembly_driver_joint",
+            {"name": "servo-1", "source_joint": "not_a_candidate"})
+        assert code == 400
+        assert "not a driver joint candidate" in payload["error"]
+
+        code, payload = _post_json(
+            base, "/api/set_subassembly_driver_joint",
+            {"name": "servo-1", "source_joint": "auto"})
+        assert code == 200
+        assert payload["source_joint"] == ""
+        assert webserver._subassembly_driver_joints(
+            yml.read_text(encoding="utf-8")) == {}
+
+        selected = "servo_1__case_1__servo_1__horn_1"
+        code, payload = _post_json(
+            base, "/api/set_subassembly_driver_joint",
+            {"name": "servo-1", "source_joint": selected})
+        assert code == 200
+        assert payload["source_joint"] == selected
+        assert webserver._subassembly_driver_joints(
+            yml.read_text(encoding="utf-8")) == {"servo-1": selected}
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        (
+            webserver._Handler.pkg_dir,
+            webserver._Handler.urdf_rel,
+            webserver._Handler.robot_name,
+            webserver._Handler.root_dir,
+        ) = old_state
 
 
 def test_collapse_preview_keeps_expanded_override():


### PR DESCRIPTION
If this PR is stacked on top of the collapsed URDF viewer PR, the focused diff is:

https://github.com/poyotamu000/solidworks_urdf_exporter2/compare/clean/subassembly-collapsed-urdf-viewer...clean/subassembly-driver-joint-selector


## Summary

This PR adds preview-only Motion driver joint choices for collapsed CAD sub-assemblies.

The collapsed sub-assembly preview can now report candidate source joints for each collapsed sub-assembly, and the Web UI lets the user choose which joint should represent the motion of that collapsed sub-assembly.

## Background

When multiple CAD parts are collapsed into one sub-assembly link, the preview tree may still need to know which original joint should be treated as the representative motion joint.

This cannot always be inferred safely from CAD mates alone. In some assemblies, several boundary or internal joints can be plausible candidates, and choosing silently can lead to confusing preview motion later.

This PR keeps the existing normal expanded robot workflow unchanged, and adds the driver joint choice as preview-only sub-assembly metadata.

## Changes

- Adds `subassembly_driver_joints` preview metadata in `joints.yaml`.
- Adds backend helpers to read/write selected driver joints.
- Adds driver joint candidate generation from the collapsed preview/collapse plan.
- Adds `/api/set_subassembly_driver_joint`.
- Adds a `Motion driver joints` selector section to the sub-assembly preview UI.
- Stores user-selected driver joints without rebuilding the normal URDF export.
- Adds tests for driver joint candidates, selected driver joints, and collapse plan propagation.

## Scope

This PR does not change normal URDF Export.

It does not change the normal expanded robot tree, rename flow, joint type editing, or existing non-subassembly behavior.

The selected driver joint is used as preview metadata for later collapsed-preview URDF and motion behavior work. Full collapsed robot motion/viewer behavior is handled in follow-up PRs.