### PR TITLE
Default sub-assembly previews to no expand

### DIFF
--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -1044,8 +1044,8 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     'subasm.btnTitle': { en: 'show CAD sub-assemblies and whether they are expanded',
                          ja: 'CADサブアセンブリと展開状態を表示' },
     'subasm.title': { en: 'CAD sub-assemblies', ja: 'CADサブアセンブリ' },
-    'subasm.help': { en: 'Sub-assembly mode keeps the normal expanded tree as the baseline, then overrides only selected CAD sub-assemblies.',
-                     ja: 'サブアセンブリモードでは通常の全展開treeを基準にして、選んだCADサブアセンブリだけを上書きします。' },
+    'subasm.help': { en: 'Sub-assembly mode starts with CAD sub-assemblies collapsed while keeping the normal expanded robot unchanged. Select auto or expand where needed.',
+                     ja: '通常の全展開ロボットは変更せず、CADサブアセンブリを畳んだ状態から始めます。必要な箇所だけautoまたはexpandを選択できます。' },
     'subasm.none': { en: 'No CAD sub-assemblies in this package.',
                      ja: 'このパッケージにはCADサブアセンブリがありません。' },
     'subasm.urdfMode': { en: 'Sub-assembly data is available for CAD-extracted packages only.',
@@ -1146,6 +1146,7 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     'subasm.overrideAuto': { en: 'auto', ja: 'auto' },
     'subasm.overrideExpand': { en: 'expand', ja: 'expand' },
     'subasm.overrideNoExpand': { en: 'no_expand', ja: 'no_expand' },
+    'subasm.modeDefault': { en: 'default', ja: '初期値' },
     'subasm.setOk': { en: a => `${a.name}: ${a.mode} ✓`,
                       ja: a => `${a.name}: ${a.mode} ✓` },
     'subasm.settingPreview': { en: a => `saving sub-assembly preview mode: ${a.name} → ${a.mode} ...`,
@@ -3444,6 +3445,8 @@ async function openSubassemblyList(ov) {
         const state = s.expanded ? t('subasm.stateExpanded')
                                  : t('subasm.stateKept');
         const col = s.expanded ? '#9fe0a8' : '#d6b36b';
+        const modeSource = s.mode_source === 'default'
+          ? `, ${t('subasm.modeDefault')}` : '';
         const opt = v => `<option value="${v}"${s.override === v ? ' selected' : ''}>` +
           `${subasmOverrideLabel(v)}</option>`;
         html += `<tr title="${htmlEsc(s.reason)}">` +
@@ -3452,7 +3455,8 @@ async function openSubassemblyList(ov) {
           `<td>${s.children ?? 0}</td>` +
           `<td>${s.internal_edges ?? 0}</td>` +
           `<td><span style="color:${col}">${state}</span>` +
-          ` <span style="color:#8a93a3">(${subasmOverrideLabel(s.override)})</span></td>` +
+          ` <span style="color:#8a93a3">` +
+          `(${subasmOverrideLabel(s.override)}${htmlEsc(modeSource)})</span></td>` +
           `<td><select class="subasm-mode" data-name="${htmlEsc(s.name)}" ` +
           `data-prev="${htmlEsc(s.override)}" data-children="${s.children ?? 0}" ` +
           `data-edges="${s.internal_edges ?? 0}">` +

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1028,6 +1028,23 @@ def _set_number_override(txt, mapkey, key, value):
     return (f"{mapkey}:\n{block}" + txt) if block else txt
 
 
+def _subassembly_modes(yml_txt):
+    """Exact per-instance modes used only by sub-assembly previews."""
+    import yaml as _yaml
+
+    try:
+        cfg = _yaml.safe_load(yml_txt) or {}
+        if not isinstance(cfg, dict):
+            return {}
+    except Exception:
+        return {}
+    raw = cfg.get("subassembly_modes") or {}
+    if not isinstance(raw, dict):
+        return {}
+    valid = {"auto", "expand", "no_expand"}
+    return {str(k): str(v) for k, v in raw.items() if str(v) in valid}
+
+
 def _subassemblies_payload(graph, yml_txt=""):
     """Read-only summary for the editor's sub-assembly panel.
 
@@ -1045,6 +1062,7 @@ def _subassemblies_payload(graph, yml_txt=""):
         cfg = {}
     expand = [str(x).lower() for x in (cfg.get("expand") or [])]
     no_expand = [str(x).lower() for x in (cfg.get("no_expand") or [])]
+    exact_modes = _subassembly_modes(yml_txt)
 
     subs = getattr(graph, "subassemblies", None) or {}
     out = []
@@ -1053,16 +1071,23 @@ def _subassemblies_payload(graph, yml_txt=""):
             continue
         sub = subs.get(c.part_path)
         nm = c.name.lower()
-        override = "auto"
-        if any(s in nm for s in no_expand):
+        override = exact_modes.get(c.name)
+        mode_source = "saved" if override else ""
+        if not override and any(s in nm for s in no_expand):
             override = "no_expand"
-        elif any(s in nm for s in expand):
+            mode_source = "legacy"
+        elif not override and any(s in nm for s in expand):
             override = "expand"
+            mode_source = "legacy"
+        elif not override:
+            override = "no_expand"
+            mode_source = "default"
         movable = bool(sub and _subgraph_is_movable(sub, subs))
         expanded = override != "no_expand" and (
             override == "expand" or movable)
         if override == "no_expand":
-            reason = "kept by no_expand"
+            reason = "kept by default no_expand" \
+                if mode_source == "default" else "kept by no_expand"
         elif override == "expand":
             reason = "forced expand"
         elif movable:
@@ -1078,6 +1103,7 @@ def _subassemblies_payload(graph, yml_txt=""):
             "internal_edges": len(sub.edges) if sub else 0,
             "movable": movable,
             "override": override,
+            "mode_source": mode_source,
             "expanded": expanded,
             "reason": reason,
         })
@@ -1086,6 +1112,7 @@ def _subassemblies_payload(graph, yml_txt=""):
         "subassemblies": out,
         "expand": cfg.get("expand") or [],
         "no_expand": cfg.get("no_expand") or [],
+        "subassembly_modes": exact_modes,
     }
 
 
@@ -1115,7 +1142,7 @@ def _matching_subasm_members(members, name, all_names):
 
 
 def _set_subassembly_mode_yaml(txt, graph, name, mode):
-    """Set one CAD sub-assembly instance to auto / expand / no_expand."""
+    """Set one exact CAD instance's preview-only sub-assembly mode."""
     import yaml as _yaml
 
     if mode not in ("auto", "expand", "no_expand"):
@@ -1131,18 +1158,21 @@ def _set_subassembly_mode_yaml(txt, graph, name, mode):
     noexp = [str(x) for x in (cfg.get("no_expand") or [])]
     exp_rm, exp_shared = _matching_subasm_members(exp, name, names)
     noexp_rm, noexp_shared = _matching_subasm_members(noexp, name, names)
-    shared = [*exp_shared, *noexp_shared]
-    if shared:
-        raise ValueError(
-            "cannot safely change this row because these substring override(s) "
-            "also match other sub-assemblies: " + ", ".join(shared))
-    add_exp = [name] if mode == "expand" else []
-    add_noexp = [name] if mode == "no_expand" else []
+    # Remove only legacy entries unique to this row. Shared substring entries
+    # remain for siblings; this exact preview mode takes precedence for name.
     txt, exp_members = _set_yaml_list_block(
-        txt, "expand", add=add_exp, remove=[*exp_rm, name])
+        txt, "expand", remove=[*exp_rm, name])
     txt, noexp_members = _set_yaml_list_block(
-        txt, "no_expand", add=add_noexp, remove=[*noexp_rm, name])
-    return txt, {"expand": exp_members, "no_expand": noexp_members}
+        txt, "no_expand", remove=[*noexp_rm, name])
+    txt = _upsert_yaml_map(
+        txt, "subassembly_modes", name, _yaml_scalar(mode))
+    return txt, {
+        "expand": exp_members,
+        "no_expand": noexp_members,
+        "subassembly_modes": _subassembly_modes(txt),
+        "retained_shared_legacy_modes": sorted(
+            {*exp_shared, *noexp_shared}),
+    }
 
 
 def _subassembly_parent_overrides(yml_txt):

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -171,7 +171,9 @@ def test_canonical_tree_payload_ignores_subassembly_modes():
     from sw2robot.editor.webserver import _canonical_tree_payload
 
     payload = _canonical_tree_payload(
-        make_graph(), "base: plate-1\nno_expand:\n- servo\n")
+        make_graph(),
+        "base: plate-1\nno_expand:\n- servo\n"
+        "subassembly_modes:\n  servo-1: no_expand\n")
     link_names = {x["link_name"] for x in payload["links"]}
     assert "servo_1" not in link_names
     assert {"servo_1__case_1", "servo_1__horn_1"} <= link_names
@@ -1324,7 +1326,7 @@ def test_validate_collapsed_tree_reports_disconnected_members():
     assert issue["components"] == [["sub_1__a"], ["sub_1__b"]]
 
 
-def test_subassemblies_payload_reports_expansion_state():
+def test_subassemblies_payload_defaults_to_no_expand():
     from sw2robot.editor.webserver import _subassemblies_payload
 
     payload = _subassemblies_payload(make_graph())
@@ -1334,8 +1336,9 @@ def test_subassemblies_payload_reports_expansion_state():
     assert rows[0]["children"] == 2
     assert rows[0]["internal_edges"] == 1
     assert rows[0]["movable"] is True
-    assert rows[0]["expanded"] is True
-    assert rows[0]["override"] == "auto"
+    assert rows[0]["expanded"] is False
+    assert rows[0]["override"] == "no_expand"
+    assert rows[0]["mode_source"] == "default"
 
 
 def test_subassemblies_payload_reports_no_expand_override():
@@ -1346,26 +1349,40 @@ def test_subassemblies_payload_reports_no_expand_override():
     assert len(rows) == 1
     assert rows[0]["expanded"] is False
     assert rows[0]["override"] == "no_expand"
+    assert rows[0]["mode_source"] == "legacy"
+
+
+def test_subassemblies_payload_keeps_legacy_expand_override():
+    from sw2robot.editor.webserver import _subassemblies_payload
+
+    payload = _subassemblies_payload(make_graph(), "expand:\n- servo\n")
+    row = payload["subassemblies"][0]
+    assert row["expanded"] is True
+    assert row["override"] == "expand"
+    assert row["mode_source"] == "legacy"
 
 
 def test_set_subassembly_mode_yaml_round_trips_exact_name():
     from sw2robot.editor.webserver import (
         _set_subassembly_mode_yaml,
         _subassemblies_payload,
+        _subassembly_modes,
     )
 
     txt, members = _set_subassembly_mode_yaml("", make_graph(), "servo-1",
                                               "no_expand")
     assert members["expand"] == []
-    assert members["no_expand"] == ["servo-1"]
+    assert members["no_expand"] == []
+    assert _subassembly_modes(txt) == {"servo-1": "no_expand"}
     row = _subassemblies_payload(make_graph(), txt)["subassemblies"][0]
     assert row["expanded"] is False
     assert row["override"] == "no_expand"
 
     txt, members = _set_subassembly_mode_yaml(txt, make_graph(), "servo-1",
                                               "expand")
-    assert members["expand"] == ["servo-1"]
+    assert members["expand"] == []
     assert members["no_expand"] == []
+    assert _subassembly_modes(txt) == {"servo-1": "expand"}
     row = _subassemblies_payload(make_graph(), txt)["subassemblies"][0]
     assert row["expanded"] is True
     assert row["override"] == "expand"
@@ -1374,20 +1391,53 @@ def test_set_subassembly_mode_yaml_round_trips_exact_name():
                                               "auto")
     assert members["expand"] == []
     assert members["no_expand"] == []
+    assert _subassembly_modes(txt) == {"servo-1": "auto"}
     row = _subassemblies_payload(make_graph(), txt)["subassemblies"][0]
     assert row["override"] == "auto"
+    assert row["expanded"] is True
 
 
-def test_set_subassembly_mode_yaml_rejects_shared_substring_override():
-    from sw2robot.editor.webserver import _set_subassembly_mode_yaml
+def test_exact_subassembly_mode_overrides_shared_legacy_substring():
+    from sw2robot.editor.webserver import (
+        _set_subassembly_mode_yaml,
+        _subassemblies_payload,
+    )
 
     g = make_graph()
     inst2 = _comp("servo-2", "servo_2", xyz=(0.2, 0, 0), sub=True,
                   path="X:/fake/servo_unit.SLDASM")
     g.components.append(inst2)
-    with pytest.raises(ValueError, match="also match other sub-assemblies"):
-        _set_subassembly_mode_yaml("no_expand:\n- servo\n", g, "servo-1",
-                                   "expand")
+    txt, members = _set_subassembly_mode_yaml(
+        "no_expand:\n- servo\n", g, "servo-1", "expand")
+
+    assert members["retained_shared_legacy_modes"] == ["servo"]
+    rows = {row["name"]: row for row in
+            _subassemblies_payload(g, txt)["subassemblies"]}
+    assert rows["servo-1"]["override"] == "expand"
+    assert rows["servo-1"]["mode_source"] == "saved"
+    assert rows["servo-2"]["override"] == "no_expand"
+    assert rows["servo-2"]["mode_source"] == "legacy"
+
+
+def test_preview_default_no_expand_does_not_change_normal_model():
+    import yaml
+
+    from sw2robot.editor.webserver import (
+        _collapse_preview_payload,
+        _set_subassembly_mode_yaml,
+    )
+    from sw2robot.exporter.model import build_model
+
+    graph = make_graph()
+    txt, _ = _set_subassembly_mode_yaml(
+        "base: plate-1\n", graph, "servo-1", "no_expand")
+
+    preview = _collapse_preview_payload(graph, txt)
+    assert {row["link_name"] for row in preview["links"]} == {
+        "plate_1", "servo_1"}
+    normal = build_model(graph, config=yaml.safe_load(txt))
+    assert {component.link_name for component in normal.components} == {
+        "plate_1", "servo_1__case_1", "servo_1__horn_1"}
 
 
 def test_rigid_subassembly_not_expanded():


### PR DESCRIPTION
## Summary

CAD sub-assemblies now start collapsed (`no_expand`) in the sub-assembly preview, which better matches the workflow where each sub-assembly is treated as one unit.

Users can still select `auto` or `expand` for individual instances. These choices are stored in a preview-only, exact-name `subassembly_modes` map, so the normal expanded robot and normal export behavior remain unchanged.

Existing `expand` and `no_expand` lists continue to be supported for backward compatibility.

## Linked issue

Refs #154 (item 3)

## Demo (required for UI / user-visible changes)

[kleiyn-demo (18).webm](https://github.com/user-attachments/assets/81632831-a07f-4228-bc1f-1082dc783823)


## AI usage disclosure (required)
- Tool(s): `OpenAI Codex`. Extent: assisted with implementation, tests
- the tests and build pass locally, verifing the behavior with the Windows EXE and SolidWorks and drafting PR by the author.