### PR TITLE
Add contributor guide, issue/PR templates, and AI-usage policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,67 @@
+name: Bug report
+description: Something doesn't work as expected. Keep it short and specific.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please keep this focused. A few precise sentences with exact steps are
+        worth more than a long write-up. One bug per issue.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened (2-3 lines)
+      description: What went wrong, and what did you expect instead? Keep it brief.
+      placeholder: When I export ..., I get ..., but I expected ...
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce (numbered, minimal)
+      description: The shortest exact steps that trigger it. Include a sample file if you can.
+      placeholder: |
+        1. Open ...
+        2. Click ...
+        3. See ...
+    validations:
+      required: true
+  - type: textarea
+    id: sample
+    attributes:
+      label: Reproducible sample (.zip)
+      description: >-
+        If a specific assembly/part is involved, drag a .zip of the MINIMAL
+        .sldasm / .sldprt files needed to reproduce it into this box. Replace
+        any confidential CAD with simple dummy stand-ins that still show the
+        problem. See CONTRIBUTING.md. If you truly can't share one, describe the
+        structure precisely here instead.
+      placeholder: Drag & drop a .zip here, or describe the minimal structure.
+    validations:
+      required: false
+  - type: input
+    id: version
+    attributes:
+      label: Version / OS
+      description: sw2robot version and your OS (and SolidWorks version if the extract step is involved).
+      placeholder: "sw2robot 0.3.4, Windows 11, SolidWorks 2024"
+    validations:
+      required: true
+  - type: dropdown
+    id: ai-usage
+    attributes:
+      label: AI usage disclosure
+      description: Did you use AI to help write this report? (See CONTRIBUTING.md.)
+      options:
+        - "No AI was used"
+        - "AI-assisted, reviewed and edited by a human"
+      default: 0
+    validations:
+      required: true
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Confirmation
+      options:
+        - label: This is one bug (not several batched together), and I searched for existing issues.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+blank_issues_enabled: false
+contact_links:
+  - name: How to contribute (read first)
+    url: https://github.com/jsk-ros-pkg/solidworks_urdf_exporter2/blob/main/CONTRIBUTING.md
+    about: >-
+      Please read the contributing guide before opening an issue. Keep it short
+      and focused, one topic per issue, and land one before opening the next.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,52 @@
+name: Feature request
+description: Propose a change or new capability. Get agreement before writing code.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Implementation PRs must reference an issue a maintainer has labelled
+        `accepted`, so this is the place to align on approach first. Please wait
+        for that label before writing code. Keep it concise — one proposal per
+        issue, and land one before opening the next.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem (2-3 lines)
+      description: What can't you do today, and why does it matter?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change (2-3 lines)
+      description: What should happen? Keep it short; details can follow in discussion.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives / open question (optional)
+      description: One key trade-off or question you'd like a maintainer to weigh in on.
+    validations:
+      required: false
+  - type: dropdown
+    id: ai-usage
+    attributes:
+      label: AI usage disclosure
+      description: Did you use AI to help write this? (See CONTRIBUTING.md.)
+      options:
+        - "No AI was used"
+        - "AI-assisted, reviewed and edited by a human"
+      default: 0
+    validations:
+      required: true
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Confirmation
+      options:
+        - label: This is a single, focused proposal, and I'm not opening several broad discussions at once.
+          required: true
+        - label: I understand implementation PRs need an issue labelled `accepted` first, and I won't send a large drive-by PR.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+<!--
+Keep this short. Reviewers read the diff, not a long description.
+Large stacked PRs that don't reference an issue labelled `accepted` may be closed.
+See CONTRIBUTING.md.
+-->
+
+## What & why (keep to a few lines)
+
+
+
+## Linked issue
+<!-- Implementation PRs must reference an issue labelled `accepted`. -->
+Closes #
+
+## How I verified this
+<!-- What did you actually run? Which platforms? Not "should work" — what you observed. -->
+
+
+
+## Demo (required for UI / user-visible changes)
+<!--
+Drag a short screen recording of the new behavior into this box.
+A before/after screenshot is fine for a purely static visual change.
+Leave blank only if this PR changes no user-visible behavior.
+-->
+
+
+
+## AI usage disclosure (required)
+<!-- Pick one and fill in. See the AI usage policy in CONTRIBUTING.md. -->
+- [ ] No AI was used.
+- [ ] AI was used. Tool(s): `____`. Extent: `____` (e.g. drafted code, reviewed & edited by hand).
+
+## Checklist
+- [ ] This PR is one focused change (not a large stack of dependent branches).
+- [ ] If this changes the UI / user-visible behavior, I attached a demo video or before/after screenshot above.
+- [ ] Tests and build pass locally.
+- [ ] I ran the change and confirmed it does what this PR claims.
+- [ ] I understand every line I'm submitting.

--- a/.github/workflows/length-check.yml
+++ b/.github/workflows/length-check.yml
@@ -1,0 +1,87 @@
+name: Flag long issues and PRs
+
+# Non-blocking nudge: when an issue or PR description is long *on prose*, add a
+# `needs-condensing` label and a friendly comment asking the author to trim it.
+# Code blocks, logs, blockquotes (citations), images, and URLs are excluded from
+# the count, so a detailed bug report with logs is not penalised — only verbose
+# prose is. Editing the description to shorten it clears the label automatically.
+
+on:
+  issues:
+    types: [opened, edited]
+  pull_request_target:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+env:
+  # Prose-word budget (excludes code/logs/quotes/images/URLs). Tune as needed.
+  PROSE_WORD_LIMIT: "400"
+  LABEL: "needs-condensing"
+  # Comma-separated usernames to never nudge (e.g. "iory,other-maintainer").
+  EXEMPT_USERS: ""
+
+jobs:
+  length-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const LIMIT = parseInt(process.env.PROSE_WORD_LIMIT, 10);
+            const LABEL = process.env.LABEL;
+            const exempt = (process.env.EXEMPT_USERS || "")
+              .split(",").map(s => s.trim().toLowerCase()).filter(Boolean);
+
+            const isPR = !!context.payload.pull_request;
+            const obj = context.payload.issue || context.payload.pull_request;
+            const number = obj.number;
+            const author = (obj.user && obj.user.login || "").toLowerCase();
+
+            if (exempt.includes(author)) {
+              core.info(`Author ${author} is exempt; skipping.`);
+              return;
+            }
+
+            // Strip everything that legitimately needs length before counting.
+            const prose = (obj.body || "")
+              .replace(/<!--[\s\S]*?-->/g, " ")        // HTML comments (template hints)
+              .replace(/```[\s\S]*?```/g, " ")         // fenced code / logs
+              .replace(/`[^`]*`/g, " ")                // inline code
+              .replace(/^\s*>.*$/gm, " ")              // blockquotes (citations)
+              .replace(/<[^>]+>/g, " ")                // HTML tags (e.g. <img>)
+              .replace(/!\[[^\]]*\]\([^)]*\)/g, " ")   // markdown images
+              .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")  // links -> keep visible text
+              .replace(/https?:\/\/\S+/g, " ");        // bare URLs
+
+            const words = prose.split(/\s+/).filter(Boolean).length;
+            const hasLabel = (obj.labels || []).some(l => (l.name || l) === LABEL);
+            core.info(`#${number} prose_words=${words} limit=${LIMIT} has_label=${hasLabel}`);
+
+            if (words > LIMIT) {
+              if (hasLabel) return; // already flagged; don't re-comment on every edit
+              await github.rest.issues.addLabels({
+                ...context.repo, issue_number: number, labels: [LABEL],
+              });
+              const kind = isPR ? "pull request" : "issue";
+              const url = `https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/CONTRIBUTING.md`;
+              const body = [
+                `👋 Thanks for this! Heads up: this ${kind}'s description runs long on prose ` +
+                  `(~**${words} words**, excluding code, logs, quotes, images and URLs; the guideline is **${LIMIT}**).`,
+                ``,
+                `To keep review sustainable, please consider trimming it to the essentials — ` +
+                  `a few precise sentences usually beat a long write-up. Logs, screenshots and ` +
+                  `reproduction steps don't count toward this, so keep those. See [CONTRIBUTING.md](${url}).`,
+                ``,
+                `_Automated, non-blocking nudge. Shorten the description and the \`${LABEL}\` label clears itself._`,
+              ].join("\n");
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: number, body,
+              });
+            } else if (hasLabel) {
+              await github.rest.issues.removeLabel({
+                ...context.repo, issue_number: number, name: LABEL,
+              }).catch(() => {}); // ignore if already removed
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ _server*.txt
 _client_report.json
 _sldasm_index.json
 _sw_spawned_pids.txt
+
+# A global core.excludesFile ignores dotpaths via ".*"; keep repo meta tracked.
+!.github/
+!.github/**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,134 @@
+# Contributing to sw2robot
+
+Thanks for your interest in improving sw2robot. This document explains how to
+propose changes so that they are reviewable by a small maintainer team.
+
+Please read the two short sections below before opening an issue or a pull
+request. They exist to keep review load sustainable — not to gatekeep.
+
+## TL;DR
+
+- **Discuss first, code second.** Open an issue and get a maintainer to agree on
+  the approach before sending an implementation PR.
+- **One PR = one reviewable change.** Small and focused beats large and stacked.
+- **Disclose AI usage.** Say which tool you used and for what. See below.
+- **Verify before you send.** If you didn't run it, it isn't ready.
+
+## Issues
+
+- **Keep it short and specific.** State the problem, what you expected, and (for
+  bugs) exact steps to reproduce. A few focused sentences are worth more than a
+  long essay.
+- **One topic per issue.** Don't batch several unrelated discussions into one
+  thread, and don't open many broad "discussion" issues at once — maintainers
+  cannot review them in parallel. Land one before opening the next.
+- **Human-in-the-loop for AI.** You may use AI to help draft an issue, but a
+  human must read, edit, and stand behind every word before you post it.
+  Unedited, machine-generated walls of text will be closed with a request to
+  condense.
+
+### Attach a reproducible sample
+
+This is an open-source project, so anything a maintainer cannot reproduce is
+very hard to act on. If your issue involves a specific SolidWorks assembly or
+part — a bug during extract/build, a wrong result, a shape the tool mishandles —
+please attach the relevant `.sldasm` / `.sldprt` files (and any references they
+need) as a **`.zip`** so we can open and inspect them here.
+
+Two rules keep this practical and safe:
+
+- **Make it minimal.** Include only what is needed to reproduce the behavior —
+  the smallest assembly/parts that still show the problem, not your whole
+  production model.
+- **Never upload confidential CAD.** If the real parts are proprietary, replace
+  them with **dummy stand-ins** — simple placeholder geometry that reproduces
+  the same behavior (the mate structure, subassembly nesting, coordinate frame,
+  or shape characteristic that matters). Share the reproduction, not your
+  secrets.
+
+If you genuinely cannot share a reproducible sample, say so and describe the
+structure precisely instead — but expect that undiagnosable reports may be
+closed.
+
+## Pull requests
+
+### Issue-first
+
+Implementation PRs must reference an **accepted** issue — an issue a maintainer
+has labelled [`accepted`](https://github.com/jsk-ros-pkg/solidworks_urdf_exporter2/issues?q=is%3Aissue+label%3Aaccepted),
+meaning the direction has been agreed. Open an issue, discuss it, and wait for
+that label before writing the implementation. Drive-by PRs that do not reference
+an `accepted` issue may be closed without a full review, regardless of how much
+code they contain. This is the single most important rule here: it prevents
+wasted work on both sides.
+
+**Maintainers are exempt.** Maintainers may open PRs directly without a
+pre-filed `accepted` issue — they own the roadmap and are trusted to apply good
+judgment. The keep-it-small, verify-it, and demo-for-UI rules below still apply
+to everyone, maintainers included. For a non-trivial or contentious change, a
+maintainer is still encouraged to open an issue first so others can weigh in.
+
+### Keep PRs small and independent
+
+- Aim for one logical change per PR. If you find yourself writing "Part 3 of 7"
+  or stacking many branches, that is a signal to stop and talk to a maintainer
+  about scope first.
+- Large stacked PRs (thousands of lines across many dependent branches) will be
+  sent back for splitting. Reviewers review the **diff**, not the description —
+  a change that cannot be understood from its diff is not ready.
+- Write the PR description for a human reviewer: a few lines on *what* changed
+  and *why*. Skip auto-generated multi-section essays.
+
+### Verify your change
+
+Before requesting review, make sure:
+
+- The code builds and the test suite passes locally.
+- You have **actually run** the change and confirmed it does what the PR claims,
+  on the platforms it affects (note that `extract` is Windows + SolidWorks only).
+- New behavior has a test where practical.
+
+### Show your work for UI changes
+
+If your PR changes the browser editor UI or any user-visible behavior, include
+**proof that you ran it**:
+
+- A **short screen recording** (a few seconds is enough) of the new behavior in
+  action is required for interactive changes — a new control, a changed flow, a
+  fixed visual bug. GitHub lets you drag a video straight into the PR
+  description.
+- A **before/after screenshot** is acceptable for a purely static visual change
+  (layout, color, label).
+
+This is not busywork: a working demo is the clearest evidence that the change
+does what the description says. PRs that alter the UI without a demo will be sent
+back with a request for one before review.
+
+## AI usage policy
+
+sw2robot is not anti-AI. Maintainers use AI tooling too. We care about the
+**quality** of a contribution, not how it was produced. The rules exist because
+low-effort, unverified AI output shifts the entire cost of a contribution onto
+the people reviewing it.
+
+1. **Disclose all AI usage.** In the PR/issue, state the tool(s) used and the
+   extent of assistance (e.g. "drafted with an LLM, reviewed and edited by
+   hand", or "wrote the tests myself, used AI for the docstrings").
+2. **AI-assisted implementation PRs are for `accepted` issues only.** See
+   Issue-first above.
+3. **You are responsible for everything you submit.** "The AI wrote it" is not
+   an explanation for a bug or a design choice. You must understand and be able
+   to defend every line.
+4. **No AI-generated media** (images, video, audio) in issues, PRs, or the repo.
+5. **Repeatedly submitting unverified AI slop** — fabricated bug reports, code
+   the author clearly doesn't understand, or floods of stacked PRs/issues — may
+   result in being blocked from further contributions.
+
+If you follow these rules, AI assistance is welcome. If you use it to generate
+volume you haven't reviewed, expect it to be closed.
+
+## Questions
+
+If you're unsure whether something is in scope or how big a change should be,
+open an issue and ask before writing code. That conversation is always cheaper
+than a rejected PR.

--- a/README.md
+++ b/README.md
@@ -355,6 +355,12 @@ cd tests/e2e && npm i && node run.mjs    # UI suite (needs a running sw2robot-we
 Some pytest fixtures expect a cached `output/<pkg>/graph.json`; those skip when
 absent.
 
+## Contributing
+
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening an issue or pull
+request. In short: discuss first via an issue, keep PRs small and focused,
+attach a demo video for UI changes, and disclose any AI usage.
+
 ## License
 
 [Apache License 2.0](LICENSE) © 2026 Iori Yanokura


### PR DESCRIPTION
## What & why

Adds a contributor guide and GitHub issue/PR templates to keep review load sustainable as AI-assisted contributions grow. The core ideas follow what curl and ghostty adopted: not anti-AI, but requiring quality, disclosure, and a reviewable scope.

## Changes

- **`CONTRIBUTING.md`**
  - Issue-first: implementation PRs must reference an issue labelled `accepted`; large drive-by / stacked PRs may be closed without full review. **Maintainers are exempt.**
  - Keep PRs and issues small and one-topic-at-a-time.
  - **AI usage must be disclosed** (tool + extent); authors own what they submit; repeated unverified slop can be blocked.
  - **UI / user-visible changes require a demo video** (or before/after screenshot).
  - **Reproducible samples** for CAD issues: attach a minimal `.zip`; replace confidential CAD with dummy stand-ins.
- **Issue templates** (bug / feature) with short, structured fields (`2-3 lines`) + AI-disclosure; blank issues routed to the guide.
- **PR template** with a required demo section, AI-disclosure, and a focused-change checklist.
- **`.github/workflows/length-check.yml`** — non-blocking nudge: labels `needs-condensing` + comments when a description is long *on prose* (code/logs/quotes/images/URLs excluded). Calibrated against current issues: real bug reports pass, verbose discussions get flagged.
- **`.gitignore`** — un-ignore `.github/` (a global `core.excludesFile` `.*` rule was hiding these files).
- **README** — link to the guide.
- New labels `accepted` and `needs-condensing` created on the repo.

## Notes

- The length-check workflow takes effect once merged to the default branch.
- Follow-ups discussed but intentionally left out of this PR: an `anti-slop` PR gate and a GitHub Models LLM screener.