### PR TITLE
feat(exporter): add DOF-folder mode to mark real joints explicitly

### DIFF
--- a/sw2robot/exporter/model.py
+++ b/sw2robot/exporter/model.py
@@ -615,6 +615,108 @@ def _entity_geo(me):
     return (_com_int(etype), p, d, radius)
 
 
+# --- DOF-folder mode ---------------------------------------------------------
+# When the assembly organizes its mates into a FeatureManager folder named
+# DOF_FOLDER_NAME (default "dof"), ONLY the mates inside that folder are treated
+# as actuated joints; every other mate is welded fixed.  This lets the CAD author
+# mark the real degrees of freedom explicitly instead of the exporter guessing
+# (which over-detects bearings / covers / linkage internals and, worse, picks a
+# spanning tree that breaks how parts move).  Folder name is configurable so the
+# convention can change later without code edits.
+DOF_FOLDER_NAME = os.environ.get("SW2URDF_DOF_FOLDER", "dof")
+_DOF_ACTIVE = False        # set by extract_graph when the top assembly has one
+
+
+def _mate_edge(sfi, name_set):
+    """``(edge, mate_type_name)`` a mate FEATURE connects, or ``(None, None)``."""
+    m2 = as_iface(safe_call(sfi, "GetSpecificFeature2"), "IMate2")
+    if m2 is None:
+        return None, None
+    mtype = _com_int(safe_prop(m2, "Type"))
+    mname = MATE_TYPES.get(mtype, str(mtype))
+    ne = safe_call(m2, "GetMateEntityCount") or 0
+    tops = []
+    for i in range(ne):
+        me = as_iface(safe_call(m2, "MateEntity", i), "IMateEntity2")
+        if me is None:
+            continue
+        rc = as_iface(safe_prop(me, "ReferenceComponent"), "IComponent2")
+        rn = safe_prop(rc, "Name2") if rc else None
+        top = _top_level(rn) if rn else None
+        if top in name_set:
+            tops.append(top)
+    real = list(dict.fromkeys(tops))
+    return (frozenset((real[0], real[1])), mname) if len(real) >= 2 else (None, None)
+
+
+def read_dof_edges(doc, name_set, folder_name=None):
+    """``(found, edges)``: whether a mate folder named ``folder_name`` exists in
+    this doc's MateGroup, and the set of top-level component-pair edges the mates
+    inside it connect.  Folders are flat markers in the feature list -- a folder
+    START feature (its Name equals the folder name) and a separate '...EndTag___'
+    FtrFolder that closes the most-recently-opened folder -- so we track a stack."""
+    folder_name = folder_name or DOF_FOLDER_NAME
+    found = False
+    edges = {}                                    # frozenset(edge) -> set(mate types)
+    feat = safe_call(doc, "FirstFeature")
+    guard = 0
+    while feat is not None and guard < 100000:
+        guard += 1
+        fi = as_iface(feat, "IFeature")
+        if safe_call(fi, "GetTypeName2") == "MateGroup":
+            stack = []
+            sub = safe_call(fi, "GetFirstSubFeature")
+            while sub is not None:
+                sfi = as_iface(sub, "IFeature")
+                tn = safe_call(sfi, "GetTypeName2")
+                nm = safe_prop(sfi, "Name") or ""
+                if tn == "FtrFolder":
+                    if "EndTag" in nm:            # closes the innermost open folder
+                        if stack:
+                            stack.pop()
+                    else:                         # a folder START
+                        stack.append(nm)
+                        if nm == folder_name:
+                            found = True
+                elif folder_name in stack:        # a mate inside the dof folder
+                    e, mt = _mate_edge(sfi, name_set)
+                    if e is not None:
+                        edges.setdefault(e, set()).add(mt)
+                sub = safe_call(sfi, "GetNextSubFeature")
+        feat = safe_call(fi, "GetNextFeature")
+    return found, edges
+
+
+def _apply_dof_filter(doc, comps, adjacency):
+    """DOF-folder mode (armed when the TOP assembly has a 'dof' mate folder): weld
+    every edge that is NOT a dof-folder joint.  A sub-assembly with no dof folder
+    of its own becomes fully rigid (all edges fixed) -- its internals are not robot
+    DOFs -- while one that HAS a dof folder keeps only those mates as joints."""
+    if not _DOF_ACTIVE:
+        return
+    name_set = {c.name for c in comps}
+    _found, dof_e = read_dof_edges(doc, name_set)
+    n = 0
+    for key, rec in adjacency.items():
+        if key in dof_e:
+            # This edge IS a marked DOF.  The dof-folder mate is the LOCK that
+            # pins the joint at its assembled angle (suppress it in SolidWorks and
+            # the joint swings free).  Keep ONLY the CONCENTRIC mate (which gives
+            # the free-rotation axis); dropping the parallel/coincident/symmetric
+            # mates is essential -- when this edge is expanded they would otherwise
+            # become FIXED cross-links that bridge the two rigid halves and let the
+            # tree pull the distal parts back onto the proximal side.
+            rec["mates"] = [g for g in rec.get("mates", []) if g.get("type") == "CONCENTRIC"]
+            rec["types"] = [t for t in rec.get("types", []) if t == "CONCENTRIC"]
+            rec.pop("force_fixed", None)
+        else:
+            rec["force_fixed"] = True
+            n += 1
+    if adjacency:
+        print(f"      DOF-folder '{DOF_FOLDER_NAME}': {len(dof_e)} joint edge(s) kept, "
+              f"{n} other edge(s) welded fixed")
+
+
 def build_mate_graph(doc, comps):
     """Adjacency over top-level component names.
 
@@ -712,6 +814,7 @@ def build_mate_graph(doc, comps):
               f"({seen} mates from GetMates"
               + (f"; entities resolved to {refs}" if refs else "")
               + ") -> attaches FIXED")
+    _apply_dof_filter(doc, comps, adjacency)
     return adjacency, ground
 
 
@@ -2470,6 +2573,13 @@ def extract_graph(doc, robot_name, source_assembly, progress=None):
     ``progress(link_name)`` is forwarded per component (see
     :func:`extract_components`)."""
     comps = extract_components(doc, progress=progress)
+    # DOF-folder mode: if the top assembly marks its real joints in a 'dof' mate
+    # folder, switch on the whitelist for this whole extraction (top + subgraphs).
+    global _DOF_ACTIVE
+    _DOF_ACTIVE, _ = read_dof_edges(doc, {c.name for c in comps})
+    if _DOF_ACTIVE:
+        print(f"      DOF-folder mode ON (mate folder '{DOF_FOLDER_NAME}'): only "
+              f"its mates become joints; everything else is welded fixed")
     adjacency, ground = build_mate_graph(doc, comps)
     mated = set()
     for key in adjacency:
@@ -2641,7 +2751,7 @@ def _mate_edges(adjacency):
             a=a, b=b, types=list(rec.get("types", [])),
             axis_point=([float(x) for x in ax[0]] if ax is not None else None),
             axis_dir=([float(x) for x in ax[1]] if ax is not None else None),
-            mates=mates))
+            mates=mates, force_fixed=bool(rec.get("force_fixed", False))))
     return edges
 
 
@@ -2749,7 +2859,8 @@ def _edge_rec(e):
     if e.axis_point and e.axis_dir:
         ax = (np.asarray(e.axis_point, float), np.asarray(e.axis_dir, float))
     return {"types": list(e.types), "axis": ax,
-            "mates": [g.model_dump() for g in e.mates] if e.mates else []}
+            "mates": [g.model_dump() for g in e.mates] if e.mates else [],
+            "force_fixed": bool(getattr(e, "force_fixed", False))}
 
 
 def _excluded(name, link_name, exclude):

--- a/sw2robot/exporter/state.py
+++ b/sw2robot/exporter/state.py
@@ -79,6 +79,8 @@ class MateEdge(BaseModel):
     axis_dir: list[float] | None = None      # world, unit
     # full per-mate geometry (newer extracts; None on graphs from older ones)
     mates: list[MateGeo] | None = None
+    # DOF-folder mode: this edge is NOT a 'dof' joint -> weld it fixed at build
+    force_fixed: bool = False
 
 
 class LimitJoint(BaseModel):

--- a/tests/test_dof_folder.py
+++ b/tests/test_dof_folder.py
@@ -1,0 +1,186 @@
+"""DOF-folder mode: only the mates inside a FeatureManager folder named 'dof'
+become joints; every other mate edge is welded fixed (force_fixed).
+
+These drive read_dof_edges / _apply_dof_filter against a fake SolidWorks feature
+tree -- no COM.  as_iface is monkeypatched to identity, and safe_prop/safe_call
+already operate on plain Python objects (getattr, then call if callable)."""
+from itertools import pairwise
+from types import SimpleNamespace
+
+import pytest
+
+from sw2robot.exporter import model
+from sw2robot.exporter.model import (
+    _apply_dof_filter,
+    _edge_rec,
+    _mate_edges,
+    classify_edge_auto,
+    read_dof_edges,
+)
+from sw2robot.exporter.state import MateEdge
+
+CONCENTRIC = 1        # MATE_TYPES key
+
+
+class _Comp:
+    def __init__(self, name):
+        self._n = name
+
+    @property
+    def Name2(self):
+        return self._n
+
+
+class _Ent:
+    def __init__(self, comp):
+        self._rc = _Comp(comp)
+
+    @property
+    def ReferenceComponent(self):
+        return self._rc
+
+
+class _Mate:
+    def __init__(self, mtype, comps):
+        self._t = mtype
+        self._ents = [_Ent(c) for c in comps]
+
+    @property
+    def Type(self):
+        return self._t
+
+    def GetMateEntityCount(self):
+        return len(self._ents)
+
+    def MateEntity(self, i):
+        return self._ents[i]
+
+
+class _Feat:
+    """A fake IFeature / sub-feature node (only the methods the code calls)."""
+
+    def __init__(self, typename, name="", spec=None):
+        self._tn = typename
+        self._nm = name
+        self._spec = spec
+        self.next_sub = None
+        self.next_feat = None
+        self.first_sub = None
+
+    def GetTypeName2(self):
+        return self._tn
+
+    def GetNextFeature(self):
+        return self.next_feat
+
+    def GetFirstSubFeature(self):
+        return self.first_sub
+
+    def GetNextSubFeature(self):
+        return self.next_sub
+
+    def GetSpecificFeature2(self):
+        return self._spec
+
+    @property
+    def Name(self):
+        return self._nm
+
+
+class _Doc:
+    def __init__(self, first):
+        self._first = first
+
+    def FirstFeature(self):
+        return self._first
+
+
+def _mategroup(subs):
+    """A doc whose single top feature is a MateGroup holding ``subs`` in order."""
+    for a, b in pairwise(subs):
+        a.next_sub = b
+    mg = _Feat("MateGroup")
+    mg.first_sub = subs[0] if subs else None
+    return _Doc(mg)
+
+
+def _dof_doc():
+    """Feature tree: a 'dof' folder wrapping one CONCENTRIC A-B mate."""
+    start = _Feat("FtrFolder", name="dof")
+    mate = _Feat("MateFeature", name="Concentric1",
+                 spec=_Mate(CONCENTRIC, ["A", "B"]))
+    end = _Feat("FtrFolder", name="dofEndTag___")
+    return _mategroup([start, mate, end])
+
+
+@pytest.fixture(autouse=True)
+def _hermetic(monkeypatch):
+    # no SolidWorks typelib marshalling, and a fixed folder name regardless of
+    # any SW2URDF_DOF_FOLDER in the environment
+    monkeypatch.setattr(model, "as_iface", lambda obj, iface: obj)
+    monkeypatch.setattr(model, "DOF_FOLDER_NAME", "dof")
+
+
+def test_read_dof_edges_finds_folder_and_edge():
+    found, edges = read_dof_edges(_dof_doc(), {"A", "B", "C"})
+    assert found is True
+    assert edges == {frozenset({"A", "B"}): {"CONCENTRIC"}}
+
+
+def test_read_dof_edges_absent_without_folder():
+    # the same mate, but sitting OUTSIDE any 'dof' folder
+    mate = _Feat("MateFeature", spec=_Mate(CONCENTRIC, ["A", "B"]))
+    found, edges = read_dof_edges(_mategroup([mate]), {"A", "B"})
+    assert found is False
+    assert edges == {}
+
+
+def test_apply_dof_filter_keeps_dof_and_welds_the_rest(monkeypatch):
+    monkeypatch.setattr(model, "_DOF_ACTIVE", True)
+    comps = [SimpleNamespace(name=n) for n in ("A", "B", "C")]
+    ab = frozenset({"A", "B"})
+    bc = frozenset({"B", "C"})
+    adjacency = {
+        ab: {"types": ["CONCENTRIC", "COINCIDENT"],
+             "mates": [{"type": "CONCENTRIC"}, {"type": "COINCIDENT"}]},
+        bc: {"types": ["CONCENTRIC"], "mates": [{"type": "CONCENTRIC"}]},
+    }
+
+    _apply_dof_filter(_dof_doc(), comps, adjacency)
+
+    # the marked DOF keeps ONLY its rotation axis and is NOT welded
+    assert "force_fixed" not in adjacency[ab]
+    assert adjacency[ab]["types"] == ["CONCENTRIC"]
+    assert [m["type"] for m in adjacency[ab]["mates"]] == ["CONCENTRIC"]
+
+    # every other edge is welded fixed, and the classifier honors it
+    assert adjacency[bc]["force_fixed"] is True
+    jtype, _axis, _note = classify_edge_auto(adjacency[bc])
+    assert jtype == "fixed"
+
+
+def test_apply_dof_filter_is_noop_when_inactive(monkeypatch):
+    monkeypatch.setattr(model, "_DOF_ACTIVE", False)
+    ab = frozenset({"A", "B"})
+    adjacency = {ab: {"types": ["CONCENTRIC"], "mates": []}}
+    _apply_dof_filter(_dof_doc(), [SimpleNamespace(name="A")], adjacency)
+    assert "force_fixed" not in adjacency[ab]
+
+
+def test_force_fixed_survives_graph_round_trip():
+    # extract-time force_fixed must reach the build via the MateEdge JSON
+    rec = _edge_rec(MateEdge(a="A", b="B", types=["CONCENTRIC"],
+                             force_fixed=True))
+    assert rec["force_fixed"] is True
+    jtype, _axis, _note = classify_edge_auto(rec)
+    assert jtype == "fixed"
+
+    # and back: _mate_edges lifts the adjacency flag onto the MateEdge
+    adjacency = {frozenset({"A", "B"}): {"types": ["CONCENTRIC"], "mates": [],
+                                         "force_fixed": True}}
+    (edge,) = _mate_edges(adjacency)
+    assert edge.force_fixed is True
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What & why (keep to a few lines)

The geometric classifier over-detects joints (bearings, covers, linkage
internals) and can pick a spanning tree that breaks how the assembly actually
moves. This adds an opt-in escape hatch: when the TOP assembly organizes its
mates into a FeatureManager folder named `dof` (env `SW2URDF_DOF_FOLDER`), only
the mates inside that folder become joints and every other edge is welded fixed.
The author marks the real DOFs explicitly instead of the exporter guessing.

It rides the existing `force_fixed` path — DOF mode just sets that flag on
non-`dof` edges (and trims a `dof` edge to its CONCENTRIC rotation axis). The
flag now round-trips through `MateEdge` so the extract-time decision survives
into the build.

## Linked issue
<!-- Maintainer PR; no pre-filed accepted issue (maintainer exemption). -->

## How I verified this

`pytest tests/test_dof_folder.py` -> 5 passed (folder detection, edge welding,
inactive no-op, and the force_fixed graph round-trip). Full non-SW suite
(`-k "not e2e and not com and not coacd and not golden"`) -> 326 passed, 9
skipped, no regressions. Not exercised against live SolidWorks in this change.

## Demo (required for UI / user-visible changes)
N/A - no UI change (export-graph behavior only).

## AI usage disclosure (required)
- [x] AI was used. Tool(s): `OpenAI Codex`. Extent: `drafted the DOF detection/filter + tests, reviewed and verified against the existing force_fixed classifier`.

## Checklist
- [x] This PR is one focused change (not a large stack of dependent branches).
- [x] No UI / user-visible change (demo not applicable).
- [x] Tests and build pass locally.
- [x] I ran the change and confirmed it does what this PR claims.
- [x] I understand every line I'm submitting.
