### PR TITLE
feat(exporter): warn when resolved geometry is missing from the URDF

### DIFF
--- a/sw2robot/exporter/export.py
+++ b/sw2robot/exporter/export.py
@@ -262,6 +262,24 @@ def build(pkg_dir, config_path=None, base_hint=None, exclude=None,
     # The working URDF KEEPS each mass-only link (geometry stripped) so it stays
     # selectable in the editor tree; only the exported package folds it away.
     mass_only_links = write_urdf(model, urdf_path, **urdf_kwargs)
+    # Surface parts that resolved + got a mesh but whose geometry never makes it
+    # into the URDF (classic case: a sub-assembly kept as one composed mesh whose
+    # 3DXML export config suppresses some children).  Best-effort: warn_dropped_
+    # geometry itself returns [] when trimesh/scipy/skrobot are absent, so this
+    # is a silent no-op there; the guard only catches unexpected failures and is
+    # advisory -- it must never break the build.
+    try:
+        import json as _json
+
+        from .validate import warn_dropped_geometry
+        with open(os.path.join(pkg_dir, GRAPH_FILE), encoding="utf-8") as _f:
+            _graph = _json.load(_f)
+        _dropped = warn_dropped_geometry(pkg_dir, urdf_path, _graph)
+        if _dropped:
+            print("      -> add the parent sub-assembly to the joint config's "
+                  "`expand:` list to bring these parts into the URDF.")
+    except Exception as _e:
+        print(f"      (dropped-geometry check skipped: {_e!r})")
     write_ros_package(model, pkg_dir)
     tmpl = os.path.join(pkg_dir, robot_name + ".joints.yaml")
     if not config_path:

--- a/sw2robot/exporter/validate.py
+++ b/sw2robot/exporter/validate.py
@@ -1,0 +1,172 @@
+"""Post-build validation: warn when a RESOLVED component's geometry is silently
+missing from the final URDF.
+
+The classic cause is a sub-assembly kept as ONE composed mesh whose 3DXML export
+ran in a configuration that suppresses some children -- those children have an
+exported per-part mesh AND a world in graph.json, yet no geometry of theirs ends
+up in the render.  Nothing warned about that before; this does.
+
+Geometry-based so it catches every mechanism, not just config suppression: it
+places each component's own exported mesh at the component's world and checks
+whether the assembled URDF actually has surface there.
+"""
+import os
+import xml.etree.ElementTree as ET
+
+import numpy as np
+
+
+def _load_glb_verts(path):
+    try:
+        import trimesh
+    except Exception:
+        return None
+    stem = os.path.splitext(path)[0]
+    for cand in (path, stem + ".3dxml.glb", stem + ".glb", path + ".glb"):
+        if os.path.exists(cand):
+            try:
+                m = trimesh.load(cand, force="mesh")
+                if len(m.vertices):
+                    return np.asarray(m.vertices, float)
+            except Exception:
+                pass
+    return None
+
+
+def _origin_mat(el):
+    if el is None:
+        return np.eye(4)
+    xyz = [float(x) for x in (el.get("xyz") or "0 0 0").split()]
+    rpy = [float(x) for x in (el.get("rpy") or "0 0 0").split()]
+    from .geometry import matrix_from_rpy
+    T = np.array(matrix_from_rpy(rpy), float).copy()
+    T[:3, 3] = xyz
+    return T
+
+
+def warn_dropped_geometry(pkg_dir, urdf_path, graph, tol_mm=3.0, min_frac=0.15):
+    """Print a WARNING per component whose geometry is absent from the URDF.
+
+    Returns the list of dropped component names (empty if all present)."""
+    try:
+        from scipy.spatial import cKDTree
+    except Exception:
+        return []                       # scipy/trimesh optional -- skip silently
+    meshes_dir = os.path.join(pkg_dir, "meshes")
+
+    # --- assembled scene point cloud, in the URDF root frame ---------------
+    try:
+        from skrobot.models.urdf import RobotModelFromURDF
+    except Exception:
+        return []
+    # strip visuals so skrobot loads even with .3dxml refs, then FK link frames
+    tree = ET.parse(urdf_path)
+    root = tree.getroot()
+    link_mesh = {}                      # link name -> [(glb_verts, visual_origin)]
+    for link in root.findall("link"):
+        items = []
+        for vis in link.findall("visual"):
+            me = vis.find("geometry/mesh")
+            if me is None:
+                continue
+            fn = os.path.basename(me.get("filename") or "")
+            verts = _load_glb_verts(os.path.join(meshes_dir, fn))
+            if verts is not None:
+                items.append((verts, _origin_mat(vis.find("origin"))))
+        if items:
+            link_mesh[link.get("name")] = items
+    for link in root.findall("link"):
+        for tag in ("visual", "collision"):
+            for e in link.findall(tag):
+                link.remove(e)
+    nm = urdf_path + ".novis.urdf"
+    ET.ElementTree(root).write(nm)
+    try:
+        rb = RobotModelFromURDF(urdf_file=nm)
+    finally:
+        try:
+            os.remove(nm)
+        except OSError:
+            pass
+    L = {l.name: l for l in rb.link_list}
+    pts = []
+    for ln, items in link_mesh.items():
+        if ln not in L:
+            continue
+        W = L[ln].worldcoords().T()
+        for verts, vo in items:
+            T = W @ vo
+            pts.append((T[:3, :3] @ verts.T).T + T[:3, 3])
+    if not pts:
+        return []
+    scene = np.vstack(pts)
+    kd = cKDTree(scene)
+
+    # The URDF is rooted at base_link (skrobot frame); graph worlds are in the
+    # SolidWorks world frame.  Recover the align transform from ONE present link
+    # so component placements below land in the URDF scene frame.
+    import re as _re
+    def _san(s):
+        return _re.sub(r"[^a-z0-9]", "", s.lower())
+    dwld = graph.get("deep_worlds") or {}
+    dw_by_leaf = {_san(k.split("/")[-1]): np.array(v, float).reshape(4, 4)
+                  for k, v in dwld.items()}
+    T_align = None
+    for ln, items in link_mesh.items():
+        if ln not in L:
+            continue
+        key = None
+        for lk in dw_by_leaf:
+            if len(lk) >= 6 and (_san(ln).endswith(lk) or lk.endswith(_san(ln))):
+                key = lk
+                break
+        if key is None:
+            continue
+        # scene pose of this link's first mesh vs its graph world
+        W = L[ln].worldcoords().T() @ items[0][1]
+        T_align = W @ np.linalg.inv(dw_by_leaf[key])
+        break
+    if T_align is None:
+        T_align = np.eye(4)
+
+    # --- every LEAF component with an exported mesh + its world -------------
+    # sub-assembly roots are represented by their composed mesh OR their
+    # expanded children, so skip them (checking their composed mesh at the SA
+    # world false-positives whenever the SA was expanded).
+    mesh_of = {}
+    for sa in (graph.get("subassemblies") or {}).values():
+        for c in sa.get("components", []):
+            if c.get("mesh_file") and not c.get("is_subassembly"):
+                mesh_of[c["name"]] = c["mesh_file"]
+    for c in graph.get("components", []):
+        if c.get("mesh_file") and not c.get("is_subassembly"):
+            mesh_of[c["name"]] = c["mesh_file"]
+
+    rng = np.random.RandomState(0)
+    dropped = []
+    for key, wl in (graph.get("deep_worlds") or {}).items():
+        nm2 = key.split("/")[-1]
+        mf = mesh_of.get(nm2)
+        if not mf:
+            continue
+        verts = _load_glb_verts(os.path.join(pkg_dir, mf.replace("\\", "/")))
+        if verts is None:
+            continue
+        W = T_align @ np.array(wl, float).reshape(4, 4)
+        sample = verts[rng.choice(len(verts), min(60, len(verts)), replace=False)]
+        wp = (W[:3, :3] @ sample.T).T + W[:3, 3]
+        d, _ = kd.query(wp)
+        frac = float((d < tol_mm / 1000.0).mean())
+        if frac < min_frac:
+            dropped.append(nm2)
+    # de-dup, keep order
+    seen = set()
+    uniq = [d for d in dropped if not (d in seen or seen.add(d))]
+    if uniq:
+        print(f"      WARNING: {len(uniq)} component(s) have geometry that is "
+              f"MISSING from the URDF (likely hidden in a non-expanded "
+              f"sub-assembly whose composed mesh omits them -- add them to "
+              f"`expand:`):")
+        for nm2 in uniq:
+            print(f"        - {nm2}")
+    return uniq

--- a/tests/test_validate_dropped.py
+++ b/tests/test_validate_dropped.py
@@ -1,0 +1,35 @@
+"""Light unit coverage for the post-build dropped-geometry validator's pure
+helpers (the full geometry check needs trimesh+scipy+skrobot + a real package
+and is exercised end-to-end by the pipeline tests)."""
+import xml.etree.ElementTree as ET
+
+import numpy as np
+import pytest
+
+from sw2robot.exporter.validate import _load_glb_verts, _origin_mat
+
+
+def test_origin_mat_none_is_identity():
+    assert np.allclose(_origin_mat(None), np.eye(4))
+
+
+def test_origin_mat_reads_xyz_and_rpy():
+    el = ET.fromstring('<origin xyz="1 2 3" rpy="0 0 0"/>')
+    T = _origin_mat(el)
+    assert np.allclose(T[:3, :3], np.eye(3))
+    assert np.allclose(T[:3, 3], [1.0, 2.0, 3.0])
+
+
+def test_origin_mat_applies_rotation():
+    # 90 deg about Z: x-axis maps to +y
+    el = ET.fromstring(f'<origin xyz="0 0 0" rpy="0 0 {np.pi / 2}"/>')
+    T = _origin_mat(el)
+    assert np.allclose(T[:3, :3] @ [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], atol=1e-9)
+
+
+def test_load_glb_verts_missing_returns_none():
+    assert _load_glb_verts("does_not_exist_anywhere.glb") is None
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What & why (keep to a few lines)

A resolved component can get an exported mesh AND a world in `graph.json` yet
have none of its geometry reach the final URDF -- the classic case is a
sub-assembly kept as one composed mesh whose 3DXML export ran in a configuration
that suppresses some children. Nothing warned about that before.

This adds a best-effort, geometry-based post-build check (new `validate.py`,
`warn_dropped_geometry`): it places each leaf component's own exported mesh at
its world and verifies the assembled URDF actually has surface there, then lists
the components that don't and points at the joint config's `expand:` list.

## Linked issue
<!-- Maintainer PR; no pre-filed accepted issue (maintainer exemption). -->

## How I verified this

`pytest tests/test_validate_dropped.py` -> 4 passed (the pure helpers:
`_origin_mat` identity/translation/rotation and `_load_glb_verts` missing-file).
Full non-SW suite (`-k "not e2e and not com and not coacd and not golden"`) ->
325 passed, 9 skipped, no regressions. The full geometry check needs
trimesh+scipy+skrobot and is exercised end-to-end by the pipeline tests; here it
is wired as a silent no-op when those are absent, so `build` never depends on it.

## Demo (required for UI / user-visible changes)
N/A - no UI change (adds a console WARNING during `build`).

## AI usage disclosure (required)
- [x] AI was used. Tool(s): `OpenAI Codex`. Extent: `drafted validate.py + the build hook, reviewed and verified; wrote the helper tests`.

## Checklist
- [x] This PR is one focused change (not a large stack of dependent branches).
- [x] No UI / user-visible change (demo not applicable).
- [x] Tests and build pass locally.
- [x] I ran the change and confirmed it does what this PR claims.
- [x] I understand every line I'm submitting.
