### PR TITLE
feat(exporter): resolve lightweight + config-suppressed components on open

### DIFF
--- a/sw2robot/exporter/swcom.py
+++ b/sw2robot/exporter/swcom.py
@@ -334,6 +334,60 @@ def _require_typelibs():
     return mod
 
 
+def resolve_lightweight_components(doc, deep=True):
+    """Force-resolve LIGHTWEIGHT components one by one; return the count.
+
+    ``ResolveAllLightWeightComponents`` needs an ACTIVE document, so in a
+    hidden automation session it can be a silent no-op -- lightweight
+    components then report ``GetModelDoc2 = None`` and vanish from mass
+    properties and meshes (a whole-sub-assembly 3DXML writes them as HOLES).
+    ``SetSuppression2`` works per component without activation.  ``deep``
+    walks nested children too (GetComponents(False))."""
+    n = 0
+    try:
+        for c in list(safe_call(doc, "GetComponents", not deep) or []):
+            ct = as_iface(c, "IComponent2")
+            if safe_call(ct, "GetSuppression") == 1:       # lightweight
+                try:
+                    ct.SetSuppression2(2)                  # fully resolved
+                    n += 1
+                except Exception:
+                    pass
+    except Exception:
+        pass
+    return n
+
+
+def resolve_suppressed_components(doc, deep=True):
+    """Force-resolve components SUPPRESSED by the saved-active configuration
+    (``GetSuppression == 0``) so their geometry is included in the export.
+
+    A component the active config suppresses is otherwise dropped entirely
+    (``extract_components`` skips ``state == 0``), so parts that ARE present on
+    disk but merely toggled off by the config -- e.g. an encoder board or a
+    Misumi extrusion carried in a variant -- silently vanish from the URDF.
+    ``SetSuppression2(2)`` brings them back; parts whose file cannot be found
+    fail the call and stay suppressed.  Returns ``(count, [names])``.  Gated by
+    the caller (opt-in) since a config MAY suppress parts on purpose."""
+    n = 0
+    names = []
+    try:
+        for c in list(safe_call(doc, "GetComponents", not deep) or []):
+            ct = as_iface(c, "IComponent2")
+            if safe_call(ct, "GetSuppression") == 0:       # config-suppressed
+                nm = safe_prop(ct, "Name2")
+                try:
+                    ct.SetSuppression2(2)                  # fully resolved
+                    if safe_call(ct, "GetSuppression") != 0:
+                        n += 1
+                        names.append(nm)
+                except Exception:
+                    pass
+    except Exception:
+        pass
+    return n, names
+
+
 class SolidWorks:
     """Owns a private SolidWorks instance; opens docs read-only; never saves.
 
@@ -532,7 +586,17 @@ class SolidWorks:
                     print(f"      co-located {n_sib} sibling CAD file(s) for "
                           f"reference resolution")
             t1 = _time.time()
-            doc, ecode, wcode = open_doc6(self.app, tmp, doc_type_for(tmp))
+            # 0x80 = swOpenDocOptions_OverrideDefaultLoadLightweight: force a
+            # FULLY RESOLVED load even when the machine's system option says
+            # "load components lightweight".  Lightweight components report
+            # GetModelDoc2 = None, so every top-level part loses its SolidWorks
+            # mass properties AND its mesh (the in-session export has no doc,
+            # and a standalone OpenDoc6 of a file the assembly already holds
+            # lightweight returns that same hollow stub -> empty 3DXML).
+            # ResolveAllLightWeightComponents below is kept as a second chance
+            # but on some installs it returns instantly without resolving.
+            doc, ecode, wcode = open_doc6(self.app, tmp, doc_type_for(tmp),
+                                          SW_OPEN_SILENT | 0x80)
             if doc is None:
                 # 65536 = swFileWithSameTitleAlreadyOpen: a doc with this title
                 # is already open in the reused session (we copy under a unique
@@ -557,6 +621,23 @@ class SolidWorks:
                 asm.ResolveAllLightWeightComponents(True)
             except Exception:
                 pass
+            # Components SAVED lightweight survive both the 0x80 open flag
+            # and the bulk resolve above -- resolve them one by one (see
+            # resolve_lightweight_components).
+            n_lw = resolve_lightweight_components(doc, deep=True)
+            if n_lw:
+                print(f"      resolved {n_lw} lightweight component(s) "
+                      f"individually")
+            # Opt-in: bring back parts the saved-active CONFIGURATION suppresses
+            # (they are present on disk but toggled off -- encoder boards, Misumi
+            # extrusions in a variant, ...).  Off by default since a config may
+            # suppress parts on purpose (e.g. a 'without_hand' variant).
+            if os.environ.get("SW2URDF_RESOLVE_SUPPRESSED") == "1":
+                n_sp, sp_names = resolve_suppressed_components(doc, deep=True)
+                if n_sp:
+                    print(f"      resolved {n_sp} config-suppressed component(s): "
+                          f"{', '.join(sp_names[:8])}"
+                          f"{' ...' if len(sp_names) > 8 else ''}")
             t3 = _time.time()
             # ForceRebuild3 was added for stale as-saved poses (propellers
             # floating off motors), but it was MEASURED to be a no-op for

--- a/tests/test_resolve_suppressed.py
+++ b/tests/test_resolve_suppressed.py
@@ -1,0 +1,81 @@
+"""resolve_lightweight_components / resolve_suppressed_components force-resolve
+components that would otherwise export as holes (lightweight) or vanish entirely
+(config-suppressed).  Driven with fake COM components -- as_iface is patched to
+identity; safe_call/safe_prop already work on plain objects.
+
+Suppression states follow swComponentSuppressionState_e: 0 = suppressed,
+1 = lightweight, 2 = fully resolved."""
+import pytest
+
+from sw2robot.exporter import swcom
+from sw2robot.exporter.swcom import (
+    resolve_lightweight_components,
+    resolve_suppressed_components,
+)
+
+
+class _Comp:
+    def __init__(self, name, state, resolvable=True):
+        self._name = name
+        self._state = state
+        self._resolvable = resolvable
+        self.set_calls = []
+
+    def GetSuppression(self):
+        return self._state
+
+    def SetSuppression2(self, v):
+        self.set_calls.append(v)
+        if not self._resolvable:                 # e.g. the part file is missing
+            raise RuntimeError("cannot resolve")
+        self._state = v
+
+    @property
+    def Name2(self):
+        return self._name
+
+
+class _Doc:
+    def __init__(self, comps):
+        self._comps = comps
+
+    def GetComponents(self, top_only):
+        return self._comps
+
+
+@pytest.fixture(autouse=True)
+def _identity_as_iface(monkeypatch):
+    monkeypatch.setattr(swcom, "as_iface", lambda obj, iface: obj)
+
+
+def test_resolve_lightweight_only_touches_lightweight():
+    lw = _Comp("lw", 1)
+    resolved = _Comp("already", 2)
+    supp = _Comp("supp", 0)
+    n = resolve_lightweight_components(_Doc([lw, resolved, supp]))
+    assert n == 1
+    assert lw.set_calls == [2]        # driven to fully-resolved
+    assert resolved.set_calls == []   # left alone
+    assert supp.set_calls == []       # not lightweight -> untouched
+
+
+def test_resolve_suppressed_counts_and_names_recovered():
+    board = _Comp("encoder_board-1", 0)
+    lw = _Comp("lw-1", 1)
+    n, names = resolve_suppressed_components(_Doc([board, lw]))
+    assert n == 1
+    assert names == ["encoder_board-1"]
+    assert lw.set_calls == []          # only config-suppressed (state 0) touched
+
+
+def test_resolve_suppressed_skips_unresolvable():
+    # a suppressed part whose file cannot be found: SetSuppression2 raises and
+    # it must NOT be counted as recovered
+    missing = _Comp("missing-1", 0, resolvable=False)
+    n, names = resolve_suppressed_components(_Doc([missing]))
+    assert n == 0
+    assert names == []
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What & why (keep to a few lines)

Lightweight components report `GetModelDoc2 = None` in a hidden automation
session, so every top-level part loses its SolidWorks mass properties AND its
mesh (a whole-sub-assembly 3DXML then writes them as holes). This forces a
fully-resolved load (`OverrideDefaultLoadLightweight` open flag) and, as a
second pass, resolves any still-lightweight components one by one via
`SetSuppression2`.

It also adds opt-in recovery of parts the saved-active CONFIGURATION suppresses
(present on disk but toggled off -- an encoder board, a Misumi extrusion in a
variant): gated behind `SW2URDF_RESOLVE_SUPPRESSED=1`, since a config may
suppress parts on purpose (a `without_hand` variant).

Note: the lightweight fixes are always-on (they change no geometry that was
already correct, only recover parts that exported empty); forcing a resolved
load can be slower on large shared-drive assemblies. The config-suppressed
recovery is deliberately opt-in.

## Linked issue
<!-- Maintainer PR; no pre-filed accepted issue (maintainer exemption). -->

## How I verified this

`pytest tests/test_resolve_suppressed.py` -> 3 passed (lightweight-only touch,
config-suppressed count+names, and the unresolvable part staying suppressed).
Full non-SW suite (`-k "not e2e and not com and not coacd and not golden"`) ->
333 passed, 9 skipped, no regressions. The resolve functions themselves drive
live SolidWorks COM (SetSuppression2) and are covered here with fake components;
not re-run against live CAD in this change.

## Demo (required for UI / user-visible changes)
N/A - no UI change (extract-time component resolution).

## AI usage disclosure (required)
- [x] AI was used. Tool(s): `OpenAI Codex`. Extent: `drafted the resolve helpers + open-flag change, reviewed and verified; wrote the fake-COM tests`.

## Checklist
- [x] This PR is one focused change (not a large stack of dependent branches).
- [x] No UI / user-visible change (demo not applicable).
- [x] Tests and build pass locally.
- [x] I ran the change and confirmed it does what this PR claims.
- [x] I understand every line I'm submitting.
