### PR TITLE
feat(exporter): capture and honor SolidWorks configurations on extract

### DIFF
--- a/sw2robot/exporter/export.py
+++ b/sw2robot/exporter/export.py
@@ -41,7 +41,7 @@ from .model import (
     to_graph_state,
 )
 from .state import GraphState
-from .swcom import SW_DOC_PART, SolidWorks, as_iface, doc_type_for
+from .swcom import SW_DOC_PART, SolidWorks, as_iface, doc_type_for, safe_call
 from .urdf_writer import write_ros_package, write_urdf
 
 GRAPH_FILE = "graph.json"
@@ -93,15 +93,35 @@ def _extract_part_into(sw, part_path, pkg_dir, meshes_dir, robot_name, _say):
 
 
 def _extract_into(sw, assembly_path, pkg_dir, meshes_dir, robot_name, _say,
-                  _part=None):
+                  _part=None, configuration=None):
     """Extraction body against an already-running SolidWorks session.  ``_part``
-    (optional) reports the part currently being read, for the load indicator."""
+    (optional) reports the part currently being read, for the load indicator.
+    ``configuration`` -- extract THIS assembly configuration instead of the
+    file's saved-active one (configs can suppress whole components, e.g. a
+    bench-mount frame present in one variant only)."""
     if doc_type_for(assembly_path) == SW_DOC_PART:
         return _extract_part_into(sw, assembly_path, pkg_dir, meshes_dir,
                                   robot_name, _say)
     _say(f"opening copy of {os.path.basename(assembly_path)} "
          f"(loading the assembly) ...")
     doc = sw.open_copy(assembly_path)
+    # surface the choice: extracts silently follow the file's SAVED-ACTIVE
+    # configuration, which is not necessarily the one on the user's screen
+    try:
+        md = as_iface(doc, "IModelDoc2")
+        cfgs = [str(c) for c in (safe_call(md, "GetConfigurationNames") or [])]
+        active = md.ConfigurationManager.ActiveConfiguration.Name
+        if len(cfgs) > 1:
+            _say(f"assembly configurations: {cfgs} (saved-active: {active!r})")
+        if configuration and configuration != active:
+            if md.ShowConfiguration2(configuration):
+                _say(f"switched to configuration {configuration!r}")
+            else:
+                print(f"      WARN: configuration {configuration!r} not found; "
+                      f"staying on {active!r}")
+    except Exception as e:
+        if configuration:
+            print(f"      WARN: could not switch configuration ({e!r})")
 
     _say("reading components + mates ...")
     comps, adjacency, ground = extract_graph(doc, robot_name, assembly_path,
@@ -161,7 +181,7 @@ def _extract_into(sw, assembly_path, pkg_dir, meshes_dir, robot_name, _say,
 
 
 def extract(assembly_path, out_dir=None, robot_name=None, visible=False,
-            progress=None, sw=None):
+            progress=None, sw=None, configuration=None):
     """SolidWorks -> graph.json (+ per-link 3DXML).  ``progress(msg)`` -- if
     given -- receives short human-readable status strings at each stage and once
     per exported mesh, so a UI can show how far along the (multi-minute) extract
@@ -202,11 +222,12 @@ def extract(assembly_path, out_dir=None, robot_name=None, visible=False,
 
     if sw is not None:
         _extract_into(sw, assembly_path, pkg_dir, meshes_dir, robot_name, _say,
-                      _part)
+                      _part, configuration=configuration)
     else:
         with SolidWorks(visible=visible) as sw_own:
             _extract_into(sw_own, assembly_path, pkg_dir, meshes_dir,
-                          robot_name, _say, _part)
+                          robot_name, _say, _part,
+                          configuration=configuration)
 
     print(f"  graph: {os.path.join(pkg_dir, GRAPH_FILE)}")
     return pkg_dir
@@ -349,8 +370,9 @@ def export(assembly_path, out_dir=None, robot_name=None, visible=False,
            config_path=None, base_hint=None, exclude=None, ros_pkg=False,
            ros_version=1, ros_pkg_name=None, ros_urdf_name=None,
            collision="copy", coacd_quality="balanced", merge_fixed=False,
-           ros_mesh_dir=None):
-    pkg_dir = extract(assembly_path, out_dir, robot_name, visible)
+           ros_mesh_dir=None, configuration=None):
+    pkg_dir = extract(assembly_path, out_dir, robot_name, visible,
+                      configuration=configuration)
     return build(pkg_dir, config_path=config_path, base_hint=base_hint,
                  exclude=exclude, ros_pkg=ros_pkg, ros_version=ros_version,
                  ros_pkg_name=ros_pkg_name, ros_urdf_name=ros_urdf_name,
@@ -370,6 +392,10 @@ def main():
     ap.add_argument("-o", "--out", default=None)
     ap.add_argument("-n", "--name", default=None)
     ap.add_argument("--visible", action="store_true")
+    ap.add_argument("--configuration", default=None, metavar="NAME",
+                    help="extract this ASSEMBLY configuration instead of the "
+                         "file's saved-active one (configs can suppress whole "
+                         "components, e.g. a bench-mount frame)")
     ap.add_argument("--config", default=None)
     ap.add_argument("--base", default=None)
     ap.add_argument("--exclude", default=None)
@@ -414,6 +440,7 @@ def main():
                          "per moving body; mesh-less coordinate frames are kept")
     args = ap.parse_args()
     export(args.assembly, args.out, args.name, args.visible,
+           configuration=args.configuration,
            config_path=args.config, base_hint=args.base,
            exclude=_exclude_list(args.exclude),
            ros_pkg=args.ros_pkg or args.ros2,

--- a/sw2robot/exporter/extract.py
+++ b/sw2robot/exporter/extract.py
@@ -15,8 +15,12 @@ def main():
     ap.add_argument("-o", "--out", default=None)
     ap.add_argument("-n", "--name", default=None)
     ap.add_argument("--visible", action="store_true")
+    ap.add_argument("--configuration", default=None, metavar="NAME",
+                    help="extract this ASSEMBLY configuration instead of the "
+                         "file's saved-active one")
     args = ap.parse_args()
-    extract(args.assembly, args.out, args.name, args.visible)
+    extract(args.assembly, args.out, args.name, args.visible,
+            configuration=args.configuration)
 
 
 if __name__ == "__main__":

--- a/sw2robot/exporter/model.py
+++ b/sw2robot/exporter/model.py
@@ -241,6 +241,12 @@ class Component:
     visual_rpy: list = field(default_factory=lambda: [0, 0, 0])
     material: str | None = None      # SolidWorks material name
     density: float | None = None     # kg/m^3 from that material
+    # the SolidWorks configuration this INSTANCE references.  Two instances of
+    # one part file can reference different configurations with different
+    # geometry (a length-configured tube: '180cm_shoulder_L120' vs
+    # '180cm_wrist_L75') -- sharing one mesh/mass across them renders both as
+    # the same variant, so exports must key on (part_path, configuration)
+    configuration: str | None = None
     # SolidWorks-native mass properties (part-local frame, SI), preferred over
     # the mesh estimate when present -- see exporter.inertia.link_inertial_from_sw
     sw_mass: float | None = None              # kg
@@ -534,13 +540,15 @@ def extract_components(doc, exclude=None, progress=None):
         if path and not is_asm:
             material, density, sw = _material_of(ct, path)
         sw = sw or {}
+        cfg = safe_prop(ct, "ReferencedConfiguration") or None
         comps.append(Component(name=name, link_name=ln, part_path=path,
                                is_subassembly=is_asm, world=world,
                                fixed=fixed, dof=dof,
                                material=material, density=density,
                                sw_mass=sw.get("mass"), sw_com=sw.get("com"),
                                sw_inertia=sw.get("inertia"),
-                               sw_mass_overridden=sw.get("overridden", False)))
+                               sw_mass_overridden=sw.get("overridden", False),
+                               configuration=cfg))
     if n_skipped or n_excluded:
         print(f"      (skipped {n_skipped} suppressed/unnamed, "
               f"excluded {n_excluded} components)")
@@ -2737,7 +2745,8 @@ def _component_states(comps):
             material=c.material, density=c.density,
             sw_mass=c.sw_mass, sw_com=c.sw_com, sw_inertia=c.sw_inertia,
             sw_mass_overridden=c.sw_mass_overridden,
-            mass_target=c.mass_target)
+            mass_target=c.mass_target,
+            configuration=getattr(c, "configuration", None))
             for c in comps]
 
 
@@ -2815,12 +2824,20 @@ def extract_subgraphs(doc, comps, sw=None, progress=None):
         live[safe_prop(ct, "Name2")] = ct
 
     out = {}
+    out_cfg = {}
     opened_docs = []
-    work = [(c.part_path, live.get(c.name))
+    work = [(c.part_path, live.get(c.name),
+             getattr(c, "configuration", None))
             for c in comps if c.is_subassembly and c.part_path]
     while work:
-        path, ct = work.pop(0)
-        if not path or path in out:
+        path, ct, cfg = work.pop(0)
+        if not path:
+            continue
+        if path in out:
+            if cfg and out_cfg.get(path) and out_cfg[path] != cfg:
+                print(f"      WARN: {os.path.basename(path)} is used with "
+                      f"configurations {out_cfg[path]!r} AND {cfg!r}; its "
+                      f"internals were extracted as {out_cfg[path]!r}")
             continue
         md = safe_call(ct, "GetModelDoc2") if ct is not None else None
         if md is None and sw is not None:
@@ -2835,6 +2852,19 @@ def extract_subgraphs(doc, comps, sw=None, progress=None):
             print(f"      WARN: no document for sub-assembly "
                   f"{os.path.basename(path)}; internals not extracted")
             continue
+        # The instance references a specific CONFIGURATION of this
+        # sub-assembly.  The file may be SAVED on a different one, where the
+        # children reference other configs of their own parts (a hinge clevis
+        # plate becomes a 22 mm spacer) or are suppressed -- reading the
+        # saved-active state then extracts the wrong internals.  Switch first.
+        if cfg:
+            try:
+                as_iface(md, "IModelDoc2").ShowConfiguration2(cfg)
+                out_cfg[path] = cfg
+            except Exception as e:
+                print(f"      WARN: could not switch "
+                      f"{os.path.basename(path)} to configuration "
+                      f"{cfg!r}: {e!r}")
         subcomps = extract_components(md, progress=progress)
         subadj, subground = build_mate_graph(md, subcomps)
         out[path] = (subcomps, subadj, subground)
@@ -2845,8 +2875,9 @@ def extract_subgraphs(doc, comps, sw=None, progress=None):
             ct2 = as_iface(c2, "IComponent2")
             live2[safe_prop(ct2, "Name2")] = ct2
         for sc in subcomps:
-            if sc.is_subassembly and sc.part_path and sc.part_path not in out:
-                work.append((sc.part_path, live2.get(sc.name)))
+            if sc.is_subassembly and sc.part_path:
+                work.append((sc.part_path, live2.get(sc.name),
+                             getattr(sc, "configuration", None)))
     if sw is not None:
         for md in opened_docs:
             sw.close_doc(md)
@@ -2897,7 +2928,8 @@ def from_graph(graph, exclude=None, expand=None, no_expand=None):
             sw_mass=cs.sw_mass, sw_com=cs.sw_com, sw_inertia=cs.sw_inertia,
             sw_mass_overridden=getattr(cs, "sw_mass_overridden", False),
             mass_target=getattr(cs, "mass_target", None),
-            mass_only=getattr(cs, "mass_only", False)))
+            mass_only=getattr(cs, "mass_only", False),
+            configuration=getattr(cs, "configuration", None)))
     names = {c.name for c in comps}
     adjacency = {}
     for e in graph.edges:

--- a/sw2robot/exporter/state.py
+++ b/sw2robot/exporter/state.py
@@ -47,6 +47,11 @@ class ComponentState(BaseModel):
     # Valid only on a fixed child -- its inertial is lumped into the fixed parent
     # on export, so the parent's mass/inertia accounts for it without a mesh.
     mass_only: bool = False
+    # the SolidWorks configuration this instance references.  Two instances of
+    # the SAME part file can reference different configurations with different
+    # geometry (length-configured tube), so mesh/mass exports key on
+    # (part_path, configuration).  None on older extracts / single-config parts.
+    configuration: str | None = None
 
     def world_matrix(self):
         return np.array(self.world, float).reshape(4, 4)

--- a/tests/test_configuration_field.py
+++ b/tests/test_configuration_field.py
@@ -1,0 +1,57 @@
+"""Configuration-aware extraction: the SolidWorks configuration an instance
+references is captured on Component/ComponentState and must survive the
+graph.json round-trip (extract keys mesh/mass on (part_path, configuration);
+losing it renders two length-configured instances as the same variant)."""
+import json
+
+import numpy as np
+import pytest
+
+from sw2robot.exporter.model import Component, _component_states, from_graph
+from sw2robot.exporter.state import ComponentState, GraphState
+
+
+def _component(name, cfg):
+    return Component(name=name, link_name=name, part_path=f"{name}.SLDPRT",
+                     is_subassembly=False, world=np.eye(4), fixed=False, dof=0,
+                     configuration=cfg)
+
+
+def _state(name, cfg):
+    return ComponentState(name=name, link_name=name, part_path=f"{name}.SLDPRT",
+                          world=[float(x) for x in np.eye(4).flatten()],
+                          configuration=cfg)
+
+
+def _graph(*states):
+    return GraphState(robot_name="r", source_assembly="a.SLDASM",
+                      components=list(states))
+
+
+def test_component_states_carries_configuration():
+    (cs,) = _component_states([_component("tube-1", "180cm_shoulder_L120")])
+    assert cs.configuration == "180cm_shoulder_L120"
+
+
+def test_configuration_survives_json_round_trip():
+    g = _graph(_state("tube-1", "shoulder_L120"), _state("tube-2", "wrist_L75"))
+    g2 = GraphState.model_validate_json(g.model_dump_json())
+    assert [c.configuration for c in g2.components] == ["shoulder_L120",
+                                                        "wrist_L75"]
+
+
+def test_from_graph_reconstructs_configuration():
+    comps, _adj, _ground = from_graph(_graph(_state("tube-1", "wrist_L75")))
+    assert comps[0].configuration == "wrist_L75"
+
+
+def test_configuration_defaults_none_on_older_extract():
+    # a graph.json written before this field existed simply lacks the key
+    d = json.loads(_graph(_state("x-1", "cfgA")).model_dump_json())
+    del d["components"][0]["configuration"]
+    g = GraphState.model_validate_json(json.dumps(d))
+    assert g.components[0].configuration is None
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What & why (keep to a few lines)

Each component instance records the SolidWorks configuration it references
(`ReferencedConfiguration`), persisted on `Component`/`ComponentState` through
`graph.json`. Two instances of one part file can reference different-geometry
configurations, so the field lets later stages key on `(part_path, configuration)`.

Two concrete behaviors ride it now:
- `--configuration NAME` extracts a chosen ASSEMBLY configuration instead of the
  file's saved-active one (configs can suppress whole components).
- `extract_subgraphs` switches each sub-assembly to the configuration its
  instance references before reading internals -- the saved-active state can
  reference other child configs or suppress children, which extracted the wrong
  internals before.

Per-instance mesh/mass dedup keying on configuration is intentionally left as
follow-up (it lives in the mesh exporter): this change captures the field and
wires config SELECTION, not the mesh-cache split.

## Linked issue
<!-- Maintainer PR; no pre-filed accepted issue (maintainer exemption). -->

## How I verified this

`pytest tests/test_configuration_field.py` -> 4 passed (field carried through
`_component_states`, JSON round-trip, `from_graph` reconstruction, and an
older-extract-without-the-field -> None). Full non-SW suite
(`-k "not e2e and not com and not coacd and not golden"`) -> 333 passed, 9
skipped, no regressions. The COM-driven config switching (`ShowConfiguration2`)
is not exercised against live CAD here.

## Demo (required for UI / user-visible changes)
N/A - no UI change (extract-time behavior + a new CLI flag).

## AI usage disclosure (required)
- [x] AI was used. Tool(s): `OpenAI Codex`. Extent: `drafted the configuration plumbing + tests, reviewed and verified`.

## Checklist
- [x] This PR is one focused change (not a large stack of dependent branches).
- [x] No UI / user-visible change (demo not applicable).
- [x] Tests and build pass locally.
- [x] I ran the change and confirmed it does what this PR claims.
- [x] I understand every line I'm submitting.
