### PR TITLE
feat(exporter): read SolidWorks inertia across typelib/marshalling variants

### DIFF
--- a/sw2robot/exporter/model.py
+++ b/sw2robot/exporter/model.py
@@ -133,8 +133,10 @@ def _sw_mass_props(mp):
 
     where ``R``'s rows are the three principal-axis unit vectors expressed in
     the part frame (SolidWorks returns them as three consecutive triples).
-    Returns ``(None, None, None)`` if the values are unavailable / degenerate
-    so the caller falls back to the mesh estimate."""
+    Returns ``(mass, com, None)`` when a valid mass/COM exist but no inertia
+    tensor can be marshalled (mass/COM are kept -- the mass editor uses them --
+    and the inertia falls back to the mesh estimate downstream), and
+    ``(None, None, None)`` only when even mass/COM are unavailable/degenerate."""
     # Force SI output if this build's interface exposes the toggle
     # (IMassProperty2); the classic IMassProperty is already SI, so the
     # attribute is simply absent and this is a no-op.
@@ -143,13 +145,27 @@ def _sw_mass_props(mp):
     except Exception:
         pass
 
-    def _arr(name, n):
-        v = safe_prop(mp, name)
-        try:
-            vals = [float(x) for x in v]
-        except (TypeError, ValueError):
-            return None
-        return vals if len(vals) == n else None
+    def _arr(names, n):
+        # SolidWorks' typelib spells these "Principle*" (sic); some builds
+        # expose only that name and some the corrected "Principal*" -- try
+        # each, as a property first, then as a no/one-arg method (the getter
+        # marshals as a method on certain pywin32/typelib combinations).
+        for name in names if isinstance(names, tuple) else (names,):
+            v = safe_prop(mp, name)
+            if v is None:
+                for args in ((), (0,)):
+                    try:
+                        v = getattr(mp, name)(*args)
+                        break
+                    except Exception:
+                        v = None
+            try:
+                vals = [float(x) for x in v]
+            except (TypeError, ValueError):
+                continue
+            if len(vals) == n:
+                return vals
+        return None
 
     try:
         mass = safe_prop(mp, "Mass")
@@ -157,18 +173,29 @@ def _sw_mass_props(mp):
     except (TypeError, ValueError):
         mass = None
     com = _arr("CenterOfMass", 3)
-    pm = _arr("PrincipalMomentsOfInertia", 3)
-    pax = _arr("PrincipalAxesOfInertia", 9)
-    if not (mass and mass > 0 and com and pm and pax):
+    if not (mass and mass > 0 and com and np.all(np.isfinite(com))):
         return None, None, None
-    if not (np.all(np.isfinite(com)) and np.all(np.isfinite(pm))
-            and np.all(np.isfinite(pax))):
-        return None, None, None
-    R = np.asarray(pax, float).reshape(3, 3)     # rows = principal axes (part frame)
-    I = R.T @ np.diag(pm) @ R                      # tensor about COM, part axes
-    inertia6 = (float(I[0, 0]), float(I[0, 1]), float(I[0, 2]),
-                float(I[1, 1]), float(I[1, 2]), float(I[2, 2]))
-    return mass, [float(x) for x in com], inertia6
+    com = [float(x) for x in com]
+    pm = _arr(("PrincipalMomentsOfInertia", "PrincipleMomentsOfInertia"), 3)
+    pax = _arr(("PrincipalAxesOfInertia", "PrincipleAxesOfInertia",
+                "IGetPrincipleAxesOfInertia"), 9)
+    if pm and pax and np.all(np.isfinite(pm)) and np.all(np.isfinite(pax)):
+        R = np.asarray(pax, float).reshape(3, 3)  # rows = principal axes (part frame)
+        I = R.T @ np.diag(pm) @ R                   # tensor about COM, part axes
+        inertia6 = (float(I[0, 0]), float(I[0, 1]), float(I[0, 2]),
+                    float(I[1, 1]), float(I[1, 2]), float(I[2, 2]))
+        return mass, com, inertia6
+    # 9-element tensor about the COM, straight from the API -- some builds
+    # give this where the principal decomposition is not marshallable
+    t9 = _arr(("MomentOfInertia", "GetMomentOfInertia"), 9)
+    if t9 and np.all(np.isfinite(t9)):
+        I = np.asarray(t9, float).reshape(3, 3)
+        inertia6 = (float(I[0, 0]), float(I[0, 1]), float(I[0, 2]),
+                    float(I[1, 1]), float(I[1, 2]), float(I[2, 2]))
+        return mass, com, inertia6
+    # no usable tensor: keep mass + COM (the mass editor / rescale still use
+    # them); the inertia falls back to the mesh estimate downstream
+    return mass, com, None
 
 
 def _sw_mass_overridden(mp):

--- a/tests/test_sw_mass_props.py
+++ b/tests/test_sw_mass_props.py
@@ -1,0 +1,86 @@
+"""_sw_mass_props robustness: the inertia tensor is read across the ways
+different SolidWorks builds / typelibs expose it -- the "Principle*" (sic)
+spelling vs the corrected "Principal*", a property vs a method getter, and a
+plain 9-element MomentOfInertia when the principal decomposition will not
+marshal.  When no tensor is available it must still keep mass + COM (inertia
+falls back to the mesh estimate downstream)."""
+import numpy as np
+import pytest
+
+from sw2robot.exporter.model import _sw_mass_props
+
+IDENT9 = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
+
+
+class _MP:
+    """A stand-in IMassProperty: attributes are properties; a callable value
+    models a method-style getter (safe_prop calls it)."""
+
+    def __init__(self, **props):
+        for k, v in props.items():
+            setattr(self, k, v)
+
+
+def test_principal_axes_reconstruct_tensor():
+    mp = _MP(Mass=2.0, CenterOfMass=[0.1, 0.2, 0.3],
+             PrincipalMomentsOfInertia=[3.0, 4.0, 5.0],
+             PrincipalAxesOfInertia=IDENT9)
+    mass, com, inertia6 = _sw_mass_props(mp)
+    assert mass == 2.0
+    assert com == [0.1, 0.2, 0.3]
+    # identity axes -> diagonal tensor (ixx,ixy,ixz,iyy,iyz,izz)
+    assert inertia6 == pytest.approx((3.0, 0.0, 0.0, 4.0, 0.0, 5.0))
+
+
+def test_misspelled_principle_variant_is_accepted():
+    # a build that only exposes the typelib's "Principle*" spelling
+    mp = _MP(Mass=1.0, CenterOfMass=[0.0, 0.0, 0.0],
+             PrincipleMomentsOfInertia=[3.0, 4.0, 5.0],
+             PrincipleAxesOfInertia=IDENT9)
+    _mass, _com, inertia6 = _sw_mass_props(mp)
+    assert inertia6 == pytest.approx((3.0, 0.0, 0.0, 4.0, 0.0, 5.0))
+
+
+def test_method_style_getter_is_called():
+    # the moments/axes marshal as no-arg methods, not properties
+    mp = _MP(Mass=1.0, CenterOfMass=[0.0, 0.0, 0.0],
+             PrincipalMomentsOfInertia=lambda: [3.0, 4.0, 5.0],
+             PrincipalAxesOfInertia=lambda: IDENT9)
+    _mass, _com, inertia6 = _sw_mass_props(mp)
+    assert inertia6 == pytest.approx((3.0, 0.0, 0.0, 4.0, 0.0, 5.0))
+
+
+def test_moment_of_inertia_9elem_fallback():
+    # no principal decomposition, but a full 9-element tensor is available
+    mp = _MP(Mass=1.0, CenterOfMass=[0.0, 0.0, 0.0],
+             MomentOfInertia=[3.0, 0.0, 0.0, 0.0, 4.0, 0.0, 0.0, 0.0, 5.0])
+    _mass, _com, inertia6 = _sw_mass_props(mp)
+    assert inertia6 == pytest.approx((3.0, 0.0, 0.0, 4.0, 0.0, 5.0))
+
+
+def test_no_tensor_keeps_mass_and_com():
+    mp = _MP(Mass=2.5, CenterOfMass=[0.1, 0.2, 0.3])
+    mass, com, inertia6 = _sw_mass_props(mp)
+    assert mass == 2.5
+    assert com == [0.1, 0.2, 0.3]
+    assert inertia6 is None            # -> mesh inertia downstream
+
+
+def test_nonpositive_mass_returns_all_none():
+    mp = _MP(Mass=0.0, CenterOfMass=[0.1, 0.2, 0.3],
+             PrincipalMomentsOfInertia=[3.0, 4.0, 5.0],
+             PrincipalAxesOfInertia=IDENT9)
+    assert _sw_mass_props(mp) == (None, None, None)
+
+
+def test_nonfinite_tensor_falls_back_to_mass_com():
+    mp = _MP(Mass=1.0, CenterOfMass=[0.0, 0.0, 0.0],
+             PrincipalMomentsOfInertia=[3.0, np.inf, 5.0],
+             PrincipalAxesOfInertia=IDENT9)
+    mass, com, inertia6 = _sw_mass_props(mp)
+    assert mass == 1.0 and com == [0.0, 0.0, 0.0]
+    assert inertia6 is None            # non-finite tensor rejected, mass/COM kept
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What & why (keep to a few lines)

The inertia tensor was reconstructed only from `PrincipalMomentsOfInertia` +
`PrincipalAxesOfInertia` read as properties. On builds whose typelib spells them
`Principle*` (sic), or marshals them as method getters, both came back empty and
`_sw_mass_props` returned `(None, None, None)` -- dropping the part's EXACT mass
and COM too, so the whole inertial fell back to the mesh/density estimate.

Try each spelling, as a property then a no/one-arg method, and add a 9-element
`MomentOfInertia` fallback. When no tensor marshals at all, still return the
exact mass + COM (inertia falls back to the mesh estimate downstream via
`link_inertial_from_sw`, which already treats a None tensor as absent).

## Linked issue
<!-- Maintainer PR; no pre-filed accepted issue (maintainer exemption). -->

## How I verified this

`pytest tests/test_sw_mass_props.py` -> 7 passed (Principal/Principle spellings,
method-getter, `MomentOfInertia` fallback, no-tensor keeps mass+COM, non-positive
mass -> all-None, non-finite tensor -> mass+COM kept). Full non-SW suite
(`-k "not e2e and not com and not coacd and not golden"`) -> 341 passed, 9
skipped, no regressions. Not exercised against live SolidWorks in this change.

## Demo (required for UI / user-visible changes)
N/A - no UI change (extract-time mass-property reading).

## AI usage disclosure (required)
- [x] AI was used. Tool(s): `OpenAI Codex`. Extent: `drafted the multi-variant reader + tests, reviewed and verified against the downstream inertia fallback`.

## Checklist
- [x] This PR is one focused change (not a large stack of dependent branches).
- [x] No UI / user-visible change (demo not applicable).
- [x] Tests and build pass locally.
- [x] I ran the change and confirmed it does what this PR claims.
- [x] I understand every line I'm submitting.
