### PR TITLE
fix(exporter): 3DXML export robust to relative and missing output dirs

### DIFF
--- a/sw2robot/exporter/export.py
+++ b/sw2robot/exporter/export.py
@@ -160,7 +160,10 @@ def _extract_into(sw, assembly_path, pkg_dir, meshes_dir, robot_name, _say,
                                     by_path=by_path)
     _say("exporting full assembly mesh ...")
     whole_rel = None
-    whole = os.path.join(pkg_dir, robot_name + "_assembly.3dxml")
+    # absolute: SolidWorks resolves a relative SaveAs path against its OWN cwd,
+    # not ours, so a relative `-o output` dir fails the export (see _save_3dxml)
+    whole = os.path.abspath(
+        os.path.join(pkg_dir, robot_name + "_assembly.3dxml"))
     try:
         ext = as_iface(doc.Extension, "IModelDocExtension")
         res = ext.SaveAs(whole, 0, _SAVE_OPTS, None, 0, 0)

--- a/sw2robot/exporter/mesh.py
+++ b/sw2robot/exporter/mesh.py
@@ -66,6 +66,12 @@ def _open_doc(app, path):
 
 
 def _save_3dxml(model_doc, out_path):
+    # SolidWorks resolves a RELATIVE SaveAs path against ITS OWN working
+    # directory (the SLDWORKS.exe process), not ours -- a `-o output` relative
+    # package dir then fails every export with swGenericSaveError (res=1)
+    # while absolute destinations (temp dirs) work.  Absolutise here, the one
+    # choke point every 3DXML export goes through.
+    out_path = os.path.abspath(out_path)
     # write to a temp name and os.replace on success: a SolidWorks crash
     # mid-SaveAs must not leave a partial file that later passes the
     # size-based reuse checks
@@ -83,6 +89,11 @@ def _save_3dxml(model_doc, out_path):
     if ok and os.path.exists(tmp) and os.path.getsize(tmp) >= _MIN_MESH_BYTES:
         os.replace(tmp, out_path)
         return True
+    # say WHY: a res=True but tiny file is the empty-envelope failure mode
+    # (hollow/lightweight doc), distinct from SaveAs refusing outright
+    sz = os.path.getsize(tmp) if os.path.exists(tmp) else -1
+    print(f"    3dxml rejected for {os.path.basename(out_path)}: "
+          f"res={res} size={sz}")
     try:
         os.remove(tmp)
     except OSError:
@@ -399,6 +410,7 @@ def _compose_from_parts(app, md, path, out_glb, meshes_dir=None, by_path=None):
     print(f"    compose: merged {len(meshes)} part meshes")
     merged = trimesh.util.concatenate(meshes)
     merged.units = "meter"
+    os.makedirs(os.path.dirname(out_glb), exist_ok=True)
     tmp = out_glb + ".part.glb"
     merged.export(tmp, file_type="glb")
     if os.path.exists(tmp) and os.path.getsize(tmp) > 500:

--- a/tests/test_save_3dxml_paths.py
+++ b/tests/test_save_3dxml_paths.py
@@ -1,0 +1,60 @@
+"""_save_3dxml must absolutise its destination: SolidWorks resolves a relative
+SaveAs path against the SLDWORKS.exe process cwd, not ours, so a relative
+`-o output` package dir otherwise fails every 3DXML export.  Driven with a fake
+model doc (no COM) whose SaveAs records the path and writes the file."""
+import os
+
+import pytest
+
+from sw2robot.exporter import mesh
+
+
+class _Ext:
+    def __init__(self, nbytes):
+        self._nbytes = nbytes
+        self.saved_path = None
+
+    def SaveAs(self, path, *args):
+        self.saved_path = path
+        with open(path, "wb") as f:      # emulate SolidWorks writing the file
+            f.write(b"x" * self._nbytes)
+        return True
+
+
+class _Doc:
+    def __init__(self, nbytes):
+        self.Extension = _Ext(nbytes)
+
+
+@pytest.fixture(autouse=True)
+def _identity_as_iface(monkeypatch):
+    monkeypatch.setattr(mesh, "as_iface", lambda obj, iface: obj)
+
+
+def test_relative_out_path_is_absolutised_and_saved(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "meshes").mkdir()
+    doc = _Doc(mesh._MIN_MESH_BYTES + 100)
+
+    ok = mesh._save_3dxml(doc, os.path.join("meshes", "foo.3dxml"))  # relative
+
+    assert ok is True
+    assert os.path.isabs(doc.Extension.saved_path)   # SolidWorks got an abs path
+    assert os.path.exists(tmp_path / "meshes" / "foo.3dxml")
+
+
+def test_tiny_envelope_is_rejected(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "meshes").mkdir()
+    doc = _Doc(10)                        # below _MIN_MESH_BYTES -> empty envelope
+
+    ok = mesh._save_3dxml(doc, os.path.join("meshes", "foo.3dxml"))
+
+    assert ok is False
+    assert not os.path.exists(tmp_path / "meshes" / "foo.3dxml")   # not kept
+    assert not os.path.exists(tmp_path / "meshes" / "foo.3dxml.part.3dxml")  # tmp cleaned
+    assert "3dxml rejected" in capsys.readouterr().out
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What & why (keep to a few lines)

Three self-contained 3DXML-export fixes:
- `_save_3dxml` absolutises its destination. SolidWorks resolves a relative
  SaveAs path against the SLDWORKS.exe cwd, not ours, so a relative `-o output`
  package dir failed every 3DXML export with `swGenericSaveError`. Absolutise at
  the one choke point every export goes through (and the same one-liner for the
  whole-assembly mesh in `export._extract_into`).
- `_compose_from_parts` makedirs the output glb's parent before writing, so a
  composed sub-assembly mesh no longer crashes when that dir is absent.
- A `res=True`-but-tiny 3DXML (the empty-envelope failure mode of a
  hollow/lightweight doc) now prints why it was rejected, distinct from SaveAs
  refusing outright.

(The larger per-`(part_path, configuration)` mesh-cache split -- the follow-up to
#172 -- is intentionally left to its own PR.)

## Linked issue
<!-- Maintainer PR; no pre-filed accepted issue (maintainer exemption). -->

## How I verified this

`pytest tests/test_save_3dxml_paths.py` -> 2 passed (a relative dest is
absolutised and saved; a sub-`_MIN_MESH_BYTES` envelope is rejected, its temp
cleaned, and the reason printed), driven with a fake model doc (no COM). Full
non-SW suite (`-k "not e2e and not com and not coacd and not golden"`) -> 338
passed, 9 skipped, no regressions. Not exercised against live SolidWorks here.

## Demo (required for UI / user-visible changes)
N/A - no UI change (extract-time mesh export).

## AI usage disclosure (required)
- [x] AI was used. Tool(s): `OpenAI Codex`. Extent: `drafted the SaveAs/makedirs fixes + tests, reviewed and verified`.

## Checklist
- [x] This PR is one focused change (not a large stack of dependent branches).
- [x] No UI / user-visible change (demo not applicable).
- [x] Tests and build pass locally.
- [x] I ran the change and confirmed it does what this PR claims.
- [x] I understand every line I'm submitting.
