### PR TITLE
feat(exporter): fast debug iteration via --attach and --refresh frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,16 @@ resolve referenced parts.
 python -m sw2robot.editor            # see the CLI
 ```
 
+**Fast re-extract while debugging.** Keep the assembly open in SolidWorks, then:
+
+```bash
+# reuse the running SolidWorks (skips the multi-minute reopen)
+python -m sw2robot.exporter.extract path/to/assembly.sldasm --attach
+
+# refresh ONLY coordinate systems / reference axes in graph.json (seconds)
+python -m sw2robot.exporter.extract output/<robot> --refresh frames --attach
+```
+
 ## Layout
 
 ```

--- a/sw2robot/exporter/export.py
+++ b/sw2robot/exporter/export.py
@@ -43,7 +43,14 @@ from .model import (
     to_graph_state,
 )
 from .state import GraphState
-from .swcom import SW_DOC_PART, SolidWorks, as_iface, doc_type_for, safe_call
+from .swcom import (
+    SW_DOC_PART,
+    SolidWorks,
+    as_iface,
+    doc_type_for,
+    safe_call,
+    safe_prop,
+)
 from .urdf_writer import write_ros_package, write_urdf
 
 GRAPH_FILE = "graph.json"
@@ -200,12 +207,16 @@ def _extract_into(sw, assembly_path, pkg_dir, meshes_dir, robot_name, _say,
 
 
 def extract(assembly_path, out_dir=None, robot_name=None, visible=False,
-            progress=None, sw=None, configuration=None):
+            progress=None, sw=None, configuration=None, attach=False):
     """SolidWorks -> graph.json (+ per-link 3DXML).  ``progress(msg)`` -- if
     given -- receives short human-readable status strings at each stage and once
     per exported mesh, so a UI can show how far along the (multi-minute) extract
     is.  Pass an existing ``SolidWorks`` session as ``sw`` to reuse it across
-    many assemblies (batch); otherwise a private one is started and shut down."""
+    many assemblies (batch); otherwise a private one is started and shut down.
+    ``attach=True`` connects to the USER'S already-running SolidWorks instead
+    (their documents are left untouched); if the assembly is already open
+    there, the multi-minute reopen is skipped entirely.  No fallback: with no
+    running SolidWorks to attach to this raises ``SolidWorksUnavailable``."""
     _tolerant_console()
     import time as _time
     t_state = {"last": _time.time()}
@@ -243,12 +254,129 @@ def extract(assembly_path, out_dir=None, robot_name=None, visible=False,
         _extract_into(sw, assembly_path, pkg_dir, meshes_dir, robot_name, _say,
                       _part, configuration=configuration)
     else:
-        with SolidWorks(visible=visible) as sw_own:
+        sw_ctx = (SolidWorks(attach=True) if attach
+                  else SolidWorks(visible=visible))
+        with sw_ctx as sw_own:
             _extract_into(sw_own, assembly_path, pkg_dir, meshes_dir,
                           robot_name, _say, _part,
                           configuration=configuration)
 
     print(f"  graph: {os.path.join(pkg_dir, GRAPH_FILE)}")
+    return pkg_dir
+
+
+# ---------------------------------------------------------------- refresh
+def _file_key(path):
+    """Lower-cased file name of ``path``, split on EITHER separator --
+    graph.json carries Windows paths even when it is read on POSIX (the
+    build/test path), where os.path.basename would keep the whole string."""
+    return str(path).replace("\\", "/").rsplit("/", 1)[-1].lower()
+
+
+def _live_subassembly_docs(doc):
+    """``basename(path).lower() -> open ModelDoc2`` for every loaded
+    sub-assembly occurrence in ``doc``, at any depth.  Matched by file name
+    because a copied session records temp-dir paths in graph.json while an
+    attached one records the originals -- the basename is the stable part."""
+    out = {}
+    for c in list(safe_call(doc, "GetComponents", False) or []):
+        ct = as_iface(c, "IComponent2")
+        path = safe_prop(ct, "GetPathName") or ""
+        if not str(path).lower().endswith(".sldasm"):
+            continue
+        key = _file_key(path)
+        if key in out:
+            continue
+        md = safe_call(ct, "GetModelDoc2")
+        if md is not None:
+            out[key] = md
+    return out
+
+
+def refresh_frames(target, out_dir=None, robot_name=None, visible=False,
+                   attach=False, sw=None, progress=None):
+    """Partial re-extract: re-read ONLY the named frames -- the top-level
+    coordinate systems + reference axes, and the coordinate systems of already
+    -extracted sub-assemblies -- into an existing ``graph.json``.
+
+    Components, mates, mass properties, deep worlds and meshes are left
+    untouched, so this is a handful of feature-tree reads instead of a full
+    assembly walk: seconds instead of minutes when iterating on frame
+    selection (e.g. the PR #178 coordinate-frame work).  Combine with
+    ``attach=True`` while the assembly is open in the user's SolidWorks and
+    even the document open is skipped.
+
+    ``target`` is either the extracted package dir (the one holding
+    ``graph.json``) or the source assembly path (the package dir is then
+    derived exactly like :func:`extract` does from ``out_dir``/``robot_name``).
+    The frames are read from whatever configuration the document opens with
+    (in attach mode: the one on the user's screen).  Requires a prior full
+    extract -- there is deliberately NO fallback to one."""
+    _tolerant_console()
+    import time as _time
+    t0 = _time.time()
+
+    def _say(msg):
+        print("[refresh] " + msg)
+        if progress:
+            progress(msg)
+
+    target = os.path.abspath(target)
+    if os.path.isdir(target):
+        pkg_dir = target
+        assembly_path = None
+    else:
+        assembly_path = target
+        _, pkg_dir = _pkg_paths(target, out_dir, robot_name)
+    graph_path = os.path.join(pkg_dir, GRAPH_FILE)
+    if not os.path.exists(graph_path):
+        raise FileNotFoundError(
+            f"{graph_path} not found -- '--refresh frames' only updates an "
+            f"existing extraction; run a full extract once first")
+    graph = GraphState.load(graph_path)
+    if assembly_path is None:
+        assembly_path = graph.source_assembly
+    if not os.path.exists(assembly_path):
+        raise FileNotFoundError(
+            f"source assembly not found: {assembly_path}")
+
+    def _refresh_into(sw_sess):
+        _say(f"opening {os.path.basename(assembly_path)} (instant when it is "
+             f"already open in an attached SolidWorks) ...")
+        doc = sw_sess.open_copy(assembly_path)
+        try:
+            _say("re-reading coordinate systems + reference axes ...")
+            graph.coordinate_systems = extract_coordinate_systems(doc)
+            graph.reference_axes = extract_reference_axes(doc)
+            if graph.subassemblies:
+                live = _live_subassembly_docs(doc)
+                for path, sub in graph.subassemblies.items():
+                    md = live.get(_file_key(path))
+                    if md is None:
+                        print(f"      WARN: {os.path.basename(path)} is not "
+                              f"loaded in this session; keeping its cached "
+                              f"coordinate systems")
+                        continue
+                    sub.coordinate_systems = extract_coordinate_systems(md)
+        finally:
+            sw_sess.close_doc(doc)
+
+    if sw is not None:
+        _refresh_into(sw)
+    else:
+        sw_ctx = (SolidWorks(attach=True) if attach
+                  else SolidWorks(visible=visible))
+        with sw_ctx as sw_own:
+            _refresh_into(sw_own)
+
+    graph.save(graph_path)
+    n_sub = sum(len(s.coordinate_systems)
+                for s in graph.subassemblies.values())
+    _say(f"graph.json frames updated in {_time.time() - t0:.1f}s: "
+         f"{len(graph.coordinate_systems)} coordinate system(s), "
+         f"{len(graph.reference_axes)} reference axis/axes"
+         + (f", {n_sub} sub-assembly frame(s)" if graph.subassemblies else ""))
+    print(f"  graph: {graph_path}")
     return pkg_dir
 
 
@@ -389,9 +517,9 @@ def export(assembly_path, out_dir=None, robot_name=None, visible=False,
            config_path=None, base_hint=None, exclude=None, ros_pkg=False,
            ros_version=1, ros_pkg_name=None, ros_urdf_name=None,
            collision="copy", coacd_quality="balanced", merge_fixed=False,
-           ros_mesh_dir=None, configuration=None):
+           ros_mesh_dir=None, configuration=None, attach=False):
     pkg_dir = extract(assembly_path, out_dir, robot_name, visible,
-                      configuration=configuration)
+                      configuration=configuration, attach=attach)
     return build(pkg_dir, config_path=config_path, base_hint=base_hint,
                  exclude=exclude, ros_pkg=ros_pkg, ros_version=ros_version,
                  ros_pkg_name=ros_pkg_name, ros_urdf_name=ros_urdf_name,
@@ -411,6 +539,12 @@ def main():
     ap.add_argument("-o", "--out", default=None)
     ap.add_argument("-n", "--name", default=None)
     ap.add_argument("--visible", action="store_true")
+    ap.add_argument("--attach", action="store_true",
+                    help="reuse the USER'S already-running SolidWorks instead "
+                         "of starting a hidden private instance; if the "
+                         "assembly is already open there, the multi-minute "
+                         "reopen is skipped entirely.  Errors out (no "
+                         "fallback) when no running SolidWorks is found")
     ap.add_argument("--configuration", default=None, metavar="NAME",
                     help="extract this ASSEMBLY configuration instead of the "
                          "file's saved-active one (configs can suppress whole "
@@ -459,7 +593,7 @@ def main():
                          "per moving body; mesh-less coordinate frames are kept")
     args = ap.parse_args()
     export(args.assembly, args.out, args.name, args.visible,
-           configuration=args.configuration,
+           configuration=args.configuration, attach=args.attach,
            config_path=args.config, base_hint=args.base,
            exclude=_exclude_list(args.exclude),
            ros_pkg=args.ros_pkg or args.ros2,

--- a/sw2robot/exporter/extract.py
+++ b/sw2robot/exporter/extract.py
@@ -1,26 +1,61 @@
 """CLI: extract the CAD graph + meshes from SolidWorks (slow, once).
 
     uv run python -m sw2robot.exporter.extract <assembly.sldasm> [-o OUT] [-n NAME] [--visible]
+
+Fast debug iteration:
+
+    # reuse the running SolidWorks (keep the assembly open there = no reopen)
+    uv run python -m sw2robot.exporter.extract <assembly.sldasm> --attach
+
+    # re-read ONLY coordinate systems / reference axes into graph.json
+    uv run python -m sw2robot.exporter.extract <assembly.sldasm|pkg_dir> --refresh frames --attach
 """
 from __future__ import annotations
 
 import argparse
 
-from .export import extract
+from .export import extract, refresh_frames
 
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("assembly")
+    ap.add_argument("assembly",
+                    help="path to a .SLDASM/.SLDPRT -- or, with --refresh, "
+                         "optionally the extracted package dir holding "
+                         "graph.json")
     ap.add_argument("-o", "--out", default=None)
     ap.add_argument("-n", "--name", default=None)
     ap.add_argument("--visible", action="store_true")
+    ap.add_argument("--attach", action="store_true",
+                    help="reuse the USER'S already-running SolidWorks instead "
+                         "of starting a hidden private instance; if the "
+                         "assembly is already open there, the multi-minute "
+                         "reopen is skipped entirely.  Errors out (no "
+                         "fallback) when no running SolidWorks is found")
+    ap.add_argument("--refresh", choices=("frames",), default=None,
+                    metavar="WHAT",
+                    help="partial re-extract: 'frames' re-reads ONLY the "
+                         "named coordinate systems + reference axes into the "
+                         "existing graph.json (components/mates/masses/meshes "
+                         "untouched) -- seconds instead of minutes when "
+                         "iterating on frame selection")
     ap.add_argument("--configuration", default=None, metavar="NAME",
                     help="extract this ASSEMBLY configuration instead of the "
                          "file's saved-active one")
     args = ap.parse_args()
-    extract(args.assembly, args.out, args.name, args.visible,
-            configuration=args.configuration)
+    import os
+    if args.refresh is None and os.path.isdir(args.assembly):
+        # without --refresh the positional is a CAD FILE; a bare directory
+        # would fall through to the .SLDPRT path and die deep in a file copy
+        ap.error(f"{args.assembly!r} is a directory -- a package dir is only "
+                 f"accepted with '--refresh frames'; a full extract needs the "
+                 f".SLDASM/.SLDPRT path itself")
+    if args.refresh == "frames":
+        refresh_frames(args.assembly, args.out, args.name, args.visible,
+                       attach=args.attach)
+    else:
+        extract(args.assembly, args.out, args.name, args.visible,
+                configuration=args.configuration, attach=args.attach)
 
 
 if __name__ == "__main__":

--- a/sw2robot/exporter/swcom.py
+++ b/sw2robot/exporter/swcom.py
@@ -420,6 +420,7 @@ class SolidWorks:
             self._open_docs = []
             self._tempdirs = []
             self._sibling_dirs = {}      # src dir -> temp dir holding its siblings
+            self._reused_titles = set()  # docs borrowed from the user's session
             if not self._responds():     # attached app is the USER's: don't quit
                 raise SolidWorksUnavailable(
                     "the running SolidWorks is not responding (license "
@@ -469,6 +470,7 @@ class SolidWorks:
         self._open_docs = []
         self._tempdirs = []
         self._sibling_dirs = {}          # src dir -> temp dir holding its siblings
+        self._reused_titles = set()      # docs borrowed from the user's session
         # A SolidWorks that launched but can't acquire a license comes back as
         # a COM object that fails every real call.  Catch a wholly unresponsive
         # instance here -- with a clear license warning -- and tear it down, so
@@ -512,6 +514,11 @@ class SolidWorks:
         path = os.path.abspath(path)
         if not os.path.exists(path):
             raise FileNotFoundError(path)
+        if os.path.isdir(path):
+            # e.g. a package dir passed where a CAD file belongs -- fail here
+            # with the real reason instead of a PermissionError from copy2
+            raise IsADirectoryError(
+                f"{path} is a directory, not a .SLDASM/.SLDPRT file")
         import time as _time
         t0 = _time.time()
         doc = None
@@ -527,6 +534,9 @@ class SolidWorks:
                 print("      reusing the already-open document from your "
                       "SolidWorks session (references already resolved)")
                 self._reused_open_doc = True
+                title = safe_prop(existing, "GetTitle")
+                if title:
+                    self._reused_titles.add(str(title))
                 doc = existing
         t1 = t0
         if doc is None:
@@ -798,11 +808,20 @@ class SolidWorks:
 
     def close_doc(self, doc):
         title = safe_prop(doc, "GetTitle")
-        if title:
-            try:
-                self.app.CloseDoc(title)
-            except Exception:
-                pass
+        if not title:
+            return
+        # A doc BORROWED from the user's attached session must stay open:
+        # closing it would modify their session AND throw away the resolved
+        # document that makes the next extraction instant (the whole point of
+        # keeping the assembly open while iterating).
+        if title in getattr(self, "_reused_titles", set()):
+            print(f"      leaving {title} open (borrowed from your "
+                  f"SolidWorks session)")
+            return
+        try:
+            self.app.CloseDoc(title)
+        except Exception:
+            pass
 
     # -- lifecycle --------------------------------------------------------
     def shutdown(self):

--- a/tests/test_refresh_frames.py
+++ b/tests/test_refresh_frames.py
@@ -1,0 +1,136 @@
+"""refresh_frames: partial re-extract of ONLY the named frames.
+
+Iterating on coordinate-frame selection (PR #178) used to require a full
+re-extract -- a multi-minute assembly walk -- just to re-read a handful of
+CoordSys/RefAxis features.  refresh_frames updates those fields of an existing
+graph.json in place and must leave everything else (components, mates, deep
+worlds, meshes) untouched.  SolidWorks is faked out; only the orchestration is
+under test here.
+"""
+import numpy as np
+import pytest
+
+from sw2robot.exporter import export as export_mod
+from sw2robot.exporter.state import (
+    ComponentState,
+    CoordinateSystemState,
+    GraphState,
+    ReferenceAxisState,
+    SubGraph,
+)
+
+_EYE = [float(x) for x in np.eye(4).flatten()]
+
+
+class FakeSW:
+    """Stands in for swcom.SolidWorks: records open/close, returns a token."""
+
+    def __init__(self):
+        self.opened = []
+        self.closed = []
+
+    def open_copy(self, path):
+        self.opened.append(path)
+        return "DOC"
+
+    def close_doc(self, doc):
+        self.closed.append(doc)
+
+
+def _make_package(tmp_path):
+    pkg = tmp_path / "robo"
+    pkg.mkdir()
+    asm = tmp_path / "robo.sldasm"
+    asm.write_bytes(b"cad")
+    graph = GraphState(
+        robot_name="robo", source_assembly=str(asm),
+        components=[ComponentState(name="a-1", link_name="a", world=_EYE)],
+        coordinate_systems=[CoordinateSystemState(
+            name="stale", document_from_frame=_EYE)],
+        reference_axes=[ReferenceAxisState(
+            name="stale_axis", document_point=[0.0, 0.0, 0.0],
+            document_direction=[1.0, 0.0, 0.0])],
+        subassemblies={
+            r"C:\cad\sub.sldasm": SubGraph(coordinate_systems=[
+                CoordinateSystemState(name="sub_stale",
+                                      document_from_frame=_EYE)]),
+            r"C:\cad\unloaded.sldasm": SubGraph(coordinate_systems=[
+                CoordinateSystemState(name="keep_me",
+                                      document_from_frame=_EYE)]),
+        })
+    graph.save(str(pkg / "graph.json"))
+    return pkg, asm
+
+
+def _patch_readers(monkeypatch):
+    fresh_cs = CoordinateSystemState(name="fresh", document_from_frame=_EYE)
+    fresh_ax = ReferenceAxisState(name="fresh_axis",
+                                  document_point=[0.0, 0.0, 0.0],
+                                  document_direction=[0.0, 0.0, 1.0])
+    monkeypatch.setattr(export_mod, "extract_coordinate_systems",
+                        lambda doc: [fresh_cs.model_copy()])
+    monkeypatch.setattr(export_mod, "extract_reference_axes",
+                        lambda doc: [fresh_ax.model_copy()])
+    # sub.sldasm is loaded in the (fake) session, unloaded.sldasm is not
+    monkeypatch.setattr(export_mod, "_live_subassembly_docs",
+                        lambda doc: {"sub.sldasm": "SUBDOC"})
+
+
+def test_refresh_updates_frames_only(tmp_path, monkeypatch):
+    pkg, asm = _make_package(tmp_path)
+    _patch_readers(monkeypatch)
+    fake = FakeSW()
+
+    out = export_mod.refresh_frames(str(pkg), sw=fake)
+
+    assert out == str(pkg)
+    assert fake.opened == [str(asm)]
+    assert fake.closed == ["DOC"]           # doc released even on success
+    graph = GraphState.load(str(pkg / "graph.json"))
+    assert [c.name for c in graph.coordinate_systems] == ["fresh"]
+    assert [a.name for a in graph.reference_axes] == ["fresh_axis"]
+    # everything that is NOT a frame is byte-for-byte untouched
+    assert [c.name for c in graph.components] == ["a-1"]
+    assert graph.robot_name == "robo"
+    # loaded sub-assembly refreshed; unloaded one keeps its cached frames
+    subs = {k.split("\\")[-1]: v for k, v in graph.subassemblies.items()}
+    assert [c.name for c in subs["sub.sldasm"].coordinate_systems] == ["fresh"]
+    assert [c.name for c in subs["unloaded.sldasm"].coordinate_systems] == \
+        ["keep_me"]
+
+
+def test_refresh_accepts_assembly_path(tmp_path, monkeypatch):
+    # the extract-style calling convention: assembly + out dir -> same pkg dir
+    pkg, asm = _make_package(tmp_path)
+    _patch_readers(monkeypatch)
+
+    out = export_mod.refresh_frames(str(asm), out_dir=str(tmp_path),
+                                    sw=FakeSW())
+
+    assert out == str(pkg)
+    graph = GraphState.load(str(pkg / "graph.json"))
+    assert [c.name for c in graph.coordinate_systems] == ["fresh"]
+
+
+def test_refresh_requires_prior_extract(tmp_path):
+    # NO fallback to a full extract: a missing graph.json is a clear error
+    asm = tmp_path / "robo.sldasm"
+    asm.write_bytes(b"cad")
+    with pytest.raises(FileNotFoundError, match=r"graph\.json"):
+        export_mod.refresh_frames(str(asm), out_dir=str(tmp_path), sw=FakeSW())
+
+
+def test_refresh_closes_doc_on_reader_failure(tmp_path, monkeypatch):
+    pkg, asm = _make_package(tmp_path)
+
+    def boom(doc):
+        raise RuntimeError("COM died")
+
+    monkeypatch.setattr(export_mod, "extract_coordinate_systems", boom)
+    fake = FakeSW()
+    with pytest.raises(RuntimeError, match="COM died"):
+        export_mod.refresh_frames(str(pkg), sw=fake)
+    assert fake.closed == ["DOC"]
+    # the half-refreshed graph was NOT saved
+    graph = GraphState.load(str(pkg / "graph.json"))
+    assert [c.name for c in graph.coordinate_systems] == ["stale"]


### PR DESCRIPTION
**TL;DR** — Iterating on frame selection (e.g. #178 debugging) no longer costs a multi-minute full re-extract: `--attach` reuses the running SolidWorks (and its already-open document), and `--refresh frames` rewrites only the frame fields of an existing `graph.json` in seconds.

- Add `--attach` to the extract/export CLIs: connect to the user's running SolidWorks instead of spawning a private instance; errors out clearly when none is running (no silent fallback).
- Add `--refresh frames`: re-reads top-level coordinate systems / reference axes (+ loaded sub-assembly frames) into the existing `graph.json`; components, mates, masses and meshes are untouched. Covered by tests with a faked session.
- Fix: `close_doc` was closing documents borrowed from the attached session, so keep-the-assembly-open iteration only worked once; borrowed docs now stay open. Also fail fast with a clear error when a directory is passed where a CAD file belongs.