### PR TITLE
refactor: use scikit-robot math instead of hand-rolled transforms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,11 @@ dependencies = [
     "lxml",
     "pydantic>=2",
     "pyyaml>=6",
-    # rotation/transform math (rpy<->matrix) and FK; >=0.3.17 also ships the
-    # per-mesh primitive API (skrobot.utils.primitive_fitting) used by the
-    # ROS-export --collision fitting.
-    "scikit-robot>=0.3.17",
+    # rotation/transform math (rpy<->matrix), FK, and the per-mesh primitive
+    # API (skrobot.utils.primitive_fitting) used by the ROS-export --collision
+    # fitting; >=0.3.27 for orthonormalize_rotation_matrix / matrix_relative /
+    # matrix2xyzrpy / rpy2homogeneous (geometry.py and friends).
+    "scikit-robot>=0.3.27",
     # only the EXTRACT step (driving SolidWorks COM) needs this, and only on Windows
     "pywin32>=306; sys_platform == 'win32'",
 ]

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1527,9 +1527,9 @@ def _canonical_tree_payload(graph, yml_txt=""):
     import numpy as _np
 
     def anchor_world(component):
-        from sw2robot.exporter.geometry import matrix_from_rpy
+        from skrobot.coordinates.math import rpy2homogeneous
 
-        visual = matrix_from_rpy(component.visual_rpy)
+        visual = rpy2homogeneous(*component.visual_rpy)
         visual[:3, 3] = _np.asarray(component.visual_xyz, float)
         return component.world @ _np.linalg.inv(visual)
 
@@ -2846,12 +2846,11 @@ def _urdf_vec(s, n=3):
 
 def _urdf_origin_matrix(elem):
     import numpy as _np
-
-    from sw2robot.exporter.geometry import matrix_from_rpy
+    from skrobot.coordinates.math import rpy2homogeneous
 
     xyz = _urdf_vec(elem.get("xyz"), 3) if elem is not None else [0, 0, 0]
     rpy = _urdf_vec(elem.get("rpy"), 3) if elem is not None else [0, 0, 0]
-    M = matrix_from_rpy(rpy)
+    M = rpy2homogeneous(*rpy)
     M[:3, 3] = _np.asarray(xyz, float)
     return M
 
@@ -2958,8 +2957,7 @@ def _collapsed_preview_urdf_text(urdf_text, plan, robot_name=None,
     import xml.etree.ElementTree as _ET
 
     import numpy as _np
-
-    from sw2robot.exporter.geometry import relative_matrix
+    from skrobot.coordinates.math import matrix_relative
 
     if not plan.get("ready_for_urdf"):
         raise ValueError("collapse plan is not ready for URDF output")
@@ -3008,7 +3006,19 @@ def _collapsed_preview_urdf_text(urdf_text, plan, robot_name=None,
         selected_frame = list(
             plan_link.get("selected_frame_transform") or [])
         if len(selected_frame) == 16:
-            return _np.asarray(selected_frame, float).reshape(4, 4)
+            from skrobot.coordinates.math import orthonormalize_rotation_matrix
+            M = _np.asarray(selected_frame, float).reshape(4, 4)
+            # downstream origin math (matrix_relative) takes the rigid
+            # inverse (R^T), so a scaled/sheared plan matrix would silently
+            # produce wrong origins -- absorb float drift, reject real scale
+            R_fixed = orthonormalize_rotation_matrix(M[:3, :3])
+            if _np.abs(R_fixed - M[:3, :3]).max() > 1e-6:
+                raise ValueError(
+                    "selected_frame_transform must be a rigid transform; "
+                    f"its rotation block has scale/shear (link "
+                    f"{plan_link.get('link')!r})")
+            M[:3, :3] = R_fixed
+            return M
         selected = plan_link.get("selected_origin_link")
         candidates = ([selected] if selected else []) + \
             list(plan_link.get("member_links") or [])
@@ -3046,7 +3056,7 @@ def _collapsed_preview_urdf_text(urdf_text, plan, robot_name=None,
                     old_origin = moved.find("origin")
                     visual_T = _urdf_origin_matrix(old_origin)
                     _set_urdf_origin(
-                        moved, relative_matrix(target_T, member_T @ visual_T))
+                        moved, matrix_relative(target_T, member_T @ visual_T))
                     out_link.append(moved)
         else:
             out_poses[link_name] = link_poses.get(link_name, _np.eye(4))
@@ -3081,7 +3091,7 @@ def _collapsed_preview_urdf_text(urdf_text, plan, robot_name=None,
         ce.set("link", child)
         parent_T = out_poses.get(parent, link_poses.get(parent, _np.eye(4)))
         child_T = out_poses.get(child, link_poses.get(child, _np.eye(4)))
-        _set_urdf_origin(joint, relative_matrix(parent_T, child_T))
+        _set_urdf_origin(joint, matrix_relative(parent_T, child_T))
         axis_elem = joint.find("axis")
         src_child = ""
         if src is not None:
@@ -3424,27 +3434,21 @@ def _remove_yaml_list_item(txt, listkey, idx):
 
 
 def _rot_z_to(zdir):
-    """3x3 minimal rotation (Rodrigues) taking +Z onto ``unit(zdir)``: an
+    """3x3 minimal (shortest-arc) rotation taking +Z onto ``unit(zdir)``: an
     already +Z-aligned vector yields identity, an antiparallel one a 180° flip
     about X.  Shared by the root align (/api/set_root_pose) and ports."""
     import numpy as np
+    from skrobot.coordinates.math import rotation_matrix_from_vectors
     z = np.asarray(zdir, float)
     nz = np.linalg.norm(z)
     if nz < 1e-12:
         return np.eye(3)
     z = z / nz
-    ez = np.array([0.0, 0.0, 1.0])
-    c = float(ez @ z)
-    # guard 1/(1+c): near-antiparallel is a deterministic 180° flip about X
-    if c < -1.0 + 1e-9:
+    # keep the historical antiparallel choice (flip about X; skrobot would
+    # pick a flip about Y) so existing port/root frames reproduce exactly
+    if z[2] < -1.0 + 1e-9:
         return np.diag([1.0, -1.0, -1.0])
-    v = np.cross(ez, z)
-    if np.linalg.norm(v) < 1e-12:
-        return np.eye(3)                         # already +Z aligned
-    K = np.array([[0, -v[2], v[1]],
-                  [v[2], 0, -v[0]],
-                  [-v[1], v[0], 0]])
-    return np.eye(3) + K + K @ K * (1.0 / (1.0 + c))
+    return rotation_matrix_from_vectors([0.0, 0.0, 1.0], z)
 
 
 def _zdir_to_rpy(zdir):
@@ -6228,15 +6232,13 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                     return self._send_json(
                         {"error": "joints.yaml not found"}, 400)
                 import numpy as np
+                from skrobot.coordinates.math import rpy2homogeneous
 
-                from sw2robot.exporter.geometry import (
-                    matrix_from_rpy,
-                    matrix_to_xyz_rpy,
-                )
+                from sw2robot.exporter.geometry import matrix_to_xyz_rpy
                 with open(yml, encoding="utf-8") as f:
                     txt = f.read()
                 rpy0, xyz0, z0 = _read_root_pose(txt)
-                M_old = matrix_from_rpy(rpy0)
+                M_old = rpy2homogeneous(*rpy0)
                 M_old[:3, 3] = (M_old[:3, :3]
                                 @ (np.asarray(xyz0, float)
                                    + np.asarray([0, 0, z0], float)))
@@ -6248,15 +6250,15 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                     # semantics: rotate first, then translate in the
                     # rotated frame (matches _finalize_tree)
                     M_old = np.eye(4)
-                    D = matrix_from_rpy(body["absolute"].get("rpy")
-                                        or [0, 0, 0])
+                    D = rpy2homogeneous(*(body["absolute"].get("rpy")
+                                          or [0, 0, 0]))
                     D[:3, 3] = D[:3, :3] @ np.asarray(
                         body["absolute"].get("xyz") or [0, 0, 0], float)
                     p = D[:3, 3].copy()     # the late D[:3,3]=p must not
                     zdir = None             # clobber the absolute shift
                 elif body.get("rpy") is not None:
                     # +-90 deg style rotation delta about the CURRENT axes
-                    D = matrix_from_rpy(body["rpy"])
+                    D = rpy2homogeneous(*body["rpy"])
                 if zdir is not None:
                     # MINIMAL rotation taking +Z onto zdir (Rodrigues), so
                     # an already-aligned normal changes nothing -- a basis

--- a/sw2robot/exporter/geometry.py
+++ b/sw2robot/exporter/geometry.py
@@ -9,16 +9,24 @@ The documented point transform (local -> global) is the row-vector form::
 
 so the column-vector rotation matrix is ``reshape(r,(3,3)).T``.  Translations
 are in METRES (the SW API is metric), which is what URDF wants.
+
+Only helpers with sw2robot-specific behaviour live here (SW marshalling, URDF
+text stability, strict ``<origin>`` parsing).  Plain rotation/transform math is
+imported straight from ``skrobot.coordinates.math`` at each call site --
+``matrix_relative`` for parent^-1 @ child, ``rpy2homogeneous`` / ``rpy2matrix``
+for rpy -> matrix (URDF convention, extrinsic X-Y-Z: R = Rz @ Ry @ Rx).
+NB: skrobot's legacy ``rpy_matrix(yaw, pitch, roll)`` takes its arguments in
+the OPPOSITE order -- avoid it.
 """
 
 from __future__ import annotations
 
 import numpy as np
-
-# rpy2matrix / matrix2rpy follow the URDF convention (extrinsic X-Y-Z:
-# R = Rz @ Ry @ Rx).  NB: skrobot's legacy ``rpy_matrix(yaw, pitch, roll)``
-# takes its arguments in the OPPOSITE order -- use rpy2matrix here.
-from skrobot.coordinates.math import matrix2rpy, rpy2matrix
+from skrobot.coordinates.math import (
+    matrix2xyzrpy,
+    orthonormalize_rotation_matrix,
+    rpy2homogeneous,
+)
 
 
 def transform_to_matrix(array_data):
@@ -31,46 +39,41 @@ def transform_to_matrix(array_data):
                   [r[1], r[4], r[7]],
                   [r[2], r[5], r[8]]], dtype=float)
     M = np.eye(4)
-    M[:3, :3] = R
+    # SW matrices carry float drift after long mate/assembly chains; project
+    # back onto SO(3) here, at the single entry point, so downstream
+    # rpy/quaternion conversions never see a non-orthogonal rotation.
+    M[:3, :3] = orthonormalize_rotation_matrix(R)
     M[:3, 3] = t
     return M
 
 
 def matrix_to_xyz_rpy(M):
     """4x4 -> (xyz, rpy) with URDF rpy = extrinsic XYZ (roll,pitch,yaw)."""
-    xyz = [float(M[0, 3]), float(M[1, 3]), float(M[2, 3])]
-    roll, pitch, yaw = matrix2rpy(np.asarray(M[:3, :3], dtype=float))
-    # + 0.0 folds IEEE negative zeros so the URDF text stays stable
-    return xyz, [float(roll) + 0.0, float(pitch) + 0.0, float(yaw) + 0.0]
+    xyz, rpy = matrix2xyzrpy(np.asarray(M, dtype=float))
+    # snap sub-1e-12 values (metres / radians -- far below any physical
+    # significance) to EXACT 0: the SVD in orthonormalize_rotation_matrix
+    # leaves BLAS-dependent noise (~1e-16..1e-33) that differs per platform,
+    # and %.8g would faithfully print it, breaking cross-platform golden
+    # comparisons of the URDF text.  Also folds IEEE negative zeros.
+    def _snap(v):
+        v = float(v)
+        return 0.0 if abs(v) < 1e-12 else v
+    return [_snap(v) for v in xyz], [_snap(v) for v in rpy]
 
 
-def relative_matrix(parent_world, child_world):
-    """child expressed in parent frame = parent^-1 * child."""
-    return np.linalg.inv(parent_world) @ child_world
-
-
-def matrix_from_rpy(rpy):
-    """4x4 rotation from extrinsic-XYZ roll/pitch/yaw (URDF convention)."""
-    roll, pitch, yaw = rpy
-    M = np.eye(4)
-    M[:3, :3] = rpy2matrix(float(roll), float(pitch), float(yaw))
+def urdf_origin_matrix(el):
+    """4x4 from a URDF ``<origin>`` element (xyz + extrinsic-XYZ rpy
+    attributes), or identity when the element is absent.  The ONE parser for
+    ``<origin>`` -- exporter and editor both route through it so the rpy
+    convention cannot drift between modules."""
+    if el is None:
+        return np.eye(4)
+    xyz = [float(x) for x in (el.get("xyz") or "0 0 0").split()]
+    rpy = [float(x) for x in (el.get("rpy") or "0 0 0").split()]
+    if len(xyz) != 3 or len(rpy) != 3:
+        raise ValueError(
+            "malformed <origin>: expected 3 values each, got "
+            f"xyz={el.get('xyz')!r} rpy={el.get('rpy')!r}")
+    M = rpy2homogeneous(*rpy)
+    M[:3, 3] = xyz
     return M
-
-
-def frame_at_point(point, R=None):
-    """4x4 frame located at ``point`` (world); rotation defaults to identity."""
-    M = np.eye(4)
-    if R is not None:
-        M[:3, :3] = R
-    M[:3, 3] = point
-    return M
-
-
-def transform_point_dir(M, point_local, dir_local):
-    """Map a (point, direction) from a local frame to world via 4x4 M."""
-    R = M[:3, :3]
-    t = M[:3, 3]
-    p = R @ np.asarray(point_local, float) + t
-    d = R @ np.asarray(dir_local, float)
-    n = np.linalg.norm(d)
-    return p, (d / n if n > 1e-12 else d)

--- a/sw2robot/exporter/inertia.py
+++ b/sw2robot/exporter/inertia.py
@@ -22,20 +22,11 @@ import os
 
 import numpy as np
 
+# URDF convention: R = Rz(yaw) @ Ry(pitch) @ Rx(roll), extrinsic X-Y-Z
+from skrobot.coordinates.math import rpy2matrix
+
 MM_TO_M = 0.001
 DEFAULT_DENSITY = 1000.0  # kg/m^3 -- generic light part; override per build
-
-
-def _rpy_matrix(rpy):
-    """4x4 homogeneous rotation for a URDF ``rpy`` (extrinsic X-Y-Z)."""
-    # rpy2matrix(roll, pitch, yaw) follows the URDF convention
-    # R = Rz @ Ry @ Rx.
-    from skrobot.coordinates.math import rpy2matrix
-
-    roll, pitch, yaw = rpy
-    T = np.eye(4)
-    T[:3, :3] = rpy2matrix(float(roll), float(pitch), float(yaw))
-    return T
 
 
 def _solid_properties(mesh, density):
@@ -91,7 +82,7 @@ def link_inertial(mesh_path, visual_xyz, visual_rpy,
     mass, com_m, I_m, method = props
     # mesh-frame -> link-frame: rotation rotates the tensor (about the com,
     # so the translation does not enter), translation moves the com
-    R = _rpy_matrix(visual_rpy)[:3, :3]
+    R = rpy2matrix(*visual_rpy)
     com = R @ com_m + np.asarray(visual_xyz, dtype=float)
     I = R @ I_m @ R.T
     return {
@@ -134,7 +125,7 @@ def link_inertial_from_sw(mass, com_local, inertia6_local,
     # mesh-frame -> link-frame, identical transform to link_inertial: the
     # rotation rotates the tensor about the (unchanged) com, the translation
     # moves the com.
-    R = _rpy_matrix(visual_rpy)[:3, :3]
+    R = rpy2matrix(*visual_rpy)
     com = R @ com_l + np.asarray(visual_xyz, dtype=float)
     I = R @ I_l @ R.T
     return {

--- a/sw2robot/exporter/merge.py
+++ b/sw2robot/exporter/merge.py
@@ -24,24 +24,14 @@ from __future__ import annotations
 import xml.etree.ElementTree as ET
 
 import numpy as np
+from skrobot.coordinates.math import rpy2matrix
 
-from .geometry import matrix_from_rpy, matrix_to_xyz_rpy
+from .geometry import matrix_to_xyz_rpy, urdf_origin_matrix
 
 
 def _fmt(v):
     # compact, round-trippable; mirror the writer's style (no sci-notation noise)
     return f"{float(v):.10g}"
-
-
-def _origin_matrix(el):
-    """4x4 from an ``<origin>`` element (xyz + extrinsic-XYZ rpy), or identity."""
-    if el is None:
-        return np.eye(4)
-    xyz = [float(x) for x in (el.get("xyz") or "0 0 0").split()]
-    rpy = [float(x) for x in (el.get("rpy") or "0 0 0").split()]
-    m = matrix_from_rpy(rpy)
-    m[:3, 3] = xyz[:3]
-    return m
 
 
 def _set_origin(parent_el, M):
@@ -88,7 +78,7 @@ def _parse_inertial(link_el):
         return None
     inertia = _inertia_tensor(it)
     if any(rpy):                       # express the tensor in link axes
-        R = matrix_from_rpy(rpy)[:3, :3]
+        R = rpy2matrix(*rpy)
         inertia = R @ inertia @ R.T
     return mass, com, inertia
 
@@ -204,13 +194,13 @@ def merge_fixed_links(root, force_merge=None, only=None):
         if target is None:
             break
         j, parent_link, child_link, pname, cname = target
-        T_pc = _origin_matrix(j.find("origin"))
+        T_pc = urdf_origin_matrix(j.find("origin"))
 
         # 1) move the child's visual/collision into the parent (compose origin)
         for vc in list(child_link):
             if vc.tag not in ("visual", "collision"):
                 continue
-            _set_origin(vc, T_pc @ _origin_matrix(vc.find("origin")))
+            _set_origin(vc, T_pc @ urdf_origin_matrix(vc.find("origin")))
             child_link.remove(vc)
             parent_link.append(vc)
         # 2) combine inertials
@@ -220,7 +210,7 @@ def merge_fixed_links(root, force_merge=None, only=None):
             kp = k.find("parent")
             if kp is not None and kp.get("link") == cname:
                 kp.set("link", pname)
-                _set_origin(k, T_pc @ _origin_matrix(k.find("origin")))
+                _set_origin(k, T_pc @ urdf_origin_matrix(k.find("origin")))
         # 4) drop the fixed joint and the (now empty) child link
         root.remove(j)
         root.remove(child_link)

--- a/sw2robot/exporter/model.py
+++ b/sw2robot/exporter/model.py
@@ -22,14 +22,13 @@ import re
 from dataclasses import dataclass, field
 
 import numpy as np
-
-from .geometry import (
-    frame_at_point,
-    matrix_from_rpy,
-    matrix_to_xyz_rpy,
-    relative_matrix,
-    transform_to_matrix,
+from skrobot.coordinates.math import (
+    matrix_relative,
+    rotation_translation2matrix,
+    rpy2homogeneous,
 )
+
+from .geometry import matrix_to_xyz_rpy, transform_to_matrix
 from .state import (
     ComponentState,
     CoordinateSystemState,
@@ -2479,7 +2478,7 @@ def _finalize_tree(comps, adjacency, base, parent_of, edge_info, root_rpy=None,
     # axis on +Z per the convention).
     base_anchor = base.world.copy()
     if root_rpy:
-        base_anchor = base_anchor @ matrix_from_rpy(root_rpy)
+        base_anchor = base_anchor @ rpy2homogeneous(*root_rpy)
     if root_xyz:
         # full origin shift in the (already re-oriented) root frame --
         # the generalisation of root_z_offset, used by the web editor's
@@ -2503,18 +2502,19 @@ def _finalize_tree(comps, adjacency, base, parent_of, edge_info, root_rpy=None,
             # to match SW exactly).  No projection -- that moved the frame to
             # the part origin, which is misleading for parts whose origin is
             # off their geometry.
-            anchor[child] = frame_at_point(np.asarray(pt, float))
+            anchor[child] = rotation_translation2matrix(
+                np.eye(3), np.asarray(pt, float))
         else:
             anchor[child] = by_name[child].world.copy()
 
     for c in comps:
-        rel = relative_matrix(anchor[c.name], c.world)
+        rel = matrix_relative(anchor[c.name], c.world)
         c.visual_xyz, c.visual_rpy = matrix_to_xyz_rpy(rel)
 
     joints = []
     for child, parent in parent_of.items():
         ch = by_name[child]; pa = by_name[parent]
-        rel = relative_matrix(anchor[parent], anchor[child])
+        rel = matrix_relative(anchor[parent], anchor[child])
         xyz, rpy = matrix_to_xyz_rpy(rel)
         info = edge_info.get((child, parent), {"type": "fixed", "axis": None})
         rec = adjacency.get(frozenset((child, parent)), {})
@@ -2582,7 +2582,7 @@ def build_tree(comps, adjacency, base, directed=None, root_rpy=None,
     if closures_out is not None:
         base_anchor = base.world.copy()
         if root_rpy:
-            base_anchor = base_anchor @ matrix_from_rpy(root_rpy)
+            base_anchor = base_anchor @ rpy2homogeneous(*root_rpy)
         saved = base.world
         try:
             base.world = base_anchor

--- a/sw2robot/exporter/ros_export.py
+++ b/sw2robot/exporter/ros_export.py
@@ -498,13 +498,13 @@ def _fit_collision_primitive(src, primitive_type):
     None`` lets scikit-robot pick the tighter of an axis-aligned / oriented fit
     (and, when ``primitive_type`` is None, the best of box/cylinder/sphere) by
     voxel IoU."""
-    import trimesh
+    from skrobot.coordinates.math import rpy2homogeneous
     from skrobot.utils import fit_primitive_to_mesh, primitive_params_to_origin
     mesh = _load_mesh_metres(src)
     params = fit_primitive_to_mesh(mesh, primitive_type=primitive_type,
                                    oriented=None)
     xyz, rpy = primitive_params_to_origin(params)
-    M = trimesh.transformations.euler_matrix(*rpy, axes="sxyz")
+    M = rpy2homogeneous(*rpy)
     M[:3, 3] = xyz
     return params, M
 
@@ -560,16 +560,8 @@ def _origin_matrix(origin_el):
     """4x4 transform for a URDF ``<origin>`` element (xyz + fixed-axis rpy), or
     identity when absent -- to bake a ``<collision>``'s origin into its part
     vertices so a preview mesh sits right when attached at the link frame."""
-    import numpy as np
-    import trimesh
-
-    if origin_el is None:
-        return np.eye(4)
-    xyz = [float(v) for v in (origin_el.get("xyz") or "0 0 0").split()]
-    rpy = [float(v) for v in (origin_el.get("rpy") or "0 0 0").split()]
-    m = trimesh.transformations.euler_matrix(*rpy, axes="sxyz")
-    m[:3, 3] = xyz[:3]
-    return m
+    from .geometry import urdf_origin_matrix
+    return urdf_origin_matrix(origin_el)
 
 
 def _fmt_num(v):

--- a/sw2robot/exporter/validate.py
+++ b/sw2robot/exporter/validate.py
@@ -34,14 +34,8 @@ def _load_glb_verts(path):
 
 
 def _origin_mat(el):
-    if el is None:
-        return np.eye(4)
-    xyz = [float(x) for x in (el.get("xyz") or "0 0 0").split()]
-    rpy = [float(x) for x in (el.get("rpy") or "0 0 0").split()]
-    from .geometry import matrix_from_rpy
-    T = np.array(matrix_from_rpy(rpy), float).copy()
-    T[:3, 3] = xyz
-    return T
+    from .geometry import urdf_origin_matrix
+    return urdf_origin_matrix(el)
 
 
 def warn_dropped_geometry(pkg_dir, urdf_path, graph, tol_mm=3.0, min_frac=0.15):

--- a/tests/golden/fingertip_base.urdf
+++ b/tests/golden/fingertip_base.urdf
@@ -3,13 +3,13 @@
   <link name="fingertip_back_1">
     <!-- sw2robot inertia="hull" -->
     <visual>
-      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 -5.5511151e-17 3.1415927"/>
+      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 0 3.1415927"/>
       <geometry>
         <mesh filename="../meshes/fingertip_back_1.3dxml"/>
       </geometry>
     </visual>
     <collision>
-      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 -5.5511151e-17 3.1415927"/>
+      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 0 3.1415927"/>
       <geometry>
         <mesh filename="../meshes/fingertip_back_1.3dxml"/>
       </geometry>
@@ -19,13 +19,13 @@
   <link name="base_link">
     <!-- sw2robot inertia="hull" -->
     <visual>
-      <origin xyz="3.8518599e-34 0 0" rpy="0 0 -4.4572704e-33"/>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
         <mesh filename="../meshes/fingertip_front_2.3dxml"/>
       </geometry>
     </visual>
     <collision>
-      <origin xyz="3.8518599e-34 0 0" rpy="0 0 -4.4572704e-33"/>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
         <mesh filename="../meshes/fingertip_front_2.3dxml"/>
       </geometry>
@@ -35,13 +35,13 @@
   <link name="screwlock_male_hard_jointbase_v4_1">
     <!-- sw2robot material="ABS" density="1020" inertia="hull" -->
     <visual>
-      <origin xyz="0 0 -1.540744e-33" rpy="5.0814364e-33 2.4652673e-34 -6.3441378e-33"/>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
         <mesh filename="../meshes/screwlock_male_hard_jointbase_v4_1.3dxml"/>
       </geometry>
     </visual>
     <collision>
-      <origin xyz="0 0 -1.540744e-33" rpy="5.0814364e-33 2.4652673e-34 -6.3441378e-33"/>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
         <mesh filename="../meshes/screwlock_male_hard_jointbase_v4_1.3dxml"/>
       </geometry>
@@ -49,14 +49,14 @@
     <inertial/>
   </link>
   <joint name="fingertip_front_2__screwlock_male_hard_jointbase_v4_1" type="fixed">
-    <origin xyz="7.0484173e-18 -0.0155 0.038" rpy="1.5707963 -3.3306691e-16 -3.1415927"/>
+    <origin xyz="0 -0.0155 0.038" rpy="1.5707963 0 -3.1415927"/>
     <parent link="base_link"/>
     <child link="screwlock_male_hard_jointbase_v4_1"/>
     <axis xyz="-0 -0 1"/>
     <!-- mates: CONCENTRIC, COINCIDENT, PARALLEL, CONCENTRIC, COINCIDENT, PARALLEL -->
   </joint>
   <joint name="fingertip_front_2__fingertip_back_1" type="revolute">
-    <origin xyz="0.021039487 -0.0155 0.031" rpy="3.1415927 8.2450846e-17 8.2450846e-17"/>
+    <origin xyz="0.021039487 -0.0155 0.031" rpy="3.1415927 0 0"/>
     <parent link="base_link"/>
     <child link="fingertip_back_1"/>
     <axis xyz="0 1 0"/>

--- a/tests/golden/fingertip_edited.urdf
+++ b/tests/golden/fingertip_edited.urdf
@@ -3,13 +3,13 @@
   <link name="tip">
     <!-- sw2robot inertia="hull" -->
     <visual>
-      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 -5.5511151e-17 3.1415927"/>
+      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 0 3.1415927"/>
       <geometry>
         <mesh filename="../meshes/fingertip_back_1.3dxml"/>
       </geometry>
     </visual>
     <collision>
-      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 -5.5511151e-17 3.1415927"/>
+      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 0 3.1415927"/>
       <geometry>
         <mesh filename="../meshes/fingertip_back_1.3dxml"/>
       </geometry>
@@ -19,13 +19,13 @@
   <link name="base_link">
     <!-- sw2robot inertia="hull" -->
     <visual>
-      <origin xyz="3.8518599e-34 0 0" rpy="0 0 -4.4572704e-33"/>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
         <mesh filename="../meshes/fingertip_front_2.3dxml"/>
       </geometry>
     </visual>
     <collision>
-      <origin xyz="3.8518599e-34 0 0" rpy="0 0 -4.4572704e-33"/>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
         <mesh filename="../meshes/fingertip_front_2.3dxml"/>
       </geometry>
@@ -35,13 +35,13 @@
   <link name="screwlock_male_hard_jointbase_v4_1">
     <!-- sw2robot material="ABS" density="1020" inertia="hull" -->
     <visual>
-      <origin xyz="1.1131366e-18 0.017 -0.003" rpy="-1.5707963 2.5061606e-16 -3.1415927"/>
+      <origin xyz="0 0.017 -0.003" rpy="-1.5707963 0 -3.1415927"/>
       <geometry>
         <mesh filename="../meshes/screwlock_male_hard_jointbase_v4_1.3dxml"/>
       </geometry>
     </visual>
     <collision>
-      <origin xyz="1.1131366e-18 0.017 -0.003" rpy="-1.5707963 2.5061606e-16 -3.1415927"/>
+      <origin xyz="0 0.017 -0.003" rpy="-1.5707963 0 -3.1415927"/>
       <geometry>
         <mesh filename="../meshes/screwlock_male_hard_jointbase_v4_1.3dxml"/>
       </geometry>
@@ -49,7 +49,7 @@
     <inertial/>
   </link>
   <joint name="fingertip_front_2__screwlock_male_hard_jointbase_v4_1" type="revolute">
-    <origin xyz="4.2862638e-18 0.0015 0.035" rpy="3.1415927 8.2450846e-17 8.2450846e-17"/>
+    <origin xyz="0 0.0015 0.035" rpy="3.1415927 0 0"/>
     <parent link="base_link"/>
     <child link="screwlock_male_hard_jointbase_v4_1"/>
     <axis xyz="0 -1 -0"/>
@@ -57,7 +57,7 @@
     <!-- mates: CONCENTRIC, COINCIDENT, PARALLEL, CONCENTRIC, COINCIDENT, PARALLEL -->
   </joint>
   <joint name="bend" type="revolute">
-    <origin xyz="0.021039487 -0.0155 0.031" rpy="3.1415927 8.2450846e-17 8.2450846e-17"/>
+    <origin xyz="0.021039487 -0.0155 0.031" rpy="3.1415927 0 0"/>
     <parent link="base_link"/>
     <child link="tip"/>
     <axis xyz="0 1 0"/>

--- a/tests/golden/fingertip_flip.urdf
+++ b/tests/golden/fingertip_flip.urdf
@@ -3,13 +3,13 @@
   <link name="fingertip_back_1">
     <!-- sw2robot inertia="hull" -->
     <visual>
-      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 -5.5511151e-17 3.1415927"/>
+      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 0 3.1415927"/>
       <geometry>
         <mesh filename="../meshes/fingertip_back_1.3dxml"/>
       </geometry>
     </visual>
     <collision>
-      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 -5.5511151e-17 3.1415927"/>
+      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 0 3.1415927"/>
       <geometry>
         <mesh filename="../meshes/fingertip_back_1.3dxml"/>
       </geometry>
@@ -19,13 +19,13 @@
   <link name="base_link">
     <!-- sw2robot inertia="hull" -->
     <visual>
-      <origin xyz="3.8518599e-34 0 0" rpy="0 0 -4.4572704e-33"/>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
         <mesh filename="../meshes/fingertip_front_2.3dxml"/>
       </geometry>
     </visual>
     <collision>
-      <origin xyz="3.8518599e-34 0 0" rpy="0 0 -4.4572704e-33"/>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
         <mesh filename="../meshes/fingertip_front_2.3dxml"/>
       </geometry>
@@ -35,13 +35,13 @@
   <link name="screwlock_male_hard_jointbase_v4_1">
     <!-- sw2robot material="ABS" density="1020" inertia="hull" -->
     <visual>
-      <origin xyz="0 0 -1.540744e-33" rpy="5.0814364e-33 2.4652673e-34 -6.3441378e-33"/>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
         <mesh filename="../meshes/screwlock_male_hard_jointbase_v4_1.3dxml"/>
       </geometry>
     </visual>
     <collision>
-      <origin xyz="0 0 -1.540744e-33" rpy="5.0814364e-33 2.4652673e-34 -6.3441378e-33"/>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
         <mesh filename="../meshes/screwlock_male_hard_jointbase_v4_1.3dxml"/>
       </geometry>
@@ -49,14 +49,14 @@
     <inertial/>
   </link>
   <joint name="fingertip_front_2__screwlock_male_hard_jointbase_v4_1" type="fixed">
-    <origin xyz="7.0484173e-18 -0.0155 0.038" rpy="1.5707963 -3.3306691e-16 -3.1415927"/>
+    <origin xyz="0 -0.0155 0.038" rpy="1.5707963 0 -3.1415927"/>
     <parent link="base_link"/>
     <child link="screwlock_male_hard_jointbase_v4_1"/>
     <axis xyz="-0 -0 1"/>
     <!-- mates: CONCENTRIC, COINCIDENT, PARALLEL, CONCENTRIC, COINCIDENT, PARALLEL -->
   </joint>
   <joint name="fingertip_front_2__fingertip_back_1" type="revolute">
-    <origin xyz="0.021039487 -0.0155 0.031" rpy="3.1415927 8.2450846e-17 8.2450846e-17"/>
+    <origin xyz="0.021039487 -0.0155 0.031" rpy="3.1415927 0 0"/>
     <parent link="base_link"/>
     <child link="fingertip_back_1"/>
     <axis xyz="0 -1 0"/>

--- a/tests/golden/fingertip_rename_direct.urdf
+++ b/tests/golden/fingertip_rename_direct.urdf
@@ -3,13 +3,13 @@
   <link name="tip">
     <!-- sw2robot inertia="hull" -->
     <visual>
-      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 -5.5511151e-17 3.1415927"/>
+      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 0 3.1415927"/>
       <geometry>
         <mesh filename="../meshes/fingertip_back_1.3dxml"/>
       </geometry>
     </visual>
     <collision>
-      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 -5.5511151e-17 3.1415927"/>
+      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 0 3.1415927"/>
       <geometry>
         <mesh filename="../meshes/fingertip_back_1.3dxml"/>
       </geometry>
@@ -19,13 +19,13 @@
   <link name="base_link">
     <!-- sw2robot inertia="hull" -->
     <visual>
-      <origin xyz="3.8518599e-34 0 0" rpy="0 0 -4.4572704e-33"/>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
         <mesh filename="../meshes/fingertip_front_2.3dxml"/>
       </geometry>
     </visual>
     <collision>
-      <origin xyz="3.8518599e-34 0 0" rpy="0 0 -4.4572704e-33"/>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
         <mesh filename="../meshes/fingertip_front_2.3dxml"/>
       </geometry>
@@ -35,13 +35,13 @@
   <link name="screwlock_male_hard_jointbase_v4_1">
     <!-- sw2robot material="ABS" density="1020" inertia="hull" -->
     <visual>
-      <origin xyz="0 0 -1.540744e-33" rpy="5.0814364e-33 2.4652673e-34 -6.3441378e-33"/>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
         <mesh filename="../meshes/screwlock_male_hard_jointbase_v4_1.3dxml"/>
       </geometry>
     </visual>
     <collision>
-      <origin xyz="0 0 -1.540744e-33" rpy="5.0814364e-33 2.4652673e-34 -6.3441378e-33"/>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
         <mesh filename="../meshes/screwlock_male_hard_jointbase_v4_1.3dxml"/>
       </geometry>
@@ -49,14 +49,14 @@
     <inertial/>
   </link>
   <joint name="fingertip_front_2__screwlock_male_hard_jointbase_v4_1" type="fixed">
-    <origin xyz="7.0484173e-18 -0.0155 0.038" rpy="1.5707963 -3.3306691e-16 -3.1415927"/>
+    <origin xyz="0 -0.0155 0.038" rpy="1.5707963 0 -3.1415927"/>
     <parent link="base_link"/>
     <child link="screwlock_male_hard_jointbase_v4_1"/>
     <axis xyz="-0 -0 1"/>
     <!-- mates: CONCENTRIC, COINCIDENT, PARALLEL, CONCENTRIC, COINCIDENT, PARALLEL -->
   </joint>
   <joint name="bend" type="revolute">
-    <origin xyz="0.021039487 -0.0155 0.031" rpy="3.1415927 8.2450846e-17 8.2450846e-17"/>
+    <origin xyz="0.021039487 -0.0155 0.031" rpy="3.1415927 0 0"/>
     <parent link="base_link"/>
     <child link="tip"/>
     <axis xyz="0 1 0"/>

--- a/tests/test_loop_mimic.py
+++ b/tests/test_loop_mimic.py
@@ -155,7 +155,7 @@ def _fk_chain(urdf_path):
     """Tiny URDF FK (the same maths the shipped relay embeds) for the test."""
     import xml.etree.ElementTree as ET
 
-    from sw2robot.exporter.geometry import matrix_from_rpy
+    from skrobot.coordinates.math import rpy2homogeneous
     root = ET.parse(urdf_path).getroot()
     js = {}
     for j in root.findall("joint"):
@@ -167,7 +167,7 @@ def _fk_chain(urdf_path):
         ax = j.find("axis")
         axis = (np.array([float(x) for x in ax.get("xyz").split()])
                 if ax is not None else np.array([0.0, 0.0, 1.0]))
-        t = matrix_from_rpy(rpy).copy()
+        t = rpy2homogeneous(*rpy).copy()
         t[:3, 3] = xyz
         js[j.get("name")] = (j.get("type"), j.find("child").get("link"),
                              j.find("parent").get("link"), t, axis)

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -7,11 +7,12 @@ import yaml
 
 
 def test_zdir_to_rpy_points_local_z_along_zdir():
+    from skrobot.coordinates.math import rpy2homogeneous
+
     from sw2robot.editor import webserver as w
-    from sw2robot.exporter.geometry import matrix_from_rpy
     for zdir in ([0, 0, 1], [1, 0, 0], [0, 1, 0], [0, 0, -1], [1, 1, 1]):
         rpy = w._zdir_to_rpy(zdir)
-        got = matrix_from_rpy(rpy)[:3, :3] @ np.array([0.0, 0.0, 1.0])
+        got = rpy2homogeneous(*rpy)[:3, :3] @ np.array([0.0, 0.0, 1.0])
         want = np.asarray(zdir, float)
         want = want / np.linalg.norm(want)
         assert np.allclose(got, want, atol=1e-6), (zdir, rpy, got)
@@ -21,11 +22,12 @@ def test_zdir_to_rpy_points_local_z_along_zdir():
 
 def test_zdir_to_rpy_near_antiparallel_is_stable():
     """A normal pointing (almost) along -Z must not blow up 1/(1+c)."""
+    from skrobot.coordinates.math import rpy2homogeneous
+
     from sw2robot.editor import webserver as w
-    from sw2robot.exporter.geometry import matrix_from_rpy
     for zdir in ([0, 0, -1], [1e-9, 0, -1], [0, -1e-8, -1]):
         rpy = w._zdir_to_rpy(zdir)
-        got = matrix_from_rpy(rpy)[:3, :3] @ np.array([0.0, 0.0, 1.0])
+        got = rpy2homogeneous(*rpy)[:3, :3] @ np.array([0.0, 0.0, 1.0])
         assert np.all(np.isfinite(got))
         assert got[2] < -0.999, (zdir, rpy, got)     # local +Z points down
 


### PR DESCRIPTION
This replaces sw2robot's hand-rolled rotation/transform math with direct `skrobot.coordinates.math` calls (`matrix_relative`, `rpy2homogeneous`, `rpy2matrix`, `matrix2xyzrpy`), removing the pure-delegation wrappers and the duplicated `<origin>` parsers (one strict shared parser now lives in `geometry.py`).
SolidWorks rotation matrices are projected back onto SO(3) with the new `orthonormalize_rotation_matrix` at the `ArrayData` entry point, so float drift from long mate/assembly chains never reaches downstream rpy/quaternion conversions; the trimesh euler backend is gone from `ros_export.py` (numerically verified identical convention).
Requires scikit-robot>=0.3.27; net -32 lines, full test suite passes (404 passed, 15 skipped).