### PR TITLE
refactor: use scikit-robot inertia utilities

### DIFF
--- a/sw2robot/editor/core.py
+++ b/sw2robot/editor/core.py
@@ -544,7 +544,7 @@ def set_inertial(state: RobotCompilerState, link: str,
         # check the exporter applies to generated inertials, so a hand-entered
         # tensor can't export a simulator-breaking link.  The tensor checks are
         # mass-independent, so use a positive placeholder when mass is unset here.
-        from sw2robot.exporter.inertia import validate_inertia
+        from skrobot.utils.inertia import validate_inertia
         probs = validate_inertia(mass if mass is not None else 1.0, inertia)
         if probs:
             raise ValueError("invalid inertia: " + "; ".join(probs))

--- a/sw2robot/exporter/inertia.py
+++ b/sw2robot/exporter/inertia.py
@@ -1,56 +1,34 @@
-"""Compute a link's inertial (mass, centre of mass, inertia tensor) from its
-mesh, so the generated URDF carries real dynamics instead of a placeholder.
+"""sw2robot's mesh-unit convention for link inertials.
 
-Units: the SolidWorks-exported meshes are in **millimetres** (a servo body is
-~32 mm), while the URDF skeleton is in **metres**.  We therefore scale the mesh
-by ``MM_TO_M`` before applying density, so mass comes out in kg and the inertia
-tensor in kg.m^2 -- directly usable by Gazebo / MoveIt.
+The inertial maths itself lives in :mod:`skrobot.utils.inertia`
+(``mesh_mass_properties``, ``transform_inertial``, ``link_inertial_from_mesh``,
+``rescale_inertial_to_mass``, ``validate_inertia``) -- call those directly.
+What is sw2robot-specific, and all that remains here, is the SCALE of the
+meshes we hand it:
 
-The mesh is moved into the *link* frame (via the visual origin) before the
-integral, so the returned centre of mass and tensor are expressed in link
-coordinates -- exactly what the URDF ``<inertial>`` element wants.
-
-Many CAD meshes are NOT watertight; trimesh's volume integral is then
-unreliable.  We fall back to the convex hull (always watertight, a mild
-over-estimate) and, failing that, the oriented bounding box, and we report which
-links used an approximation rather than silently emitting wrong numbers.
+* SolidWorks exports parts in **millimetres** (a servo body is ~32 mm) while
+  the URDF skeleton is in **metres**, so a per-part mesh needs ``MM_TO_M``
+  before density is applied -- otherwise mass comes out 1e9 times too large.
+* Composed sub-assembly ``.glb`` files are the exception: ``mesh.py`` already
+  applies the 0.001 and stamps ``units="meter"`` when it writes them, so they
+  must NOT be scaled again.
 """
 
 from __future__ import annotations
 
-import os
-
-import numpy as np
-
-# URDF convention: R = Rz(yaw) @ Ry(pitch) @ Rx(roll), extrinsic X-Y-Z
-from skrobot.coordinates.math import rpy2matrix
+from skrobot.utils.inertia import DEFAULT_DENSITY, link_inertial_from_mesh
 
 MM_TO_M = 0.001
-DEFAULT_DENSITY = 1000.0  # kg/m^3 -- generic light part; override per build
-
-
-def _solid_properties(mesh, density):
-    """(mass, com(3), I 3x3) for ``mesh`` treated as a solid of ``density``.
-
-    Returns ``None`` if the mesh has no usable volume."""
-    if mesh is None or not hasattr(mesh, "vertices") or len(mesh.vertices) == 0:
-        return None
-    vol = float(getattr(mesh, "volume", 0.0) or 0.0)
-    if not np.isfinite(vol) or vol <= 0:
-        return None
-    mesh.density = float(density)
-    mass = float(mesh.mass)
-    com = np.asarray(mesh.center_mass, dtype=float)
-    inertia = np.asarray(mesh.moment_inertia, dtype=float)  # about COM, link axes
-    if not (np.isfinite(mass) and mass > 0 and np.all(np.isfinite(com))
-            and np.all(np.isfinite(inertia))):
-        return None
-    return mass, com, inertia
 
 
 def link_inertial(mesh_path, visual_xyz, visual_rpy,
                   density=DEFAULT_DENSITY, scale=MM_TO_M):
-    """Inertial for one link, computed in the link frame.
+    """Inertial for one link, in the link frame, from a sw2robot-exported mesh.
+
+    A thin wrapper over :func:`skrobot.utils.inertia.link_inertial_from_mesh`
+    that applies sw2robot's mesh-unit convention: millimetre parts by default,
+    but ``.glb`` sub-assembly composites taken as metres (see the module
+    docstring).
 
     Parameters
     ----------
@@ -61,7 +39,7 @@ def link_inertial(mesh_path, visual_xyz, visual_rpy,
     density : float
         Material density in kg/m^3.
     scale : float
-        Mesh-unit -> metre factor (SolidWorks mm exports -> 0.001).
+        Mesh-unit -> metre factor, overridden to 1.0 for ``.glb`` inputs.
 
     Returns
     -------
@@ -73,184 +51,6 @@ def link_inertial(mesh_path, visual_xyz, visual_rpy,
     if not mesh_path:
         return None
     if mesh_path.lower().endswith(".glb"):
-        # composed sub-assembly GLBs are written in metres already
-        # (mesh.py applies the 0.001 and stamps units="meter")
         scale = 1.0
-    props = _mesh_props(mesh_path, density, scale)
-    if props is None:
-        return None
-    mass, com_m, I_m, method = props
-    # mesh-frame -> link-frame: rotation rotates the tensor (about the com,
-    # so the translation does not enter), translation moves the com
-    R = rpy2matrix(*visual_rpy)
-    com = R @ com_m + np.asarray(visual_xyz, dtype=float)
-    I = R @ I_m @ R.T
-    return {
-        "mass": mass,
-        "com": [float(c) for c in com],
-        "inertia": (float(I[0, 0]), float(I[0, 1]), float(I[0, 2]),
-                    float(I[1, 1]), float(I[1, 2]), float(I[2, 2])),
-        "method": method,
-    }
-
-
-def link_inertial_from_sw(mass, com_local, inertia6_local,
-                          visual_xyz, visual_rpy):
-    """Inertial in the LINK frame from SolidWorks-native mass properties.
-
-    ``mass``/``com_local``/``inertia6_local`` come straight from the part's
-    ``IMassProperty`` (see ``model._sw_mass_props``): SI units already (kg,
-    metres, kg.m^2) and expressed in the part's OWN coordinate frame -- the
-    very frame the mesh is exported in -- so the visual origin maps them into
-    the link frame exactly as the mesh path does, with NO extra scaling.
-
-    ``inertia6_local`` is ``(ixx, ixy, ixz, iyy, iyz, izz)`` of the tensor
-    about the centre of mass.  Returns the same dict shape as
-    :func:`link_inertial` (``method="solidworks"``), or ``None`` if the values
-    are missing / non-finite so the caller can fall back to the mesh."""
-    if mass is None or com_local is None or inertia6_local is None:
-        return None
-    try:
-        m = float(mass)
-        com_l = np.asarray(com_local, dtype=float)
-        ixx, ixy, ixz, iyy, iyz, izz = (float(x) for x in inertia6_local)
-    except (TypeError, ValueError):
-        return None
-    I_l = np.array([[ixx, ixy, ixz],
-                    [ixy, iyy, iyz],
-                    [ixz, iyz, izz]], dtype=float)
-    if not (np.isfinite(m) and m > 0 and com_l.shape == (3,)
-            and np.all(np.isfinite(com_l)) and np.all(np.isfinite(I_l))):
-        return None
-    # mesh-frame -> link-frame, identical transform to link_inertial: the
-    # rotation rotates the tensor about the (unchanged) com, the translation
-    # moves the com.
-    R = rpy2matrix(*visual_rpy)
-    com = R @ com_l + np.asarray(visual_xyz, dtype=float)
-    I = R @ I_l @ R.T
-    return {
-        "mass": m,
-        "com": [float(c) for c in com],
-        "inertia": (float(I[0, 0]), float(I[0, 1]), float(I[0, 2]),
-                    float(I[1, 1]), float(I[1, 2]), float(I[2, 2])),
-        "method": "solidworks",
-    }
-
-
-def rescale_to_mass(info, target_mass):
-    """Rescale a computed inertial dict to an exact target mass (kg).
-
-    ``info`` is a dict as returned by :func:`link_inertial` /
-    :func:`link_inertial_from_sw` (``{mass, com, inertia, method}``).  For a
-    rigid body of fixed geometry, changing the (uniform) density scales the
-    mass and the full inertia tensor by the SAME factor, while the centre of
-    mass is unchanged -- so we multiply ``mass`` and all six inertia components
-    by ``target_mass / mass`` and leave ``com`` alone.  ``method`` is annotated
-    with ``"->mass"`` so the provenance report shows the rescale happened.
-
-    Returns a new dict (does not mutate ``info``).  If ``info`` is falsy or its
-    mass is non-positive/non-finite, returns ``info`` unchanged (nothing sane to
-    scale from)."""
-    if not info:
-        return info
-    try:
-        m0 = float(info["mass"])
-        target = float(target_mass)
-    except (TypeError, ValueError, KeyError):
-        return info
-    if not (np.isfinite(m0) and m0 > 0 and np.isfinite(target) and target > 0):
-        return info
-    factor = target / m0
-    return {
-        "mass": target,
-        "com": list(info["com"]),
-        "inertia": tuple(float(x) * factor for x in info["inertia"]),
-        "method": f'{info.get("method", "?")}->mass',
-    }
-
-
-def validate_inertia(mass, inertia6, rel_tol=1e-6):
-    """Physics sanity-check one link's inertial; return a list of problem
-    strings (empty list == OK).
-
-    A real rigid body's inertia tensor (taken about the centre of mass) must be
-    symmetric **positive definite** -- all principal moments (eigenvalues
-    ``I1 <= I2 <= I3``) strictly positive -- and those moments must satisfy the
-    **triangle inequality** ``I1 + I2 >= I3`` (the geometric constraint every
-    physical mass distribution obeys; the other two combinations follow once all
-    are positive).  Violating either makes a simulator's integrator diverge, and
-    usually signals a units / frame / transform bug upstream.
-
-    ``rel_tol`` is applied relative to the largest principal moment so ordinary
-    floating-point / tessellation noise does not trip the checks."""
-    problems = []
-    if mass is None or not np.isfinite(mass) or mass <= 0:
-        problems.append(f"mass is not positive (= {mass})")
-    try:
-        ixx, ixy, ixz, iyy, iyz, izz = (float(x) for x in inertia6)
-    except (TypeError, ValueError):
-        problems.append("inertia is not a 6-tuple (ixx,ixy,ixz,iyy,iyz,izz)")
-        return problems
-    I = np.array([[ixx, ixy, ixz], [ixy, iyy, iyz], [ixz, iyz, izz]], float)
-    if not np.all(np.isfinite(I)):
-        problems.append("inertia tensor has non-finite entries")
-        return problems
-    e = np.linalg.eigvalsh(I)                 # ascending, real (symmetric)
-    atol = rel_tol * max(abs(float(e[-1])), 1e-12)
-    if e[0] <= atol:
-        problems.append(
-            "inertia tensor is not positive definite "
-            f"(smallest principal moment {e[0]:.4g} <= 0)")
-    elif e[0] + e[1] < e[2] - atol:           # triangle inequality (binding pair)
-        problems.append(
-            "principal moments violate the triangle inequality "
-            f"(I1+I2 < I3: {e[0]:.4g} + {e[1]:.4g} < {e[2]:.4g})")
-    return problems
-
-
-_PROPS_CACHE = {}
-
-
-def _mesh_props(mesh_path, density, scale):
-    """(mass, com, I_about_com, method) in SCALED MESH coordinates, cached by
-    (path, mtime, density, scale).  Loading + watertight checks dominate a
-    rebuild (~60 ms per mesh), and the result is pose-independent, so every
-    re-build / instance reuse after the first is effectively free."""
-    try:
-        key = (os.path.abspath(mesh_path), os.path.getmtime(mesh_path),
-               float(density), float(scale))
-    except OSError:
-        return None
-    if key in _PROPS_CACHE:
-        return _PROPS_CACHE[key]
-    result = None
-    try:
-        import trimesh
-        mesh = trimesh.load(mesh_path, force="mesh")
-        if mesh is not None and hasattr(mesh, "vertices") \
-                and len(mesh.vertices):
-            mesh = mesh.copy()
-            mesh.apply_scale(scale)
-            method = "mesh"
-            props = _solid_properties(mesh, density) \
-                if mesh.is_watertight else None
-            if props is None:
-                method = "hull"
-                try:
-                    props = _solid_properties(mesh.convex_hull, density)
-                except Exception:
-                    props = None
-            if props is None:
-                method = "bbox"
-                try:
-                    props = _solid_properties(mesh.bounding_box_oriented,
-                                              density)
-                except Exception:
-                    props = None
-            if props is not None:
-                mass, com, inertia = props
-                result = (mass, com, inertia, method)
-    except Exception:
-        result = None
-    _PROPS_CACHE[key] = result
-    return result
+    return link_inertial_from_mesh(mesh_path, visual_xyz, visual_rpy,
+                                   density=density, scale=scale)

--- a/sw2robot/exporter/model.py
+++ b/sw2robot/exporter/model.py
@@ -276,7 +276,7 @@ class Component:
     # the same variant, so exports must key on (part_path, configuration)
     configuration: str | None = None
     # SolidWorks-native mass properties (part-local frame, SI), preferred over
-    # the mesh estimate when present -- see exporter.inertia.link_inertial_from_sw
+    # the mesh estimate when present -- see skrobot.utils.inertia.transform_inertial
     sw_mass: float | None = None              # kg
     sw_com: list | None = None                # centre of mass [x,y,z] (m)
     sw_inertia: list | None = None            # (ixx,ixy,ixz,iyy,iyz,izz) about COM
@@ -289,7 +289,7 @@ class Component:
     density_override: bool = False
     # per-link target mass (kg): the inertial is rescaled to this exact weight
     # (config `masses:` / the web editor), mutually exclusive with a density
-    # override -- see exporter.inertia.rescale_to_mass
+    # override -- see skrobot.utils.inertia.rescale_inertial_to_mass
     mass_target: float | None = None
     # standard hardware (screw/bolt/nut/washer/pin): weld it FIXED to whatever it
     # fastens and never let it be a tree parent -- see is_fastener_part
@@ -3441,7 +3441,7 @@ def build_model(graph, robot_name=None, base_hint=None, config=None,
         # Same name matching as densities.  Mutually exclusive with a density
         # override: a target mass rescales the inertial to an exact weight, so
         # clear any density override on the same link (mass wins).  Consumed in
-        # urdf_writer._inertial_xml via exporter.inertia.rescale_to_mass.
+        # urdf_writer._inertial_xml via skrobot.utils.inertia.rescale_inertial_to_mass.
         by_ln = {c.link_name: c for c in comps}
         by_nm = {c.name: c for c in comps}
         for k, v in config["masses"].items():

--- a/sw2robot/exporter/urdf_writer.py
+++ b/sw2robot/exporter/urdf_writer.py
@@ -18,7 +18,14 @@ from __future__ import annotations
 
 import os
 
-from . import inertia as _inertia
+from skrobot.utils.inertia import (
+    DEFAULT_DENSITY,
+    rescale_inertial_to_mass,
+    transform_inertial,
+    validate_inertia,
+)
+
+from .inertia import link_inertial
 from .model import safe_name
 
 # Fallback inertial when no mesh is available / its volume is unusable.
@@ -87,10 +94,14 @@ def _inertial_xml(comp, mesh_dir, density):
     info = None
     # 1. SolidWorks-native values (only when no density override is in force)
     if density is None and not getattr(comp, "density_override", False):
-        info = _inertia.link_inertial_from_sw(
+        # SI already (kg, metres, kg.m^2) and expressed in the part's OWN
+        # frame -- the frame the mesh is exported in -- so the visual origin
+        # maps them into the link frame exactly as the mesh path does, with
+        # NO extra scaling.
+        info = transform_inertial(
             getattr(comp, "sw_mass", None), getattr(comp, "sw_com", None),
             getattr(comp, "sw_inertia", None),
-            comp.visual_xyz, comp.visual_rpy)
+            comp.visual_xyz, comp.visual_rpy, method="solidworks")
     # 2. Mesh estimate
     if info is None and comp.mesh_file and mesh_dir:
         # mesh_file may carry Windows backslashes (extracted on Windows); split
@@ -100,8 +111,8 @@ def _inertial_xml(comp, mesh_dir, density):
         # global default (config `density:` still overrides everything via
         # the caller)
         d = (getattr(comp, "density", None)
-             or (density if density is not None else _inertia.DEFAULT_DENSITY))
-        info = _inertia.link_inertial(
+             or (density if density is not None else DEFAULT_DENSITY))
+        info = link_inertial(
             os.path.join(mesh_dir, *rel.split("/")),
             comp.visual_xyz, comp.visual_rpy, density=d)
     if info is None:
@@ -109,10 +120,10 @@ def _inertial_xml(comp, mesh_dir, density):
     # 4. per-link target mass: rescale whatever inertial we derived (SW-native,
     # mesh, or placeholder) to the exact requested weight -- see the `masses:`
     # override applied in model.build.  Mass and the full tensor scale together;
-    # the com is unchanged (exporter.inertia.rescale_to_mass).
+    # the com is unchanged (skrobot.utils.inertia.rescale_inertial_to_mass).
     mass_target = getattr(comp, "mass_target", None)
     if mass_target:
-        info = _inertia.rescale_to_mass(info, mass_target)
+        info = rescale_inertial_to_mass(info, mass_target)
     ixx, ixy, ixz, iyy, iyz, izz = info["inertia"]
     lines = [
         "    <inertial>",
@@ -122,7 +133,7 @@ def _inertial_xml(comp, mesh_dir, density):
         f'iyy="{iyy:.6g}" iyz="{iyz:.6g}" izz="{izz:.6g}"/>',
         "    </inertial>",
     ]
-    problems = _inertia.validate_inertia(info["mass"], info["inertia"])
+    problems = validate_inertia(info["mass"], info["inertia"])
     return lines, info["method"], problems
 
 

--- a/tests/test_inertia_mesh_units.py
+++ b/tests/test_inertia_mesh_units.py
@@ -1,0 +1,60 @@
+"""sw2robot's mesh-unit convention for inertials (exporter.inertia).
+
+The inertial maths is scikit-robot's; the ONE thing sw2robot owns is the scale
+it hands the library: SolidWorks per-part meshes are millimetres, while the
+composed sub-assembly ``.glb`` files ``mesh.py`` writes are already metres and
+must NOT be scaled again.  Getting this wrong is a 1e9 error in mass, so it is
+pinned here.
+"""
+import numpy as np
+import pytest
+
+from sw2robot.exporter.inertia import MM_TO_M, link_inertial
+
+DENSITY = 1200.0
+EXTENTS = (20.0, 30.0, 40.0)        # in MESH units
+ORIGIN = ([0, 0, 0], [0, 0, 0])     # identity visual origin
+
+
+def _box(tmp_path, suffix):
+    trimesh = pytest.importorskip("trimesh")
+    path = tmp_path / f"box{suffix}"
+    trimesh.creation.box(extents=list(EXTENTS)).export(path)
+    return str(path)
+
+
+def test_part_mesh_is_treated_as_millimetres(tmp_path):
+    """A 20x30x40 *mm* box at 1200 kg/m^3 weighs 2.4e-5 m^3 * 1200 = 28.8 g."""
+    info = link_inertial(_box(tmp_path, ".stl"), *ORIGIN, density=DENSITY)
+    volume_m3 = np.prod([e * MM_TO_M for e in EXTENTS])
+    assert info["mass"] == pytest.approx(volume_m3 * DENSITY, rel=1e-9)
+    assert info["method"] == "mesh"          # a box is watertight
+
+
+def test_glb_subassembly_mesh_is_already_metres(tmp_path):
+    """The same box as .glb is metres, so it comes out 1e9 times heavier --
+    mesh.py already applied the 0.001 when it composed the sub-assembly."""
+    glb = link_inertial(_box(tmp_path, ".glb"), *ORIGIN, density=DENSITY)
+    stl = link_inertial(_box(tmp_path, ".stl"), *ORIGIN, density=DENSITY)
+    assert glb["mass"] == pytest.approx(np.prod(EXTENTS) * DENSITY, rel=1e-9)
+    assert glb["mass"] / stl["mass"] == pytest.approx(1 / MM_TO_M ** 3, rel=1e-6)
+
+
+def test_glb_detection_ignores_case(tmp_path):
+    """Extensions are matched case-insensitively (paths come from Windows)."""
+    lower = link_inertial(_box(tmp_path, ".glb"), *ORIGIN, density=DENSITY)
+    upper = link_inertial(_box(tmp_path, ".GLB"), *ORIGIN, density=DENSITY)
+    assert upper["mass"] == pytest.approx(lower["mass"], rel=1e-12)
+
+
+def test_explicit_scale_is_honoured_for_non_glb(tmp_path):
+    """A caller-supplied scale overrides the millimetre default."""
+    info = link_inertial(_box(tmp_path, ".stl"), *ORIGIN,
+                         density=DENSITY, scale=1.0)
+    assert info["mass"] == pytest.approx(np.prod(EXTENTS) * DENSITY, rel=1e-9)
+
+
+@pytest.mark.parametrize("path", [None, "", "no_such_mesh.stl"])
+def test_missing_mesh_returns_none(path):
+    """No usable mesh -> None, so the writer keeps its placeholder inertial."""
+    assert link_inertial(path, *ORIGIN) is None

--- a/tests/test_mass_override.py
+++ b/tests/test_mass_override.py
@@ -1,6 +1,6 @@
 """Per-link target-mass override (issue #29): a `masses:` block (mirroring
 `densities:`) rescales a link's inertial to an exact weight.  Covers the
-inertia.rescale_to_mass helper, the urdf_writer consumption, the build_model
+rescale_inertial_to_mass helper, the urdf_writer consumption, the build_model
 config parsing + mutual-exclusivity with a density override, and an end-to-end
 build() through joints.yaml."""
 import xml.etree.ElementTree as ET
@@ -15,11 +15,11 @@ def _eye():
 
 # ---------------------------------------------------------------- rescale helper
 
-def test_rescale_to_mass_scales_mass_and_tensor_keeps_com():
-    from sw2robot.exporter.inertia import rescale_to_mass
+def test_rescale_inertial_to_mass_scales_mass_and_tensor_keeps_com():
+    from skrobot.utils.inertia import rescale_inertial_to_mass
     info = {"mass": 2.0, "com": [0.1, -0.2, 0.3],
             "inertia": (3.0, 0.5, 0.0, 4.0, 0.0, 5.0), "method": "solidworks"}
-    out = rescale_to_mass(info, 6.0)          # factor 3
+    out = rescale_inertial_to_mass(info, 6.0)          # factor 3
     assert out["mass"] == 6.0
     assert np.allclose(out["com"], [0.1, -0.2, 0.3])          # com unchanged
     assert np.allclose(out["inertia"], (9.0, 1.5, 0.0, 12.0, 0.0, 15.0))
@@ -28,15 +28,15 @@ def test_rescale_to_mass_scales_mass_and_tensor_keeps_com():
     assert info["mass"] == 2.0 and info["method"] == "solidworks"
 
 
-def test_rescale_to_mass_noop_on_bad_input():
-    from sw2robot.exporter.inertia import rescale_to_mass
-    assert rescale_to_mass(None, 5.0) is None
+def test_rescale_inertial_to_mass_noop_on_bad_input():
+    from skrobot.utils.inertia import rescale_inertial_to_mass
+    assert rescale_inertial_to_mass(None, 5.0) is None
     bad = {"mass": 0.0, "com": [0, 0, 0], "inertia": (1, 0, 0, 1, 0, 1),
            "method": "x"}
-    assert rescale_to_mass(bad, 5.0) is bad          # zero base mass -> unchanged
+    assert rescale_inertial_to_mass(bad, 5.0) is bad          # zero base mass -> unchanged
     good = {"mass": 1.0, "com": [0, 0, 0], "inertia": (1, 0, 0, 1, 0, 1),
             "method": "x"}
-    assert rescale_to_mass(good, 0.0) is good        # non-positive target -> unchanged
+    assert rescale_inertial_to_mass(good, 0.0) is good        # non-positive target -> unchanged
 
 
 # ---------------------------------------------------------------- urdf writer

--- a/tests/test_sw_inertia.py
+++ b/tests/test_sw_inertia.py
@@ -46,27 +46,31 @@ def test_sw_mass_props_rejects_degenerate():
 
 
 # ---------------------------------------------------------------- transform
-def test_link_inertial_from_sw_identity_origin():
+# The SW-native -> link-frame mapping is skrobot's transform_inertial; these
+# pin the contract urdf_writer._inertial_xml depends on (frame mapping + the
+# "solidworks" provenance tag it passes).
+def test_sw_inertial_transform_identity_origin():
     """With an identity visual origin the SW values pass through unchanged."""
-    from sw2robot.exporter.inertia import link_inertial_from_sw
+    from skrobot.utils.inertia import transform_inertial
 
-    info = link_inertial_from_sw(
+    info = transform_inertial(
         2.0, [0.1, 0.0, 0.0], (3.0, 0.0, 0.0, 4.0, 0.0, 5.0),
-        visual_xyz=[0, 0, 0], visual_rpy=[0, 0, 0])
+        visual_xyz=[0, 0, 0], visual_rpy=[0, 0, 0], method="solidworks")
     assert info["method"] == "solidworks"
     assert info["mass"] == 2.0
     assert np.allclose(info["com"], [0.1, 0.0, 0.0])
     assert np.allclose(info["inertia"], (3.0, 0.0, 0.0, 4.0, 0.0, 5.0))
 
 
-def test_link_inertial_from_sw_rotation_translation():
+def test_sw_inertial_transform_rotation_translation():
     """A 90 deg rotation about Z swaps the x/y diagonal terms; the COM is both
     rotated and translated."""
-    from sw2robot.exporter.inertia import link_inertial_from_sw
+    from skrobot.utils.inertia import transform_inertial
 
-    info = link_inertial_from_sw(
+    info = transform_inertial(
         1.0, [1.0, 0.0, 0.0], (2.0, 0.0, 0.0, 7.0, 0.0, 9.0),
-        visual_xyz=[0.0, 0.0, 0.5], visual_rpy=[0.0, 0.0, np.pi / 2])
+        visual_xyz=[0.0, 0.0, 0.5], visual_rpy=[0.0, 0.0, np.pi / 2],
+        method="solidworks")
     # com: Rz(90)@[1,0,0] = [0,1,0], then + [0,0,0.5]
     assert np.allclose(info["com"], [0.0, 1.0, 0.5], atol=1e-9)
     ixx, ixy, ixz, iyy, iyz, izz = info["inertia"]
@@ -76,9 +80,11 @@ def test_link_inertial_from_sw_rotation_translation():
     assert np.isclose(izz, 9.0, atol=1e-9)
 
 
-def test_link_inertial_from_sw_none_on_missing():
-    from sw2robot.exporter.inertia import link_inertial_from_sw
-    assert link_inertial_from_sw(None, None, None, [0, 0, 0], [0, 0, 0]) is None
+def test_sw_inertial_transform_none_on_missing():
+    """Missing SW values must yield None so the writer falls back to the mesh."""
+    from skrobot.utils.inertia import transform_inertial
+    assert transform_inertial(None, None, None, [0, 0, 0], [0, 0, 0],
+                              method="solidworks") is None
 
 
 # ---------------------------------------------------------------- writer priority
@@ -119,7 +125,7 @@ def test_explicit_density_overrides_solidworks(tmp_path):
 
 # ---------------------------------------------------------------- validate_inertia
 def test_validate_inertia_accepts_a_real_tensor():
-    from sw2robot.exporter.inertia import validate_inertia
+    from skrobot.utils.inertia import validate_inertia
     # a plausible solid block: diagonal, triangle inequality holds
     assert validate_inertia(2.0, (3.0, 0.0, 0.0, 4.0, 0.0, 5.0)) == []
     # off-diagonal but still SPD + valid
@@ -127,27 +133,28 @@ def test_validate_inertia_accepts_a_real_tensor():
 
 
 def test_validate_inertia_flags_bad_mass():
-    from sw2robot.exporter.inertia import validate_inertia
+    from skrobot.utils.inertia import validate_inertia
     probs = validate_inertia(0.0, (1.0, 0.0, 0.0, 1.0, 0.0, 1.0))
     assert any("mass" in p for p in probs)
     assert validate_inertia(-1.0, (1.0, 0.0, 0.0, 1.0, 0.0, 1.0))
 
 
 def test_validate_inertia_flags_non_positive_definite():
-    from sw2robot.exporter.inertia import validate_inertia
+    from skrobot.utils.inertia import validate_inertia
     # a negative principal moment (e.g. a sign/units bug) -> not SPD
     probs = validate_inertia(1.0, (-1.0, 0.0, 0.0, 2.0, 0.0, 3.0))
     assert any("positive definite" in p for p in probs)
 
 
 def test_validate_inertia_flags_triangle_violation():
-    from sw2robot.exporter.inertia import validate_inertia
+    from skrobot.utils.inertia import validate_inertia
     # all positive, but I1+I2 < I3 (1 + 1 < 10) -> physically impossible
     probs = validate_inertia(1.0, (1.0, 0.0, 0.0, 1.0, 0.0, 10.0))
     assert any("triangle inequality" in p for p in probs)
 
 
 def test_validate_inertia_placeholder_is_valid():
-    from sw2robot.exporter.inertia import validate_inertia
+    from skrobot.utils.inertia import validate_inertia
+
     from sw2robot.exporter.urdf_writer import _PLACEHOLDER_INERTIAL as P
     assert validate_inertia(P["mass"], P["inertia"]) == []


### PR DESCRIPTION
This drops sw2robot's near-identical copies of the mass-property, tensor-transform, rescale and validation helpers in favour of `skrobot.utils.inertia`, shrinking `exporter/inertia.py` from 257 lines to 55.
What remains local is the one sw2robot-specific rule: per-part meshes are millimetres while composed sub-assembly `.glb` files are already metres, so only the former get scaled — a 1e9 error in mass if it is lost, and it had no test until now.
Verified bit-identical against the old implementation (mesh, hull and SolidWorks-native paths, plus degenerate inputs all agree exactly); the golden URDF tests normalise `<inertial>` away, so that equivalence was checked separately.