### PR TITLE
refactor: lump inertials with scikit-robot's rigid-body helpers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,10 @@ dependencies = [
     "pyyaml>=6",
     # rotation/transform math (rpy<->matrix), FK, and the per-mesh primitive
     # API (skrobot.utils.primitive_fitting) used by the ROS-export --collision
-    # fitting; >=0.3.27 for orthonormalize_rotation_matrix / matrix_relative /
-    # matrix2xyzrpy / rpy2homogeneous (geometry.py and friends).
-    "scikit-robot>=0.3.27",
+    # fitting; >=0.3.28 for the rigid-body inertia helpers merge.py builds on
+    # (parallel_axis / combine_inertials) on top of 0.3.27's
+    # orthonormalize_rotation_matrix / matrix_relative / matrix2xyzrpy.
+    "scikit-robot>=0.3.28",
     # only the EXTRACT step (driving SolidWorks COM) needs this, and only on Windows
     "pywin32>=306; sys_platform == 'win32'",
 ]

--- a/sw2robot/exporter/merge.py
+++ b/sw2robot/exporter/merge.py
@@ -23,8 +23,7 @@ from __future__ import annotations
 
 import xml.etree.ElementTree as ET
 
-import numpy as np
-from skrobot.coordinates.math import rpy2matrix
+from skrobot.utils.inertia import combine_inertials, transform_inertial
 
 from .geometry import matrix_to_xyz_rpy, urdf_origin_matrix
 
@@ -51,83 +50,66 @@ def _has_geometry(link_el):
             or link_el.find("collision") is not None)
 
 
-def _inertia_tensor(inertia_el):
-    def g(k):
-        return float(inertia_el.get(k, "0"))
-    ixx, ixy, ixz = g("ixx"), g("ixy"), g("ixz")
-    iyy, iyz, izz = g("iyy"), g("iyz"), g("izz")
-    return np.array([[ixx, ixy, ixz], [ixy, iyy, iyz], [ixz, iyz, izz]], float)
+def _vec3(el, attr):
+    """A 3-vector attribute of ``el`` (``"0 0 0"`` when absent/empty)."""
+    raw = (el.get(attr) if el is not None else None) or "0 0 0"
+    return [float(x) for x in raw.split()]
 
 
 def _parse_inertial(link_el):
-    """``(mass, com(3), I(3x3) about com)`` for a link, or None if no inertial.
-    Inertial ``rpy`` is honoured (rotates the tensor into link axes)."""
+    """A link's ``<inertial>`` as skrobot's ``{mass, com, inertia, method}``
+    dict, expressed in the LINK frame -- or None when the block is missing or
+    carries a non-positive / non-finite mass.
+
+    The inertial ``<origin>`` is applied by ``transform_inertial``: its ``rpy``
+    rotates the tensor into link axes and its ``xyz`` places the centre of
+    mass."""
     el = link_el.find("inertial")
     if el is None:
         return None
-    mass_el = el.find("mass")
-    mass = float(mass_el.get("value", "0")) if mass_el is not None else 0.0
-    o = el.find("origin")
-    com = np.array([float(x) for x in (o.get("xyz") if o is not None
-                                       and o.get("xyz") else "0 0 0").split()],
-                   float)
-    rpy = [float(x) for x in (o.get("rpy") if o is not None and o.get("rpy")
-                              else "0 0 0").split()]
     it = el.find("inertia")
     if it is None:
         return None
-    inertia = _inertia_tensor(it)
-    if any(rpy):                       # express the tensor in link axes
-        R = rpy2matrix(*rpy)
-        inertia = R @ inertia @ R.T
-    return mass, com, inertia
+    mass_el = el.find("mass")
+    mass = float(mass_el.get("value", "0")) if mass_el is not None else 0.0
+    components = tuple(float(it.get(k, "0")) for k in
+                       ("ixx", "ixy", "ixz", "iyy", "iyz", "izz"))
+    origin = el.find("origin")
+    return transform_inertial(mass, [0.0, 0.0, 0.0], components,
+                              _vec3(origin, "xyz"), _vec3(origin, "rpy"))
 
 
-def _write_inertial(link_el, mass, com, inertia):
-    """Replace ``link_el``'s ``<inertial>`` with the given mass/com/tensor
-    (axis-aligned: rpy=0)."""
+def _write_inertial(link_el, info):
+    """Replace ``link_el``'s ``<inertial>`` with ``info`` (a skrobot inertial
+    dict), written axis-aligned: ``rpy=0``, since the tensor is already in link
+    axes about ``com``."""
     old = link_el.find("inertial")
     if old is not None:
         link_el.remove(old)
     el = ET.SubElement(link_el, "inertial")
     o = ET.SubElement(el, "origin")
-    o.set("xyz", " ".join(_fmt(v) for v in com))
+    o.set("xyz", " ".join(_fmt(v) for v in info["com"]))
     o.set("rpy", "0 0 0")
-    ET.SubElement(el, "mass").set("value", _fmt(mass))
+    ET.SubElement(el, "mass").set("value", _fmt(info["mass"]))
     it = ET.SubElement(el, "inertia")
-    for k, v in (("ixx", inertia[0, 0]), ("ixy", inertia[0, 1]),
-                 ("ixz", inertia[0, 2]), ("iyy", inertia[1, 1]),
-                 ("iyz", inertia[1, 2]), ("izz", inertia[2, 2])):
+    for k, v in zip(("ixx", "ixy", "ixz", "iyy", "iyz", "izz"),
+                    info["inertia"]):
         it.set(k, _fmt(v))
 
 
-def _parallel_axis(mass, com, inertia, new_com):
-    """Shift an inertia tensor (about ``com``) to be about ``new_com``."""
-    d = np.asarray(com, float) - np.asarray(new_com, float)
-    return inertia + mass * (float(d @ d) * np.eye(3) - np.outer(d, d))
-
-
 def _combine_inertials(parent_el, child_el, T_pc):
-    """Lump the child link's <inertial> into the parent's, with the child first
-    moved into the parent frame by ``T_pc`` (parent<-child).  No-op if the child
-    has no inertial; seeds the parent if it had none."""
-    ci = _parse_inertial(child_el)
-    if ci is None:
+    """Lump the child link's ``<inertial>`` into the parent's, with the child
+    first moved into the parent frame by ``T_pc`` (parent<-child).  No-op if the
+    child has no usable inertial; seeds the parent if it had none."""
+    child = _parse_inertial(child_el)
+    if child is None:
         return
-    m2, c2, I2 = ci
-    R = T_pc[:3, :3]
-    c2 = (T_pc @ np.append(c2, 1.0))[:3]      # child COM in parent frame
-    I2 = R @ I2 @ R.T                          # child tensor in parent axes
-    pi = _parse_inertial(parent_el)
-    if pi is None or pi[0] <= 0:
-        _write_inertial(parent_el, m2, c2, I2)
-        return
-    m1, c1, I1 = pi
-    m = m1 + m2
-    com = (m1 * c1 + m2 * c2) / m
-    inertia = (_parallel_axis(m1, c1, I1, com)
-               + _parallel_axis(m2, c2, I2, com))
-    _write_inertial(parent_el, m, com, inertia)
+    xyz, rpy = matrix_to_xyz_rpy(T_pc)
+    child = transform_inertial(child["mass"], child["com"], child["inertia"],
+                               xyz, rpy)
+    combined = combine_inertials(_parse_inertial(parent_el), child)
+    if combined is not None:
+        _write_inertial(parent_el, combined)
 
 
 def merge_fixed_links(root, force_merge=None, only=None):

--- a/tests/test_merge_fixed.py
+++ b/tests/test_merge_fixed.py
@@ -327,3 +327,32 @@ def test_fold_rotates_child_inertia_into_the_parent_frame():
     assert abs(float(it.get("ixy"))) < 1e-9
     assert abs(float(it.get("ixz"))) < 1e-9
     assert abs(float(it.get("iyz"))) < 1e-9
+
+
+def test_massless_child_inertial_contributes_nothing():
+    """A child whose <inertial> declares mass 0 must not push a phantom tensor
+    into the parent: a body with no mass carries no inertia, and such a block is
+    malformed URDF (validate_inertia flags it).  The parent keeps its own
+    inertial untouched."""
+    urdf = """<?xml version="1.0"?>
+<robot name="z">
+  <link name="base"><inertial><origin xyz="0 0 0" rpy="0 0 0"/><mass value="2"/>
+    <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/></inertial>
+    <visual><geometry><box size="1 1 1"/></geometry></visual></link>
+  <joint name="fix_z" type="fixed"><origin xyz="1 0 0" rpy="0 0 0"/>
+    <parent link="base"/><child link="ghost"/></joint>
+  <link name="ghost"><inertial><origin xyz="0 0 0" rpy="0 0 0"/><mass value="0"/>
+    <inertia ixx="9" ixy="0" ixz="0" iyy="9" iyz="0" izz="9"/></inertial>
+    <visual><geometry><box size="0.1 0.1 0.1"/></geometry></visual></link>
+</robot>"""
+    root = ET.fromstring(urdf)
+    n, _ = merge_fixed_links(root)
+    assert n == 1
+
+    base = next(ln for ln in root.findall("link") if ln.get("name") == "base")
+    inertial = base.find("inertial")
+    assert abs(float(inertial.find("mass").get("value")) - 2.0) < 1e-9
+    assert _f(inertial.find("origin").get("xyz")) == [0.0, 0.0, 0.0]
+    it = inertial.find("inertia")
+    for key in ("ixx", "iyy", "izz"):
+        assert abs(float(it.get(key)) - 1.0) < 1e-9, (key, it.get(key))


### PR DESCRIPTION
`merge.py`'s parallel-axis theorem and two-body composition move to `skrobot.utils.inertia` (`parallel_axis` / `combine_inertials`, added upstream in iory/scikit-robot#844 and released in 0.3.28), and parsing an `<inertial>` now goes through `transform_inertial`, leaving the file with only the URDF XML plumbing.
Verified identical to the old implementation on 500 randomised parent/child pairs with arbitrary transforms (mass, centre of mass and all six tensor components agree exactly), with one deliberate change: a child whose `<inertial>` declares mass 0 no longer pushes its tensor into the parent, since a massless body carries no inertia and such a block is malformed URDF — pinned by a new test.
Requires scikit-robot>=0.3.28.