### PR TITLE
refactor: use scikit-robot's URDF name sanitizer and CoACD helpers

### DIFF
--- a/sw2robot/editor/core.py
+++ b/sw2robot/editor/core.py
@@ -668,48 +668,6 @@ def _safe_name(name: str) -> str:
     return safe_name(name)
 
 
-def _sanitize_urdf_names(root) -> None:
-    """Rewrite every ``<link>``/``<joint>`` name -- and all their cross
-    references (joint parent/child link, mimic joint) -- through
-    :func:`_safe_name`, so the emitted URDF never carries a hyphen, space, dot
-    or other character that downstream tools (xacro, ROS, MoveIt) choke on.
-
-    A no-op when the names are already clean (the usual case: the exporter and
-    ``rename_joint`` both validate), so it is a safety net that also covers
-    hand-edited root names, ports and externally imported URDFs."""
-    def _remap(elems, attr):
-        mapping, used = {}, set()
-        for el in elems:
-            orig = el.get(attr)
-            if orig is None or orig in mapping:
-                continue
-            cand, i = _safe_name(orig), 1
-            while cand in used:               # two dirty names -> same clean one
-                i += 1
-                cand = f"{_safe_name(orig)}_{i}"
-            mapping[orig] = cand
-            used.add(cand)
-        return mapping
-
-    links = root.findall("link")
-    joints = root.findall("joint")
-    lmap = _remap(links, "name")
-    jmap = _remap(joints, "name")
-    for le in links:
-        if le.get("name") in lmap:
-            le.set("name", lmap[le.get("name")])
-    for je in joints:
-        if je.get("name") in jmap:
-            je.set("name", jmap[je.get("name")])
-        for tag in ("parent", "child"):
-            el = je.find(tag)
-            if el is not None and el.get("link") in lmap:
-                el.set("link", lmap[el.get("link")])
-        mim = je.find("mimic")
-        if mim is not None and mim.get("joint") in jmap:
-            mim.set("joint", jmap[mim.get("joint")])
-
-
 # <element>: (urdf attribute, JointEdit field) pairs, in URDF attribute order.
 _PHYSICS_ELEMENTS = (
     ("dynamics", (("damping", "damping"), ("friction", "friction"))),
@@ -750,10 +708,11 @@ def build_urdf(state: RobotCompilerState, sanitize: bool = True,
     the exported package and configs stay consistent.
 
     With ``sanitize`` (default), link/joint names are passed through
-    :func:`_sanitize_urdf_names` last, so a CAD-derived URDF is guaranteed free
-    of hyphens and other unsafe characters.  Pass ``sanitize=False`` when editing
-    a URDF the user opened directly: its names are already its own contract (the
-    viewer shows them, edits reference them), so they must be preserved verbatim.
+    :func:`skrobot.urdf.sanitize_urdf_names` last, so a CAD-derived URDF is
+    guaranteed free of hyphens and other unsafe characters.  Pass
+    ``sanitize=False`` when editing a URDF the user opened directly: its names
+    are already its own contract (the viewer shows them, edits reference them),
+    so they must be preserved verbatim.
 
     ``fold_mass_only`` (default) lumps each mass-only link into its fixed parent
     -- the export representation.  Pass ``False`` for the editor's served URDF so
@@ -872,7 +831,8 @@ def build_urdf(state: RobotCompilerState, sanitize: bool = True,
 
     # final guarantee: no hyphens/spaces/etc. in any emitted link or joint name
     if sanitize:
-        _sanitize_urdf_names(root)
+        from skrobot.urdf.sanitize import sanitize_urdf_names
+        sanitize_urdf_names(root)
     return ET.tostring(root, encoding="unicode")
 
 

--- a/sw2robot/exporter/ros_export.py
+++ b/sw2robot/exporter/ros_export.py
@@ -30,6 +30,12 @@ import re
 import threading
 import xml.etree.ElementTree as ET
 
+from skrobot.utils.convex_decomposition import (
+    COACD_PRESETS,
+    convex_decomposition,
+    is_coacd_available,
+)
+
 from .urdf_writer import (
     CMAKELISTS,
     CMAKELISTS_ROS2,
@@ -333,20 +339,11 @@ class _MeshCache:
 # CoACD is an OPTIONAL dependency (the `coacd` extra) and decomposition is slow
 # (tens of seconds per link), so this is opt-in and the result is cached on disk
 # keyed by the source mesh content + parameters -- a re-export is then instant.
+#
+# The quality presets are skrobot's ``COACD_PRESETS``: measured on the
+# feetech_hand parts, 'balanced' costs ~8-60 s per part and 'fine' several times
+# that in exchange for a tighter fit.
 
-# CoACD parameters per quality preset.  CoACD's cost is dominated by the MCTS
-# search, which runs to ``max_convex_hull`` cuts whenever ``threshold`` is too
-# low to stop earlier -- so a low threshold + high part cap + many MCTS
-# iterations makes EVERY part (even a tiny one) pay the full ~2-minute search.
-# Measured on the feetech_hand parts: the old 'balanced' (0.1 / 8 / mcts 100)
-# took 100-150 s on small parts; 'balanced' below is ~8-60 s (2-5x faster) with
-# 'fine' kept for a tighter fit when the wait is worth it.
-_COACD_PRESETS = {
-    "balanced": {"threshold": 0.2, "max_convex_hull": 6,
-                 "preprocess_resolution": 30, "mcts_iterations": 30},
-    "fine": {"threshold": 0.1, "max_convex_hull": 8,
-             "preprocess_resolution": 40, "mcts_iterations": 60},
-}
 # bump when the decomposition output format changes so stale caches are ignored
 _COACD_CACHE_VERSION = 1
 
@@ -366,33 +363,13 @@ def _coacd_key_lock(key):
         return lk
 
 
-def coacd_available():
-    """True if the optional ``coacd`` package is importable."""
-    import importlib.util
-    return importlib.util.find_spec("coacd") is not None
-
-
-def _run_coacd(vertices, faces, params):
-    """Run CoACD and return ``[(verts, faces), ...]`` convex parts.  Thin
-    indirection over the ``coacd`` package so tests can monkeypatch it without
-    installing CoACD or paying its (tens-of-seconds) runtime."""
-    import coacd
-
-    coacd.set_log_level("error")
-    mesh = coacd.Mesh(vertices, faces)
-    return coacd.run_coacd(mesh, merge=True, **params)
-
-
 def _coacd_part_stls(src, quality, cache_dir):
     """``[stl_bytes, ...]`` -- the source mesh ``src`` decomposed into convex
     collision parts (each a watertight STL in metres) per the ``quality`` preset.
 
     Cached under ``cache_dir/<key>/`` keyed by the source file content + params,
     so repeated exports of an unchanged mesh skip the slow CoACD run."""
-    import numpy as np
-    import trimesh
-
-    params = _COACD_PRESETS[quality]
+    params = COACD_PRESETS[quality]
     with open(src, "rb") as f:
         src_bytes = f.read()
     h = hashlib.sha1(src_bytes)
@@ -420,16 +397,10 @@ def _coacd_part_stls(src, quality, cache_dir):
         cached = _read_cache()          # another thread may have built it first
         if cached is not None:
             return cached
-        mesh = _load_mesh_metres(src)
-        parts = _run_coacd(mesh.vertices, mesh.faces, params)
+        parts = convex_decomposition(_load_mesh_metres(src), quality)
         os.makedirs(part_dir, exist_ok=True)
         out, names = [], []
-        for i, (verts, faces) in enumerate(parts):
-            # CoACD parts are convex; take the convex hull to drop any sliver
-            # faces and guarantee a clean watertight collision mesh
-            part = trimesh.Trimesh(vertices=np.asarray(verts),
-                                   faces=np.asarray(faces),
-                                   process=False).convex_hull
+        for i, part in enumerate(parts):
             part.units = "meter"
             data = part.export(file_type="stl")
             name = f"part_{i}.stl"
@@ -725,10 +696,10 @@ def collision_preview_glbs(pkg_dir, robot_name, quality="balanced", progress=Non
     import trimesh
 
     if mode == "coacd":
-        if quality not in _COACD_PRESETS:
+        if quality not in COACD_PRESETS:
             raise ValueError(f"unsupported coacd_quality: {quality!r} "
-                             f"(use one of {sorted(_COACD_PRESETS)})")
-        if not coacd_available():
+                             f"(use one of {sorted(COACD_PRESETS)})")
+        if not is_coacd_available():
             raise ValueError(
                 "CoACD collision decomposition needs the optional 'coacd' "
                 "package -- install it with: pip install coacd")
@@ -1146,11 +1117,11 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
         raise ValueError(f"unsupported collision mode: {collision!r} "
                          f"(use one of {COLLISION_MODES})")
     if collision == "coacd":
-        if coacd_quality not in _COACD_PRESETS:
+        if coacd_quality not in COACD_PRESETS:
             raise ValueError(
                 f"unsupported coacd_quality: {coacd_quality!r} "
-                f"(use one of {sorted(_COACD_PRESETS)})")
-        if not coacd_available():
+                f"(use one of {sorted(COACD_PRESETS)})")
+        if not is_coacd_available():
             raise ValueError(
                 "CoACD collision decomposition needs the optional 'coacd' "
                 "package -- install it with: pip install coacd")

--- a/tests/test_coacd_smoke.py
+++ b/tests/test_coacd_smoke.py
@@ -8,9 +8,9 @@ Skipped where ``coacd`` is not installed, so it is a no-op for the default
 """
 import pytest
 
-from sw2robot.exporter.ros_export import _run_coacd, coacd_available
+from sw2robot.exporter.ros_export import convex_decomposition, is_coacd_available
 
-if not coacd_available():
+if not is_coacd_available():
     pytest.skip("coacd not installed", allow_module_level=True)
 
 
@@ -26,18 +26,14 @@ def _l_shape():
 
 
 def test_real_coacd_runs_and_decomposes():
-    import numpy as np
-
-    mesh = _l_shape()
     # coarse + cheap params: this is an "it runs on this OS" check, not a
     # quality check, so keep the MCTS search small
-    parts = _run_coacd(
-        np.asarray(mesh.vertices), np.asarray(mesh.faces),
-        {"threshold": 0.2, "max_convex_hull": 4,
-         "preprocess_resolution": 20, "mcts_iterations": 20})
+    parts = convex_decomposition(
+        _l_shape(), threshold=0.2, max_convex_hull=4,
+        preprocess_resolution=20, mcts_iterations=20)
 
     assert len(parts) >= 1                       # produced at least one hull
-    for verts, faces in parts:
-        v, f = np.asarray(verts), np.asarray(faces)
-        assert v.ndim == 2 and v.shape[1] == 3 and len(v) >= 4
-        assert f.ndim == 2 and f.shape[1] == 3 and len(f) >= 4
+    for part in parts:
+        assert part.vertices.shape[1] == 3 and len(part.vertices) >= 4
+        assert part.faces.shape[1] == 3 and len(part.faces) >= 4
+        assert part.is_watertight

--- a/tests/test_ros_export.py
+++ b/tests/test_ros_export.py
@@ -165,9 +165,9 @@ def test_merge_fixed_plus_coacd_compose(tmp_path, monkeypatch):
 
     from sw2robot.exporter import ros_export
 
-    monkeypatch.setattr(ros_export, "coacd_available", lambda: True)
-    monkeypatch.setattr(ros_export, "_run_coacd",
-                        lambda v, f, params: _two_unit_boxes())
+    monkeypatch.setattr(ros_export, "is_coacd_available", lambda: True)
+    monkeypatch.setattr(ros_export, "convex_decomposition",
+                        lambda mesh, quality: _two_unit_boxes())
 
     pkg_dir = _make_fixed_pkg_with_collision(tmp_path, robot="rc")
     files = dict(ros_export.build_ros_description(
@@ -263,7 +263,7 @@ def test_collision_hull_needs_no_coacd(tmp_path, monkeypatch):
 
     from sw2robot.exporter import ros_export
 
-    monkeypatch.setattr(ros_export, "coacd_available", lambda: False)
+    monkeypatch.setattr(ros_export, "is_coacd_available", lambda: False)
     pkg_dir = _make_pkg(tmp_path, robot="fing")
     files = dict(ros_export.build_ros_description(
         pkg_dir, "fing", collision="hull"))
@@ -674,14 +674,14 @@ def test_dae_visual_emits_no_material(tmp_path):
 
 
 def _two_unit_boxes():
-    """Two trivial convex parts (unit cubes), as CoACD returns ``(verts, faces)``
-    pairs -- a stand-in for a real decomposition so tests stay fast + CoACD-free."""
+    """Two trivial convex parts (unit cubes), as a decomposition returns them --
+    a stand-in for a real CoACD run so tests stay fast + CoACD-free."""
     import trimesh
 
     a = trimesh.creation.box(extents=(1, 1, 1))
     b = trimesh.creation.box(extents=(1, 1, 1))
     b.apply_translation((2, 0, 0))
-    return [(a.vertices, a.faces), (b.vertices, b.faces)]
+    return [a, b]
 
 
 def test_coacd_collision_expands_into_convex_parts(tmp_path, monkeypatch):
@@ -692,9 +692,9 @@ def test_coacd_collision_expands_into_convex_parts(tmp_path, monkeypatch):
     from sw2robot.exporter import ros_export
 
     # stub CoACD itself so the test is fast and needs no compiled wheel
-    monkeypatch.setattr(ros_export, "coacd_available", lambda: True)
-    monkeypatch.setattr(ros_export, "_run_coacd",
-                        lambda v, f, params: _two_unit_boxes())
+    monkeypatch.setattr(ros_export, "is_coacd_available", lambda: True)
+    monkeypatch.setattr(ros_export, "convex_decomposition",
+                        lambda mesh, quality: _two_unit_boxes())
 
     pkg_dir = _make_pkg(tmp_path, robot="c")
     files = dict(ros_export.build_ros_description(pkg_dir, "c",
@@ -725,12 +725,12 @@ def test_coacd_decomposition_is_cached(tmp_path, monkeypatch):
 
     calls = {"n": 0}
 
-    def _counting_coacd(v, f, params):
+    def _counting_coacd(mesh, quality):
         calls["n"] += 1
         return _two_unit_boxes()
 
-    monkeypatch.setattr(ros_export, "coacd_available", lambda: True)
-    monkeypatch.setattr(ros_export, "_run_coacd", _counting_coacd)
+    monkeypatch.setattr(ros_export, "is_coacd_available", lambda: True)
+    monkeypatch.setattr(ros_export, "convex_decomposition", _counting_coacd)
 
     pkg_dir = _make_pkg(tmp_path, robot="c")
     ros_export.build_ros_description(pkg_dir, "c", collision="coacd")
@@ -746,7 +746,7 @@ def test_coacd_missing_package_errors(tmp_path, monkeypatch):
 
     from sw2robot.exporter import ros_export
 
-    monkeypatch.setattr(ros_export, "coacd_available", lambda: False)
+    monkeypatch.setattr(ros_export, "is_coacd_available", lambda: False)
     pkg_dir = _make_pkg(tmp_path, robot="c")
     with pytest.raises(ValueError, match="pip install coacd"):
         ros_export.build_ros_description(pkg_dir, "c", collision="coacd")
@@ -757,7 +757,7 @@ def test_coacd_invalid_quality_rejected(tmp_path, monkeypatch):
 
     from sw2robot.exporter import ros_export
 
-    monkeypatch.setattr(ros_export, "coacd_available", lambda: True)
+    monkeypatch.setattr(ros_export, "is_coacd_available", lambda: True)
     pkg_dir = _make_pkg(tmp_path, robot="c")
     with pytest.raises(ValueError, match="coacd_quality"):
         ros_export.build_ros_description(pkg_dir, "c", collision="coacd",
@@ -774,12 +774,12 @@ def test_preview_warms_export_cache(tmp_path, monkeypatch):
 
     calls = {"n": 0}
 
-    def _counting(v, f, params):
+    def _counting(mesh, quality):
         calls["n"] += 1
         return _two_unit_boxes()
 
-    monkeypatch.setattr(ros_export, "coacd_available", lambda: True)
-    monkeypatch.setattr(ros_export, "_run_coacd", _counting)
+    monkeypatch.setattr(ros_export, "is_coacd_available", lambda: True)
+    monkeypatch.setattr(ros_export, "convex_decomposition", _counting)
 
     pkg_dir = _make_pkg(tmp_path, robot="c")
     # 1) generate the preview (decomposes the one mesh -> 1 CoACD run)
@@ -805,9 +805,9 @@ def test_collision_preview_glbs_per_link(tmp_path, monkeypatch):
 
     from sw2robot.exporter import ros_export
 
-    monkeypatch.setattr(ros_export, "coacd_available", lambda: True)
-    monkeypatch.setattr(ros_export, "_run_coacd",
-                        lambda v, f, params: _two_unit_boxes())
+    monkeypatch.setattr(ros_export, "is_coacd_available", lambda: True)
+    monkeypatch.setattr(ros_export, "convex_decomposition",
+                        lambda mesh, quality: _two_unit_boxes())
 
     pkg_dir = _make_pkg(tmp_path, robot="c")
     seen = []
@@ -1133,10 +1133,10 @@ def test_build_ros_description_cancels_during_collision_warm(tmp_path):
     from sw2robot.exporter.ros_export import (
         ExportCancelled,
         build_ros_description,
-        coacd_available,
+        is_coacd_available,
     )
 
-    if not coacd_available():
+    if not is_coacd_available():
         _pytest.skip("coacd not installed")
     pkg_dir = _make_pkg(tmp_path, robot="rw")
     with _pytest.raises(ExportCancelled):

--- a/tests/test_sanitize_names.py
+++ b/tests/test_sanitize_names.py
@@ -3,8 +3,9 @@
 Covers both output paths:
   * the exporter (``urdf_writer.write_urdf``) -- a hand-set ``root_link_name``
     or port name is sanitized;
-  * the editor (``core._sanitize_urdf_names``) -- the final export pass cleans
-    any name and rewrites every cross reference (parent/child link, mimic).
+  * the editor (``core.build_urdf(sanitize=True)``) -- the final export pass
+    cleans any name and rewrites every cross reference (parent/child link,
+    mimic).
 """
 import re
 import xml.etree.ElementTree as ET
@@ -64,10 +65,25 @@ def test_exporter_sanitizes_root_and_port(tmp_path):
     assert parent in link_names
 
 
-def test_editor_sanitize_pass_rewrites_references():
-    from sw2robot.editor.core import _sanitize_urdf_names
+def _built(tmp_path, urdf):
+    """``build_urdf`` over a raw URDF string, parsed back to a root element."""
+    from sw2robot.editor._vendor.rc_config.urdf_parser import parse_urdf_content
+    from sw2robot.editor.core import build_urdf
+    from sw2robot.editor.state import RobotCompilerState
 
-    urdf = """<robot name="r">
+    path = tmp_path / "r.urdf"
+    path.write_text(urdf, encoding="utf-8")
+    parsed = parse_urdf_content(urdf)
+    state = RobotCompilerState(
+        robot_name="r", urdf_path=str(path), package_dir=str(tmp_path),
+        joints=parsed["joints"], links=parsed["links"],
+        root_link=parsed["root_link"],
+    )
+    return ET.fromstring(build_urdf(state))
+
+
+def test_editor_sanitize_pass_rewrites_references(tmp_path):
+    root = _built(tmp_path, """<robot name="r">
       <link name="base-link"/>
       <link name="arm.1"/>
       <joint name="base-link__arm.1" type="revolute">
@@ -75,9 +91,7 @@ def test_editor_sanitize_pass_rewrites_references():
         <child link="arm.1"/>
         <mimic joint="base-link__arm.1"/>
       </joint>
-    </robot>"""
-    root = ET.fromstring(urdf)
-    _sanitize_urdf_names(root)
+    </robot>""")
 
     for e in root.findall("link") + root.findall("joint"):
         assert _SAFE.match(e.get("name"))
@@ -89,14 +103,12 @@ def test_editor_sanitize_pass_rewrites_references():
     assert j.find("mimic").get("joint") == j.get("name")
 
 
-def test_editor_sanitize_is_noop_on_clean_names():
-    from sw2robot.editor.core import _sanitize_urdf_names
-
-    urdf = ('<robot name="r"><link name="base_link"/><link name="arm_link"/>'
-            '<joint name="base_link__arm_link" type="fixed">'
-            '<parent link="base_link"/><child link="arm_link"/></joint></robot>')
-    root = ET.fromstring(urdf)
-    _sanitize_urdf_names(root)
+def test_editor_sanitize_is_noop_on_clean_names(tmp_path):
+    root = _built(
+        tmp_path,
+        '<robot name="r"><link name="base_link"/><link name="arm_link"/>'
+        '<joint name="base_link__arm_link" type="fixed">'
+        '<parent link="base_link"/><child link="arm_link"/></joint></robot>')
     assert {e.get("name") for e in root.findall("link")} == {"base_link", "arm_link"}
     assert root.find("joint").get("name") == "base_link__arm_link"
 


### PR DESCRIPTION
The editor's export sanitize pass and the ROS exporter's convex-decomposition layer both reimplemented code scikit-robot now ships, so they call it directly: `editor.core._sanitize_urdf_names` becomes `skrobot.urdf.sanitize_urdf_names`, and `_COACD_PRESETS` / `coacd_available` / `_run_coacd` become `skrobot.utils.convex_decomposition`.
The two sanitizers were verified to produce byte-identical names over 4674 adversarial inputs and 600 randomised URDFs, and the CoACD presets are equal, so the on-disk cache keys that hash them stay valid.
`_coacd_part_stls` keeps its content-hash cache and per-key lock, which are sw2robot's own; net −61 lines.