### PR TITLE
refactor: one <origin> formatter and writer in exporter/geometry.py

### DIFF
--- a/sw2robot/editor/core.py
+++ b/sw2robot/editor/core.py
@@ -592,7 +592,9 @@ def validate(state: RobotCompilerState) -> list:
 
 # --------------------------------------------------------------- #4 export
 def _set_xyz(elem, vec):
-    elem.set("xyz", " ".join(f"{v:.8g}" for v in vec))
+    from sw2robot.exporter.geometry import fmt_urdf_vec
+
+    elem.set("xyz", fmt_urdf_vec(vec))
 
 
 def _hex_to_rgba(hex_color: str) -> str:

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -2845,29 +2845,20 @@ def _urdf_vec(s, n=3):
 
 
 def _urdf_origin_matrix(elem):
-    import numpy as _np
-    from skrobot.coordinates.math import rpy2homogeneous
+    """The served URDF's ``<origin>`` parser -- non-strict, because the editor
+    also opens URDFs sw2robot did not write, and one hand-typed ``xyz="0 0"``
+    must not abort a load that the user could still fix in the editor."""
+    from sw2robot.exporter.geometry import urdf_origin_matrix
 
-    xyz = _urdf_vec(elem.get("xyz"), 3) if elem is not None else [0, 0, 0]
-    rpy = _urdf_vec(elem.get("rpy"), 3) if elem is not None else [0, 0, 0]
-    M = rpy2homogeneous(*rpy)
-    M[:3, 3] = _np.asarray(xyz, float)
-    return M
+    return urdf_origin_matrix(elem, strict=False)
 
 
 def _set_urdf_origin(elem, T):
-    import xml.etree.ElementTree as _ET
+    """Write ``elem``'s ``<origin>`` from a 4x4 -- the exporter's writer, so an
+    edited URDF is formatted exactly like a freshly exported one."""
+    from sw2robot.exporter.geometry import set_urdf_origin
 
-    from sw2robot.exporter.geometry import matrix_to_xyz_rpy
-    from sw2robot.exporter.urdf_writer import _fmt
-
-    origin = elem.find("origin")
-    if origin is None:
-        origin = _ET.Element("origin")
-        elem.insert(0, origin)
-    xyz, rpy = matrix_to_xyz_rpy(T)
-    origin.set("xyz", _fmt(xyz))
-    origin.set("rpy", _fmt(rpy))
+    set_urdf_origin(elem, T)
 
 
 def _set_urdf_axis(joint, axis):
@@ -2875,7 +2866,7 @@ def _set_urdf_axis(joint, axis):
 
     import numpy as _np
 
-    from sw2robot.exporter.urdf_writer import _fmt
+    from sw2robot.exporter.geometry import fmt_urdf_vec
 
     if axis is None:
         return
@@ -2889,7 +2880,7 @@ def _set_urdf_axis(joint, axis):
         elem = _ET.Element("axis")
         insert_at = 3
         joint.insert(min(insert_at, len(list(joint))), elem)
-    elem.set("xyz", _fmt(axis))
+    elem.set("xyz", fmt_urdf_vec(axis))
 
 
 def _urdf_link_world_poses(root):
@@ -3546,7 +3537,9 @@ def _rename_in_urdf(pkg_dir, urdf_rel, kind, old, new):
 
 def _fmt_num(v):
     """Compact URDF numeric attribute -- no ``-0.0``, trims trailing zeros."""
-    return "0" if v == 0 else f"{v:.8g}"
+    from sw2robot.exporter.geometry import fmt_urdf_num
+
+    return fmt_urdf_num(v)
 
 
 def _flip_axis_in_urdf(pkg_dir, urdf_rel, joint_name):

--- a/sw2robot/exporter/geometry.py
+++ b/sw2robot/exporter/geometry.py
@@ -11,8 +11,13 @@ so the column-vector rotation matrix is ``reshape(r,(3,3)).T``.  Translations
 are in METRES (the SW API is metric), which is what URDF wants.
 
 Only helpers with sw2robot-specific behaviour live here (SW marshalling, URDF
-text stability, strict ``<origin>`` parsing).  Plain rotation/transform math is
-imported straight from ``skrobot.coordinates.math`` at each call site --
+text stability, ``<origin>`` parsing and writing).  BOTH directions of the
+``<origin>`` round trip are in this module -- ``urdf_origin_matrix`` reads,
+``set_urdf_origin`` / ``fmt_urdf_num`` write -- so neither the rpy convention
+nor the number formatting can drift between the exporter and the editor.
+
+Plain rotation/transform math is imported straight from
+``skrobot.coordinates.math`` at each call site --
 ``matrix_relative`` for parent^-1 @ child, ``rpy2homogeneous`` / ``rpy2matrix``
 for rpy -> matrix (URDF convention, extrinsic X-Y-Z: R = Rz @ Ry @ Rx).
 NB: skrobot's legacy ``rpy_matrix(yaw, pitch, roll)`` takes its arguments in
@@ -20,6 +25,8 @@ the OPPOSITE order -- avoid it.
 """
 
 from __future__ import annotations
+
+import xml.etree.ElementTree as ET
 
 import numpy as np
 from skrobot.coordinates.math import (
@@ -53,7 +60,7 @@ def matrix_to_xyz_rpy(M):
     # snap sub-1e-12 values (metres / radians -- far below any physical
     # significance) to EXACT 0: the SVD in orthonormalize_rotation_matrix
     # leaves BLAS-dependent noise (~1e-16..1e-33) that differs per platform,
-    # and %.8g would faithfully print it, breaking cross-platform golden
+    # and fmt_urdf_num would faithfully print it, breaking cross-platform golden
     # comparisons of the URDF text.  Also folds IEEE negative zeros.
     def _snap(v):
         v = float(v)
@@ -61,19 +68,68 @@ def matrix_to_xyz_rpy(M):
     return [_snap(v) for v in xyz], [_snap(v) for v in rpy]
 
 
-def urdf_origin_matrix(el):
+def urdf_origin_matrix(el, strict=True):
     """4x4 from a URDF ``<origin>`` element (xyz + extrinsic-XYZ rpy
     attributes), or identity when the element is absent.  The ONE parser for
     ``<origin>`` -- exporter and editor both route through it so the rpy
-    convention cannot drift between modules."""
+    convention cannot drift between modules.
+
+    ``strict`` (the default) is for URDFs sw2robot itself wrote: a wrong-length
+    ``xyz`` / ``rpy`` there is an exporter bug, and raising surfaces it.  Pass
+    ``strict=False`` for URDFs that arrived from outside -- hand-edited files,
+    other tool chains -- where a single malformed attribute must not take the
+    editor down with it; that attribute alone falls back to zeros."""
     if el is None:
         return np.eye(4)
-    xyz = [float(x) for x in (el.get("xyz") or "0 0 0").split()]
-    rpy = [float(x) for x in (el.get("rpy") or "0 0 0").split()]
-    if len(xyz) != 3 or len(rpy) != 3:
-        raise ValueError(
-            "malformed <origin>: expected 3 values each, got "
-            f"xyz={el.get('xyz')!r} rpy={el.get('rpy')!r}")
+    vecs = []
+    for attr in ("xyz", "rpy"):
+        v = [float(x) for x in (el.get(attr) or "0 0 0").split()]
+        if len(v) != 3:
+            if strict:
+                raise ValueError(
+                    "malformed <origin>: expected 3 values each, got "
+                    f"xyz={el.get('xyz')!r} rpy={el.get('rpy')!r}")
+            v = [0.0, 0.0, 0.0]
+        vecs.append(v)
+    xyz, rpy = vecs
     M = rpy2homogeneous(*rpy)
     M[:3, 3] = xyz
     return M
+
+
+def fmt_urdf_num(v):
+    """One float -> URDF attribute text.
+
+    ``%.10g``: an editor edit re-writes every ``<origin>`` it touches, so the
+    text is the storage format and has to survive write -> read -> write
+    unchanged.  10 significant digits keep a millimetre-scale coordinate exact
+    to well below a nanometre while staying readable; the 8 digits some call
+    sites used to print truncated the value on the first edit.
+
+    This is pure formatting -- no rounding.  Floating-point noise is snapped
+    where it is produced (``matrix_to_xyz_rpy``), not here, so a small number
+    that reached this function is a real one.  The single exception is IEEE
+    negative zero, which prints as ``0``: ``-0`` is legal XML but reads as a
+    bug in an exported file.
+    """
+    v = float(v)
+    return "0" if v == 0.0 else f"{v:.10g}"
+
+
+def fmt_urdf_vec(vec):
+    """A vector -> a space-separated URDF attribute value."""
+    return " ".join(fmt_urdf_num(x) for x in vec)
+
+
+def set_urdf_origin(el, M):
+    """Write/overwrite ``el``'s ``<origin>`` child from a 4x4 matrix.
+
+    A missing ``<origin>`` is created first among ``el``'s children, the
+    position URDF conventionally puts it in."""
+    origin = el.find("origin")
+    if origin is None:
+        origin = ET.Element("origin")
+        el.insert(0, origin)
+    xyz, rpy = matrix_to_xyz_rpy(M)
+    origin.set("xyz", fmt_urdf_vec(xyz))
+    origin.set("rpy", fmt_urdf_vec(rpy))

--- a/sw2robot/exporter/geometry.py
+++ b/sw2robot/exporter/geometry.py
@@ -106,11 +106,11 @@ def fmt_urdf_num(v):
     to well below a nanometre while staying readable; the 8 digits some call
     sites used to print truncated the value on the first edit.
 
-    This is pure formatting -- no rounding.  Floating-point noise is snapped
-    where it is produced (``matrix_to_xyz_rpy``), not here, so a small number
-    that reached this function is a real one.  The single exception is IEEE
-    negative zero, which prints as ``0``: ``-0`` is legal XML but reads as a
-    bug in an exported file.
+    Rounding stops at that 10th digit and goes no further: floating-point
+    noise is snapped where it is produced (``matrix_to_xyz_rpy``), not here,
+    so a very small number that reaches this function is a real one and prints
+    as itself.  The single exception is IEEE negative zero, which prints as
+    ``0``: ``-0`` is legal XML but reads as a bug in an exported file.
     """
     v = float(v)
     return "0" if v == 0.0 else f"{v:.10g}"

--- a/sw2robot/exporter/merge.py
+++ b/sw2robot/exporter/merge.py
@@ -25,22 +25,13 @@ import xml.etree.ElementTree as ET
 
 from skrobot.utils.inertia import combine_inertials, transform_inertial
 
-from .geometry import matrix_to_xyz_rpy, urdf_origin_matrix
-
-
-def _fmt(v):
-    # compact, round-trippable; mirror the writer's style (no sci-notation noise)
-    return f"{float(v):.10g}"
-
-
-def _set_origin(parent_el, M):
-    """Write/overwrite ``parent_el``'s ``<origin>`` from a 4x4 matrix."""
-    xyz, rpy = matrix_to_xyz_rpy(M)
-    o = parent_el.find("origin")
-    if o is None:
-        o = ET.SubElement(parent_el, "origin")
-    o.set("xyz", " ".join(_fmt(v) for v in xyz))
-    o.set("rpy", " ".join(_fmt(v) for v in rpy))
+from .geometry import (
+    fmt_urdf_num,
+    fmt_urdf_vec,
+    matrix_to_xyz_rpy,
+    set_urdf_origin,
+    urdf_origin_matrix,
+)
 
 
 def _has_geometry(link_el):
@@ -88,13 +79,13 @@ def _write_inertial(link_el, info):
         link_el.remove(old)
     el = ET.SubElement(link_el, "inertial")
     o = ET.SubElement(el, "origin")
-    o.set("xyz", " ".join(_fmt(v) for v in info["com"]))
+    o.set("xyz", fmt_urdf_vec(info["com"]))
     o.set("rpy", "0 0 0")
-    ET.SubElement(el, "mass").set("value", _fmt(info["mass"]))
+    ET.SubElement(el, "mass").set("value", fmt_urdf_num(info["mass"]))
     it = ET.SubElement(el, "inertia")
     for k, v in zip(("ixx", "ixy", "ixz", "iyy", "iyz", "izz"),
                     info["inertia"]):
-        it.set(k, _fmt(v))
+        it.set(k, fmt_urdf_num(v))
 
 
 def _combine_inertials(parent_el, child_el, T_pc):
@@ -182,7 +173,7 @@ def merge_fixed_links(root, force_merge=None, only=None):
         for vc in list(child_link):
             if vc.tag not in ("visual", "collision"):
                 continue
-            _set_origin(vc, T_pc @ urdf_origin_matrix(vc.find("origin")))
+            set_urdf_origin(vc, T_pc @ urdf_origin_matrix(vc.find("origin")))
             child_link.remove(vc)
             parent_link.append(vc)
         # 2) combine inertials
@@ -192,7 +183,7 @@ def merge_fixed_links(root, force_merge=None, only=None):
             kp = k.find("parent")
             if kp is not None and kp.get("link") == cname:
                 kp.set("link", pname)
-                _set_origin(k, T_pc @ urdf_origin_matrix(k.find("origin")))
+                set_urdf_origin(k, T_pc @ urdf_origin_matrix(k.find("origin")))
         # 4) drop the fixed joint and the (now empty) child link
         root.remove(j)
         root.remove(child_link)

--- a/sw2robot/exporter/ros_export.py
+++ b/sw2robot/exporter/ros_export.py
@@ -36,6 +36,12 @@ from skrobot.utils.convex_decomposition import (
     is_coacd_available,
 )
 
+from .geometry import (
+    fmt_urdf_num,
+    fmt_urdf_vec,
+    set_urdf_origin,
+    urdf_origin_matrix,
+)
 from .urdf_writer import (
     CMAKELISTS,
     CMAKELISTS_ROS2,
@@ -487,17 +493,16 @@ def _primitive_geometry_el(params):
     geo = ET.Element("geometry")
     t = params["type"]
     if t == "box":
-        ET.SubElement(geo, "box").set(
-            "size", " ".join(_fmt_num(v) for v in params["extents"]))
+        ET.SubElement(geo, "box").set("size", fmt_urdf_vec(params["extents"]))
     elif t == "sphere":
-        ET.SubElement(geo, "sphere").set("radius", _fmt_num(params["radius"]))
+        ET.SubElement(geo, "sphere").set("radius", fmt_urdf_num(params["radius"]))
     elif t in ("cylinder", "capsule"):
         cyl = ET.SubElement(geo, "cylinder")
-        cyl.set("radius", _fmt_num(params["radius"]))
+        cyl.set("radius", fmt_urdf_num(params["radius"]))
         length = float(params["height"])
         if t == "capsule":            # URDF has no capsule; fold the caps in
             length += 2 * float(params["radius"])
-        cyl.set("length", _fmt_num(length))
+        cyl.set("length", fmt_urdf_num(length))
     else:
         raise ValueError(f"unsupported primitive type: {t!r}")
     return geo
@@ -525,34 +530,6 @@ _COLLISION_PALETTE = (
     (210, 210, 40), (166, 86, 40), (247, 129, 191), (102, 194, 165),
     (141, 160, 203), (153, 153, 153),
 )
-
-
-def _origin_matrix(origin_el):
-    """4x4 transform for a URDF ``<origin>`` element (xyz + fixed-axis rpy), or
-    identity when absent -- to bake a ``<collision>``'s origin into its part
-    vertices so a preview mesh sits right when attached at the link frame."""
-    from .geometry import urdf_origin_matrix
-    return urdf_origin_matrix(origin_el)
-
-
-def _fmt_num(v):
-    """Format a float for a URDF attribute, snapping FP noise to exact 0."""
-    v = float(v)
-    if abs(v) < 1e-9:
-        return "0"
-    return repr(round(v, 9))
-
-
-def _set_origin_el(el, M):
-    import numpy as np
-
-    from .geometry import matrix_to_xyz_rpy
-    o = el.find("origin")
-    if o is None:
-        o = ET.SubElement(el, "origin")
-    xyz, rpy = matrix_to_xyz_rpy(np.asarray(M, float))
-    o.set("xyz", " ".join(_fmt_num(v) for v in xyz))
-    o.set("rpy", " ".join(_fmt_num(v) for v in rpy))
 
 
 def _tf_marker_scale(root, pkg_dir, own_pkgs, cache):
@@ -609,7 +586,7 @@ def _bake_origins(root, pkg_dir, own_pkgs, cache):
         pj = child_joint.get(name)
         fixed = pj is not None and pj.get("type") == "fixed"
         vis = link.find("visual")
-        v_mat = _origin_matrix(vis.find("origin")) if vis is not None \
+        v_mat = urdf_origin_matrix(vis.find("origin")) if vis is not None \
             else np.eye(4)
         d = np.zeros(3)
         if vis is not None:
@@ -631,15 +608,15 @@ def _bake_origins(root, pkg_dir, own_pkgs, cache):
             # F' = F . T(+d): parent joint . T(+d); child joints, inertial . T(-d)
             t_pos = np.eye(4)
             t_pos[:3, 3] = d
-            _set_origin_el(pj, _origin_matrix(pj.find("origin")) @ t_pos)
+            set_urdf_origin(pj, urdf_origin_matrix(pj.find("origin")) @ t_pos)
             for cj in child_lists.get(name, []):
-                _set_origin_el(cj, t_neg @ _origin_matrix(cj.find("origin")))
+                set_urdf_origin(cj, t_neg @ urdf_origin_matrix(cj.find("origin")))
             inel = link.find("inertial")
             if inel is not None:
-                _set_origin_el(inel, t_neg @ _origin_matrix(inel.find("origin")))
+                set_urdf_origin(inel, t_neg @ urdf_origin_matrix(inel.find("origin")))
         for ctx in ("visual", "collision"):
             for block in link.findall(ctx):
-                vb = _origin_matrix(block.find("origin"))
+                vb = urdf_origin_matrix(block.find("origin"))
                 mb = t_neg @ vb                # bake into the mesh
                 # only bake when it actually moves vertices; an identity (or pure
                 # FP-noise) origin just gets zeroed -- no lossy mesh round-trip,
@@ -736,7 +713,7 @@ def collision_preview_glbs(pkg_dir, robot_name, quality="balanced", progress=Non
             _b, src, _e = _resolve_mesh(pkg_dir, ms[0].get("filename"),
                                         own_pkgs=own_pkgs)
             if src:
-                blocks.append((src, _origin_matrix(block.find("origin"))))
+                blocks.append((src, urdf_origin_matrix(block.find("origin"))))
         (mesh_links if blocks else plain_links).append((name, blocks))
 
     out = {}
@@ -1267,7 +1244,7 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
             for k, name in enumerate(names):
                 nb = copy.deepcopy(block)
                 if m_bake is not None:         # parts are in the source frame:
-                    _set_origin_el(nb, m_bake)  # carry the bake transform here
+                    set_urdf_origin(nb, m_bake)  # carry the bake transform here
                 next(nb.iter("mesh")).set(
                     "filename", f"package://{pkg}/{mesh_rel}/{name}")
                 link.insert(idx + k, nb)
@@ -1312,7 +1289,7 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
             # are kept, via the block's own <origin>
             m_bake = bake.get(id(meshes[0]))
             base_M = m_bake if m_bake is not None \
-                else _origin_matrix(block.find("origin"))
+                else urdf_origin_matrix(block.find("origin"))
             geo = block.find("geometry")
             new_geo = _primitive_geometry_el(params)
             if geo is not None:                # stdlib ElementTree: no .replace()
@@ -1321,7 +1298,7 @@ def build_ros_description(pkg_dir, robot_name, email="auto@example.com",
                 block.insert(gi, new_geo)
             else:
                 block.append(new_geo)
-            _set_origin_el(block, np.asarray(base_M, float) @ M)
+            set_urdf_origin(block, np.asarray(base_M, float) @ M)
 
     _warm_lock = threading.Lock()
     _warm_state = {"n": 0}

--- a/sw2robot/exporter/urdf_writer.py
+++ b/sw2robot/exporter/urdf_writer.py
@@ -25,6 +25,7 @@ from skrobot.utils.inertia import (
     validate_inertia,
 )
 
+from .geometry import fmt_urdf_vec
 from .inertia import link_inertial
 from .model import safe_name
 
@@ -33,10 +34,6 @@ _PLACEHOLDER_INERTIAL = {
     "mass": 0.1, "com": [0.0, 0.0, 0.0],
     "inertia": (1e-4, 0.0, 0.0, 1e-4, 0.0, 1e-4), "method": "placeholder",
 }
-
-
-def _fmt(v):
-    return " ".join(f"{x:.8g}" for x in v)
 
 
 def _comment_safe(text):
@@ -127,7 +124,7 @@ def _inertial_xml(comp, mesh_dir, density):
     ixx, ixy, ixz, iyy, iyz, izz = info["inertia"]
     lines = [
         "    <inertial>",
-        f'      <origin xyz="{_fmt(info["com"])}" rpy="0 0 0"/>',
+        f'      <origin xyz="{fmt_urdf_vec(info["com"])}" rpy="0 0 0"/>',
         f'      <mass value="{info["mass"]:.6g}"/>',
         f'      <inertia ixx="{ixx:.6g}" ixy="{ixy:.6g}" ixz="{ixz:.6g}" '
         f'iyy="{iyy:.6g}" iyz="{iyz:.6g}" izz="{izz:.6g}"/>',
@@ -177,8 +174,8 @@ def _link_xml(comp, ros_pkg=None, rn=lambda n: n, mesh_dir=None, density=None):
     if comp.mesh_file and not getattr(comp, "mass_only", False):
         mesh_ref = ("package://{}/{}".format(ros_pkg, comp.mesh_file.replace("\\", "/"))
                     if ros_pkg else "../" + comp.mesh_file.replace("\\", "/"))
-        vorigin = (f'      <origin xyz="{_fmt(comp.visual_xyz)}" '
-                   f'rpy="{_fmt(comp.visual_rpy)}"/>')
+        vorigin = (f'      <origin xyz="{fmt_urdf_vec(comp.visual_xyz)}" '
+                   f'rpy="{fmt_urdf_vec(comp.visual_rpy)}"/>')
         for tag in ("visual", "collision"):
             lines.append(f"    <{tag}>")
             lines.append(vorigin)
@@ -227,11 +224,12 @@ def _physics_lines(joint):
 
 def _joint_xml(joint, rn=lambda n: n, jn=lambda n: n):
     lines = [f'  <joint name="{jn(joint.name)}" type="{joint.jtype}">']
-    lines.append(f'    <origin xyz="{_fmt(joint.xyz)}" rpy="{_fmt(joint.rpy)}"/>')
+    lines.append(f'    <origin xyz="{fmt_urdf_vec(joint.xyz)}" '
+                 f'rpy="{fmt_urdf_vec(joint.rpy)}"/>')
     lines.append(f'    <parent link="{rn(joint.parent)}"/>')
     lines.append(f'    <child link="{rn(joint.child)}"/>')
     if joint.axis is not None:
-        lines.append(f'    <axis xyz="{_fmt(joint.axis)}"/>')
+        lines.append(f'    <axis xyz="{fmt_urdf_vec(joint.axis)}"/>')
     eff = getattr(joint, "effort", None)
     vel = getattr(joint, "velocity", None)
     eff = 10 if eff is None else eff
@@ -275,7 +273,7 @@ def _port_xml(port, rn=lambda n: n, link_name=None, joint_name=None):
     return "\n".join([
         f'  <link name="{link_name}"/>',
         f'  <joint name="{joint_name}" type="fixed">',
-        f'    <origin xyz="{_fmt(port.xyz)}" rpy="{_fmt(port.rpy)}"/>',
+        f'    <origin xyz="{fmt_urdf_vec(port.xyz)}" rpy="{fmt_urdf_vec(port.rpy)}"/>',
         f'    <parent link="{rn(port.parent_link)}"/>',
         f'    <child link="{link_name}"/>',
         "  </joint>",

--- a/tests/golden/fingertip_base.urdf
+++ b/tests/golden/fingertip_base.urdf
@@ -3,13 +3,13 @@
   <link name="fingertip_back_1">
     <!-- sw2robot inertia="hull" -->
     <visual>
-      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 0 3.1415927"/>
+      <origin xyz="-0.02103948669 0.0155 0.031" rpy="3.141592654 0 3.141592654"/>
       <geometry>
         <mesh filename="../meshes/fingertip_back_1.3dxml"/>
       </geometry>
     </visual>
     <collision>
-      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 0 3.1415927"/>
+      <origin xyz="-0.02103948669 0.0155 0.031" rpy="3.141592654 0 3.141592654"/>
       <geometry>
         <mesh filename="../meshes/fingertip_back_1.3dxml"/>
       </geometry>
@@ -49,14 +49,14 @@
     <inertial/>
   </link>
   <joint name="fingertip_front_2__screwlock_male_hard_jointbase_v4_1" type="fixed">
-    <origin xyz="0 -0.0155 0.038" rpy="1.5707963 0 -3.1415927"/>
+    <origin xyz="0 -0.0155 0.038" rpy="1.570796327 0 -3.141592654"/>
     <parent link="base_link"/>
     <child link="screwlock_male_hard_jointbase_v4_1"/>
-    <axis xyz="-0 -0 1"/>
+    <axis xyz="0 0 1"/>
     <!-- mates: CONCENTRIC, COINCIDENT, PARALLEL, CONCENTRIC, COINCIDENT, PARALLEL -->
   </joint>
   <joint name="fingertip_front_2__fingertip_back_1" type="revolute">
-    <origin xyz="0.021039487 -0.0155 0.031" rpy="3.1415927 0 0"/>
+    <origin xyz="0.02103948669 -0.0155 0.031" rpy="3.141592654 0 0"/>
     <parent link="base_link"/>
     <child link="fingertip_back_1"/>
     <axis xyz="0 1 0"/>

--- a/tests/golden/fingertip_edited.urdf
+++ b/tests/golden/fingertip_edited.urdf
@@ -3,13 +3,13 @@
   <link name="tip">
     <!-- sw2robot inertia="hull" -->
     <visual>
-      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 0 3.1415927"/>
+      <origin xyz="-0.02103948669 0.0155 0.031" rpy="3.141592654 0 3.141592654"/>
       <geometry>
         <mesh filename="../meshes/fingertip_back_1.3dxml"/>
       </geometry>
     </visual>
     <collision>
-      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 0 3.1415927"/>
+      <origin xyz="-0.02103948669 0.0155 0.031" rpy="3.141592654 0 3.141592654"/>
       <geometry>
         <mesh filename="../meshes/fingertip_back_1.3dxml"/>
       </geometry>
@@ -35,13 +35,13 @@
   <link name="screwlock_male_hard_jointbase_v4_1">
     <!-- sw2robot material="ABS" density="1020" inertia="hull" -->
     <visual>
-      <origin xyz="0 0.017 -0.003" rpy="-1.5707963 0 -3.1415927"/>
+      <origin xyz="0 0.017 -0.003" rpy="-1.570796327 0 -3.141592654"/>
       <geometry>
         <mesh filename="../meshes/screwlock_male_hard_jointbase_v4_1.3dxml"/>
       </geometry>
     </visual>
     <collision>
-      <origin xyz="0 0.017 -0.003" rpy="-1.5707963 0 -3.1415927"/>
+      <origin xyz="0 0.017 -0.003" rpy="-1.570796327 0 -3.141592654"/>
       <geometry>
         <mesh filename="../meshes/screwlock_male_hard_jointbase_v4_1.3dxml"/>
       </geometry>
@@ -49,15 +49,15 @@
     <inertial/>
   </link>
   <joint name="fingertip_front_2__screwlock_male_hard_jointbase_v4_1" type="revolute">
-    <origin xyz="0 0.0015 0.035" rpy="3.1415927 0 0"/>
+    <origin xyz="0 0.0015 0.035" rpy="3.141592654 0 0"/>
     <parent link="base_link"/>
     <child link="screwlock_male_hard_jointbase_v4_1"/>
-    <axis xyz="0 -1 -0"/>
+    <axis xyz="0 -1 0"/>
     <limit lower="-0.5" upper="0.5" effort="10" velocity="3.14"/>
     <!-- mates: CONCENTRIC, COINCIDENT, PARALLEL, CONCENTRIC, COINCIDENT, PARALLEL -->
   </joint>
   <joint name="bend" type="revolute">
-    <origin xyz="0.021039487 -0.0155 0.031" rpy="3.1415927 0 0"/>
+    <origin xyz="0.02103948669 -0.0155 0.031" rpy="3.141592654 0 0"/>
     <parent link="base_link"/>
     <child link="tip"/>
     <axis xyz="0 1 0"/>

--- a/tests/golden/fingertip_flip.urdf
+++ b/tests/golden/fingertip_flip.urdf
@@ -3,13 +3,13 @@
   <link name="fingertip_back_1">
     <!-- sw2robot inertia="hull" -->
     <visual>
-      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 0 3.1415927"/>
+      <origin xyz="-0.02103948669 0.0155 0.031" rpy="3.141592654 0 3.141592654"/>
       <geometry>
         <mesh filename="../meshes/fingertip_back_1.3dxml"/>
       </geometry>
     </visual>
     <collision>
-      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 0 3.1415927"/>
+      <origin xyz="-0.02103948669 0.0155 0.031" rpy="3.141592654 0 3.141592654"/>
       <geometry>
         <mesh filename="../meshes/fingertip_back_1.3dxml"/>
       </geometry>
@@ -49,14 +49,14 @@
     <inertial/>
   </link>
   <joint name="fingertip_front_2__screwlock_male_hard_jointbase_v4_1" type="fixed">
-    <origin xyz="0 -0.0155 0.038" rpy="1.5707963 0 -3.1415927"/>
+    <origin xyz="0 -0.0155 0.038" rpy="1.570796327 0 -3.141592654"/>
     <parent link="base_link"/>
     <child link="screwlock_male_hard_jointbase_v4_1"/>
-    <axis xyz="-0 -0 1"/>
+    <axis xyz="0 0 1"/>
     <!-- mates: CONCENTRIC, COINCIDENT, PARALLEL, CONCENTRIC, COINCIDENT, PARALLEL -->
   </joint>
   <joint name="fingertip_front_2__fingertip_back_1" type="revolute">
-    <origin xyz="0.021039487 -0.0155 0.031" rpy="3.1415927 0 0"/>
+    <origin xyz="0.02103948669 -0.0155 0.031" rpy="3.141592654 0 0"/>
     <parent link="base_link"/>
     <child link="fingertip_back_1"/>
     <axis xyz="0 -1 0"/>

--- a/tests/golden/fingertip_rename_direct.urdf
+++ b/tests/golden/fingertip_rename_direct.urdf
@@ -3,13 +3,13 @@
   <link name="tip">
     <!-- sw2robot inertia="hull" -->
     <visual>
-      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 0 3.1415927"/>
+      <origin xyz="-0.02103948669 0.0155 0.031" rpy="3.141592654 0 3.141592654"/>
       <geometry>
         <mesh filename="../meshes/fingertip_back_1.3dxml"/>
       </geometry>
     </visual>
     <collision>
-      <origin xyz="-0.021039487 0.0155 0.031" rpy="3.1415927 0 3.1415927"/>
+      <origin xyz="-0.02103948669 0.0155 0.031" rpy="3.141592654 0 3.141592654"/>
       <geometry>
         <mesh filename="../meshes/fingertip_back_1.3dxml"/>
       </geometry>
@@ -49,14 +49,14 @@
     <inertial/>
   </link>
   <joint name="fingertip_front_2__screwlock_male_hard_jointbase_v4_1" type="fixed">
-    <origin xyz="0 -0.0155 0.038" rpy="1.5707963 0 -3.1415927"/>
+    <origin xyz="0 -0.0155 0.038" rpy="1.570796327 0 -3.141592654"/>
     <parent link="base_link"/>
     <child link="screwlock_male_hard_jointbase_v4_1"/>
-    <axis xyz="-0 -0 1"/>
+    <axis xyz="0 0 1"/>
     <!-- mates: CONCENTRIC, COINCIDENT, PARALLEL, CONCENTRIC, COINCIDENT, PARALLEL -->
   </joint>
   <joint name="bend" type="revolute">
-    <origin xyz="0.021039487 -0.0155 0.031" rpy="3.1415927 0 0"/>
+    <origin xyz="0.02103948669 -0.0155 0.031" rpy="3.141592654 0 0"/>
     <parent link="base_link"/>
     <child link="tip"/>
     <axis xyz="0 1 0"/>


### PR DESCRIPTION
Four modules each wrote URDF `<origin>` with their own float formatter (`%.10g`, `repr(round(v, 9))`, `%.8g` twice), so the same coordinate printed differently depending on which path touched it last, and an editor edit silently truncated an exported origin from 10 digits to 8; `fmt_urdf_num` / `fmt_urdf_vec` / `set_urdf_origin` now live next to the parser and everything routes through them.
`%.10g` is the precision because it is the highest any call site already used, so nothing is degraded — origins are the storage format for an editor edit and have to survive write → read → write unchanged. `urdf_origin_matrix` grows a `strict=` flag instead of the editor keeping a second copy: strict for URDFs sw2robot wrote, tolerant for hand-edited files it only reads.
The golden URDFs are re-baselined: 22 lines, purely two extra significant digits and `<axis>` losing `-0`, with no coordinate moved, and the generated ROS package is content-identical between Windows and Linux.