### PR TITLE
feat(exporter): import the embedded SW2URDF configuration automatically

### DIFF
--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -1591,6 +1591,8 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     'hist.fail': { en: a => `${a.which} failed: ${a.e}`, ja: a => `${a.which} に失敗: ${a.e}` },
     // open / extract
     'open.fail': { en: a => `open failed: ${a.e}`, ja: a => `オープンに失敗: ${a.e}` },
+    'open.foundAsm': { en: a => `no package here, but found ${a.name} → SolidWorks extract`, ja: a => `パッケージは無いが ${a.name} を発見 → SolidWorks 抽出を開始` },
+    'open.manyAsm': { en: a => `no package here; ${a.n} assemblies inside — open the .SLDASM you want (🗄)`, ja: a => `パッケージが無く、アセンブリが ${a.n} 個あります — 開きたい .SLDASM を選んでください (🗄)` },
     'time.sec': { en: a => `${a.s}s`, ja: a => `${a.s}秒` },
     'time.minSec': { en: a => `${a.m}m${a.s}s`, ja: a => `${a.m}分${a.s}秒` },
     'extract.request': { en: a => `requesting SolidWorks extraction: ${a.p}`, ja: a => `SolidWorks 抽出を要求: ${a.p}` },

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -166,6 +166,24 @@ def _resolve_package(path):
     raise ValueError(f"not a package dir or .urdf file: {path}")
 
 
+def _dir_is_package(path):
+    """True when :func:`_resolve_package` would open ``path``: a ``*.urdf``
+    sits DIRECTLY in ``path/urdf/`` or in ``path`` itself.  A bare ``urdf/``
+    subdirectory is not enough -- CAD folders often carry an unrelated
+    ``urdf/`` tree (e.g. an old export one level deeper), and flagging them
+    as packages makes the file browser open them instead of navigating."""
+    for sub in ("urdf", "."):
+        d = os.path.normpath(os.path.join(path, sub))
+        try:
+            names = os.listdir(d)
+        except OSError:
+            continue
+        if any(n.lower().endswith(".urdf") and not n.startswith(".")
+               for n in names):
+            return True
+    return False
+
+
 # --- URDF-input editing mode -------------------------------------------------
 # A package WITHOUT a graph.json is a plain URDF the user opened directly: there
 # is no CAD graph to rebuild from, so edits cannot go through joints.yaml +
@@ -4935,9 +4953,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                         if e.startswith(("~$", ".")):
                             continue
                         if os.path.isdir(full):
-                            pkg = os.path.isdir(os.path.join(full, "urdf"))
                             dirs.append({"name": e, "path": full,
-                                         "package": pkg})
+                                         "package": _dir_is_package(full)})
                         elif e.lower().endswith((".sldasm", ".sldprt", ".urdf")):
                             files.append({"name": e, "path": full})
                 except OSError as e:

--- a/sw2robot/exporter/export.py
+++ b/sw2robot/exporter/export.py
@@ -38,7 +38,9 @@ from .model import (
     extract_limit_joints,
     extract_part_graph,
     extract_reference_axes,
+    extract_reference_geometry,
     extract_subgraphs,
+    extract_sw2urdf_attribute,
     safe_name,
     to_graph_state,
 )
@@ -95,12 +97,16 @@ def _extract_part_into(sw, part_path, pkg_dir, meshes_dir, robot_name, _say):
     export_part_mesh(doc, comps[0], meshes_dir)
 
     _say("saving graph.json ...")
-    coordinate_systems = extract_coordinate_systems(doc)
-    reference_axes = extract_reference_axes(doc)
+    (coordinate_systems,
+     reference_axes,
+     sw2urdf_marker,
+     sw2urdf_config_xml) = extract_reference_geometry(doc)
     graph = to_graph_state(
         comps, adjacency, ground, robot_name, part_path,
         coordinate_systems=coordinate_systems,
-        reference_axes=reference_axes)
+        reference_axes=reference_axes,
+        sw2urdf_marker=sw2urdf_marker,
+        sw2urdf_config_xml=sw2urdf_config_xml)
     graph.save(os.path.join(pkg_dir, GRAPH_FILE))
     sw.close_doc(doc)
     return pkg_dir
@@ -140,8 +146,10 @@ def _extract_into(sw, assembly_path, pkg_dir, meshes_dir, robot_name, _say,
     _say("reading components + mates ...")
     comps, adjacency, ground = extract_graph(doc, robot_name, assembly_path,
                                              progress=_part)
-    coordinate_systems = extract_coordinate_systems(doc)
-    reference_axes = extract_reference_axes(doc)
+    (coordinate_systems,
+     reference_axes,
+     sw2urdf_marker,
+     sw2urdf_config_xml) = extract_reference_geometry(doc)
     _say(f"found {len(comps)} components, {len(adjacency)} mate pairs")
     if not comps:
         sw.close_doc(doc)
@@ -199,6 +207,8 @@ def _extract_into(sw, assembly_path, pkg_dir, meshes_dir, robot_name, _say,
                            hidden=hidden, limit_joints=limit_joints,
                            coordinate_systems=coordinate_systems,
                            reference_axes=reference_axes,
+                           sw2urdf_marker=sw2urdf_marker,
+                           sw2urdf_config_xml=sw2urdf_config_xml,
                            subassembly_coordinate_systems=
                            subassembly_coordinate_systems)
     graph.save(os.path.join(pkg_dir, GRAPH_FILE))
@@ -348,6 +358,8 @@ def refresh_frames(target, out_dir=None, robot_name=None, visible=False,
             _say("re-reading coordinate systems + reference axes ...")
             graph.coordinate_systems = extract_coordinate_systems(doc)
             graph.reference_axes = extract_reference_axes(doc)
+            (graph.sw2urdf_marker,
+             graph.sw2urdf_config_xml) = extract_sw2urdf_attribute(doc)
             if graph.subassemblies:
                 live = _live_subassembly_docs(doc)
                 for path, sub in graph.subassemblies.items():
@@ -430,6 +442,21 @@ def build(pkg_dir, config_path=None, base_hint=None, exclude=None,
     # The working URDF KEEPS each mass-only link (geometry stripped) so it stays
     # selectable in the editor tree; only the exported package folds it away.
     mass_only_links = write_urdf(model, urdf_path, **urdf_kwargs)
+    # An SW2URDF config may bundle several loose components into ONE link;
+    # they leave the tree as fixed children, so lump exactly those back into
+    # their parent to reproduce the authored link granularity.
+    if getattr(model, "lumped_links", None):
+        import xml.etree.ElementTree as _ET
+
+        from skrobot.urdf import merge_fixed_links
+        _tree = _ET.parse(urdf_path)
+        _root = _tree.getroot()          # skrobot merges IN PLACE
+        _res = merge_fixed_links(_root, only=list(model.lumped_links))
+        _n = _res[0] if isinstance(_res, tuple) else _res
+        if _n:
+            _tree.write(urdf_path, encoding="utf-8", xml_declaration=True)
+            print(f"      SW2URDF config: lumped {_n} member link(s) into "
+                  "their configured link")
     # Surface parts that resolved + got a mesh but whose geometry never makes it
     # into the URDF (classic case: a sub-assembly kept as one composed mesh whose
     # 3DXML export config suppresses some children).  Best-effort: warn_dropped_

--- a/sw2robot/exporter/jointcfg.py
+++ b/sw2robot/exporter/jointcfg.py
@@ -92,6 +92,8 @@ def write_template(model, path):
         "# type: fixed | revolute | prismatic | continuous",
         "# Sub-assemblies with moving internals expand automatically;",
         "# override with  expand: [name-substr]  /  no_expand: [name-substr]",
+        "# Embedded SW2URDF CoordSys/RefAxis config auto-applies when present;",
+        "# set sw2urdf_config: off | require  to disable or enforce it",
         "# Optional per-joint actuator/physics (movable joints only):",
         "#   effort: 5   velocity: 2   dynamics: {damping: 0.1, friction: 0.0}",
         "#   safety_controller: {soft_lower_limit: -1, soft_upper_limit: 1,"

--- a/sw2robot/exporter/model.py
+++ b/sw2robot/exporter/model.py
@@ -39,6 +39,13 @@ from .state import (
     ReferenceAxisState,
     SubGraph,
 )
+from .sw2urdf_import import (
+    detect_sw2urdf_reference_geometry,
+    parse_sw2urdf_payload,
+    reconstruct_sw2urdf_config,
+    reconstruct_sw2urdf_config_from_payload,
+    reconstruct_sw2urdf_config_geometric,
+)
 from .swcom import as_iface, safe_call, safe_prop
 
 MATE_TYPES = {0: "COINCIDENT", 1: "CONCENTRIC", 2: "PERPENDICULAR",
@@ -364,6 +371,10 @@ class RobotModel:
     # closed-loop (four-bar / parallel) data for the runtime-IK relay:
     # {closures:[{link_a,link_b,point,axis}], dependent:[...], independent:[...]}
     loop_closures: dict | None = None
+    # link names an SW2URDF config declares as members of their parent link
+    # (several loose components per link): the writer lumps them so the URDF
+    # has the link granularity the config author intended.
+    lumped_links: list = field(default_factory=list)
 
 
 def _match_component(comps, ref):
@@ -465,7 +476,8 @@ def resolve_directed(comps, joints_cfg):
         if not (np_ and nc):
             print(f"      WARN: joint config '{pa}->{ca}' did not match links")
             continue
-        out.append({"parent": np_, "child": nc,
+        out.append({"name": j.get("name"),
+                    "parent": np_, "child": nc,
                     "type": j.get("type", "fixed"),
                     "lower": j.get("lower"), "upper": j.get("upper"),
                     "axis_point": j.get("axis_point"),
@@ -2423,6 +2435,7 @@ def _config_parent_map(comps, adjacency, base, directed):
             lo = olo if lo is None else lo
             up = ohi if up is None else up
         edge_info[(child, parent)] = {
+            "name": d.get("name"),
             "type": jtype, "axis": ax,
             "lower": -3.141592 if lo is None else lo,
             "upper": 3.141592 if up is None else up,
@@ -2464,7 +2477,7 @@ def _config_parent_map(comps, adjacency, base, directed):
 
 
 def _finalize_tree(comps, adjacency, base, parent_of, edge_info, root_rpy=None,
-                   root_z_offset=0.0, root_xyz=None):
+                   root_z_offset=0.0, root_xyz=None, anchor_frames=None):
     """Compute anchors, visual origins and Joint objects from a parent map."""
     by_name = {c.name: c for c in comps}
 
@@ -2492,9 +2505,29 @@ def _finalize_tree(comps, adjacency, base, parent_of, edge_info, root_rpy=None,
         T = np.eye(4)
         T[2, 3] = root_z_offset
         base_anchor = base_anchor @ T
+    # A SW2URDF config states each link's frame explicitly (its CoordSys);
+    # honour that verbatim -- position AND orientation -- so the tree comes
+    # out in the frames the human authored, the way the classic add-in wrote
+    # them.  Links without one keep the world-aligned-on-axis convention.
+    anchor_frames = anchor_frames or {}
+    if base.name in anchor_frames:
+        base_anchor = np.asarray(anchor_frames[base.name], float).copy()
+        if root_rpy:
+            base_anchor = base_anchor @ rpy2homogeneous(*root_rpy)
+        if root_xyz:
+            T = np.eye(4)
+            T[:3, 3] = np.asarray(root_xyz, float)
+            base_anchor = base_anchor @ T
+        if root_z_offset:
+            T = np.eye(4)
+            T[2, 3] = root_z_offset
+            base_anchor = base_anchor @ T
     anchor = {base.name: base_anchor}
     for child, parent in parent_of.items():
         info = edge_info.get((child, parent), {"type": "fixed", "axis": None})
+        if child in anchor_frames:
+            anchor[child] = np.asarray(anchor_frames[child], float).copy()
+            continue
         if info["type"] in ("revolute", "continuous", "prismatic") \
                 and info.get("axis") is not None:
             pt, d = info["axis"]
@@ -2528,10 +2561,14 @@ def _finalize_tree(comps, adjacency, base, parent_of, edge_info, root_rpy=None,
             else:
                 pt, d = info["axis"]
                 d = np.asarray(d, float)
-                axis = [round(float(x), 8) for x in d]
+                sw_dir = [round(float(x), 8) for x in d]
+                # URDF expresses <axis> in the CHILD (joint) frame.  With the
+                # world-aligned anchors that is the document frame verbatim,
+                # but an authored CoordSys anchor is rotated -- map into it.
+                d_local = anchor[child][:3, :3].T @ d
+                axis = [round(float(x), 8) for x in d_local]
                 lower = info.get("lower"); upper = info.get("upper")
                 sw_pt = [round(float(x), 8) for x in np.asarray(pt, float)]
-                sw_dir = axis
         if jtype == "fixed":
             # write the WOULD-BE axis (best concentric/mate line) even for
             # fixed joints: URDF consumers ignore <axis> on fixed, but the
@@ -2553,8 +2590,9 @@ def _finalize_tree(comps, adjacency, base, parent_of, edge_info, root_rpy=None,
         # physics sub-elements are meaningful only on movable joints; a joint
         # the config pinned to fixed drops them (URDF ignores them there anyway)
         movable = jtype in ("revolute", "continuous", "prismatic")
+        joint_name = info.get("name") or f"{pa.link_name}__{ch.link_name}"
         joints.append(Joint(
-            name=f"{pa.link_name}__{ch.link_name}",
+            name=joint_name,
             parent=pa.link_name, child=ch.link_name, jtype=jtype,
             xyz=xyz, rpy=rpy, axis=axis, lower=lower, upper=upper,
             effort=info.get("effort") if movable else None,
@@ -2569,7 +2607,8 @@ def _finalize_tree(comps, adjacency, base, parent_of, edge_info, root_rpy=None,
 
 
 def build_tree(comps, adjacency, base, directed=None, root_rpy=None,
-               root_z_offset=0.0, root_xyz=None, closures_out=None):
+               root_z_offset=0.0, root_xyz=None, closures_out=None,
+               anchor_frames=None):
     if directed:
         parent_of, edge_info = _config_parent_map(comps, adjacency, base,
                                                   directed)
@@ -2594,7 +2633,7 @@ def build_tree(comps, adjacency, base, directed=None, root_rpy=None,
             closures_out.append(lc)
     return _finalize_tree(comps, adjacency, base, parent_of, edge_info,
                           root_rpy=root_rpy, root_z_offset=root_z_offset,
-                          root_xyz=root_xyz)
+                          root_xyz=root_xyz, anchor_frames=anchor_frames)
 
 
 # ====================================================================
@@ -2652,6 +2691,131 @@ def _document_features(doc):
         out.append(fi)
         feat = safe_call(fi, "GetNextFeature")
     return out
+
+
+def _sw2urdf_attribute_payload_xml(feature):
+    """Best-effort extraction of the SW2URDF attribute payload XML."""
+    specific = safe_call(feature, "GetSpecificFeature2")
+    attribute = as_iface(specific, "IAttribute")
+    parameter_obj = safe_call(attribute, "GetParameter", "data")
+    parameter = as_iface(parameter_obj, "IParameter")
+    value = safe_call(parameter, "GetStringValue")
+    if isinstance(value, (tuple, list)):
+        value = next((x for x in value if x), None)
+    if value is None:
+        return None
+    try:
+        return str(value)
+    except Exception:
+        return None
+
+
+def extract_sw2urdf_attribute(doc):
+    """Return ``(marker, payload_xml)`` for the SW2URDF attribute feature.
+
+    ``(None, None)`` when the document carries no ``URDF Export
+    Configuration`` feature.  Kept separate from the frame readers so the
+    frame-refresh path can update the marker without going through them.
+    """
+    for fi in _document_features(doc):
+        name = str(safe_prop(fi, "Name") or "")
+        if name.startswith("URDF Export Configuration"):
+            payload = _sw2urdf_attribute_payload_xml(fi)
+            if payload is None:
+                print("      WARN: SW2URDF marker found but attribute payload "
+                      "could not be read")
+            return name, payload
+    return None, None
+
+
+def extract_reference_geometry(doc):
+    """Return reference geometry and SW2URDF marker data in one feature walk.
+
+    Returns
+    -------
+    tuple
+        ``(coordinate_systems, reference_axes, sw2urdf_marker,
+        sw2urdf_config_xml)``.
+    """
+    coordinate_systems = []
+    reference_axes = []
+    sw2urdf_marker = None
+    sw2urdf_config_xml = None
+
+    extension = as_iface(
+        safe_prop(doc, "Extension"), "IModelDocExtension")
+    for fi in _document_features(doc):
+        name = str(safe_prop(fi, "Name") or "")
+        if (sw2urdf_marker is None and
+                name.startswith("URDF Export Configuration")):
+            sw2urdf_marker = name
+            sw2urdf_config_xml = _sw2urdf_attribute_payload_xml(fi)
+            if sw2urdf_config_xml is None:
+                print("      WARN: SW2URDF marker found but attribute payload "
+                      "could not be read")
+
+        kind = safe_call(fi, "GetTypeName2")
+        if kind == "CoordSys":
+            data = None
+            accessed = False
+            try:
+                transform = safe_call(
+                    extension, "GetCoordinateSystemTransformByName", name)
+                if transform is None:
+                    data = safe_call(fi, "GetDefinition")
+                    data = as_iface(data, "ICoordinateSystemFeatureData")
+                    # SolidWorks' examples access the feature selections before
+                    # reading Transform.  Some releases return the transform
+                    # without this call, but use the documented path here.
+                    accessed = bool(safe_call(
+                        data, "AccessSelections", doc, None))
+                    transform = safe_prop(data, "Transform")
+                if transform is None:
+                    raise ValueError("coordinate system has no Transform")
+                document_from_frame = transform_to_matrix(transform.ArrayData)
+                coordinate_systems.append(CoordinateSystemState(
+                    name=name,
+                    document_from_frame=[
+                        float(x) for x in document_from_frame.flatten()
+                    ]))
+            except Exception as e:
+                print(f"      WARN: coordinate system {name!r} could not be "
+                      f"read: {e!r}")
+            finally:
+                if accessed:
+                    safe_call(data, "ReleaseSelectionAccess")
+        elif kind == "RefAxis":
+            try:
+                axis = as_iface(safe_call(fi, "GetSpecificFeature2"), "IRefAxis")
+                params = np.asarray(
+                    list(safe_call(axis, "GetRefAxisParams") or []), float)
+                if params.size < 6:
+                    raise ValueError("reference axis has no start/end points")
+                start = params[:3]
+                end = params[3:6]
+                direction = start - end
+                norm = float(np.linalg.norm(direction))
+                if norm <= 1e-12:
+                    raise ValueError("reference axis direction is degenerate")
+                reference_axes.append(ReferenceAxisState(
+                    name=name,
+                    document_point=[float(x) for x in start],
+                    document_direction=[float(x) for x in direction / norm],
+                ))
+            except Exception as e:
+                print(f"      WARN: reference axis {name!r} could not be "
+                      f"read: {e!r}")
+
+    if coordinate_systems:
+        print("      coordinate systems: " +
+              ", ".join(repr(c.name) for c in coordinate_systems))
+    if reference_axes:
+        print("      reference axes: " +
+              ", ".join(repr(axis.name) for axis in reference_axes))
+    if sw2urdf_marker is not None:
+        print(f"      SW2URDF marker: {sw2urdf_marker!r}")
+    return (coordinate_systems, reference_axes,
+            sw2urdf_marker, sw2urdf_config_xml)
 
 
 def extract_coordinate_systems(doc):
@@ -2910,7 +3074,8 @@ def _mate_edges(adjacency):
 def to_graph_state(comps, adjacency, ground, robot_name, source_assembly,
                    assembly_mesh=None, subassemblies=None, deep_worlds=None,
                    hidden=None, limit_joints=None, coordinate_systems=None,
-                   subassembly_coordinate_systems=None, reference_axes=None):
+                   subassembly_coordinate_systems=None, reference_axes=None,
+                   sw2urdf_marker=None, sw2urdf_config_xml=None):
     subs = {}
     for path, (scomps, sadj, sground) in (subassemblies or {}).items():
         subs[path] = SubGraph(components=_component_states(scomps),
@@ -2925,6 +3090,8 @@ def to_graph_state(comps, adjacency, ground, robot_name, source_assembly,
                       assembly_mesh=assembly_mesh,
                       coordinate_systems=list(coordinate_systems or []),
                       reference_axes=list(reference_axes or []),
+                      sw2urdf_marker=sw2urdf_marker,
+                      sw2urdf_config_xml=sw2urdf_config_xml,
                       subassemblies=subs,
                       deep_worlds=deep_worlds or {}, hidden=hidden or [],
                       limit_joints=[LimitJoint(**j) for j in
@@ -3059,7 +3226,144 @@ def _excluded(name, link_name, exclude):
     return any(e in n or (ln and e in ln) for e in exclude)
 
 
-def from_graph(graph, exclude=None, expand=None, no_expand=None):
+def _sw2urdf_sanitized_link_names(swcfg, graph_components=None):
+    """Return component -> sanitised link name for a SW2URDF mapping.
+
+    Raises ValueError on any post-sanitisation collision: among the SW2URDF
+    links themselves, against a non-SW2URDF top-level component's link name,
+    or between two sanitised joint names.
+    """
+    used = {}
+    out = {}
+    for comp_name, rec in sorted(swcfg["links"].items()):
+        ln = safe_name(rec["link_name"])
+        prev = used.get(ln)
+        if prev is not None and prev != comp_name:
+            raise ValueError(
+                f"sanitised SW2URDF link name collision: {comp_name!r} and "
+                f"{prev!r} -> {ln!r}"
+            )
+        used[ln] = comp_name
+        out[comp_name] = ln
+    for c in graph_components or []:
+        if c.name in swcfg["links"]:
+            continue
+        other = safe_name(getattr(c, "link_name", None) or c.name)
+        if other in used:
+            raise ValueError(
+                f"SW2URDF link name {other!r} collides with non-SW2URDF "
+                f"component {c.name!r}")
+    jused = {}
+    for j in swcfg["joints"]:
+        jn = safe_name(str(j["name"]))
+        if jn in jused and jused[jn] != j["name"]:
+            raise ValueError(
+                f"sanitised SW2URDF joint name collision: {j['name']!r} and "
+                f"{jused[jn]!r} -> {jn!r}")
+        jused[jn] = j["name"]
+    return out
+
+
+def _sw2urdf_print_mapping(swcfg, route="name"):
+    """Print a compact SW2URDF mapping summary."""
+    links = swcfg["links"]
+    root = swcfg["root_link"]
+    if route == "name":
+        print("      SW2URDF config: applied")
+    else:
+        print(f"      SW2URDF config: applied ({route} route)")
+    print(f"        links: {len(links)}, joints: {len(swcfg['joints'])}, "
+          f"root: {links[root]['link_name']} ({root})")
+    for j in swcfg["joints"]:
+        if j.get("axis_direction") is None:
+            # a configured FIXED joint needs no axis
+            print("        - {}: {} -> {}  ({}, no axis)".format(
+                j["name"], j["parent"], j["child"],
+                j.get("type", "fixed")))
+            continue
+        p = np.asarray(j["axis_point"], float)
+        d = np.asarray(j["axis_direction"], float)
+        print("        - {}: {} -> {}  axis_point=[{:.6g}, {:.6g}, {:.6g}] "
+              "axis_dir=[{:.6g}, {:.6g}, {:.6g}]  origin_dist={:.3e}m  "
+              "flip={}".format(
+                  j["name"], j["parent"], j["child"],
+                  float(p[0]), float(p[1]), float(p[2]),
+                  float(d[0]), float(d[1]), float(d[2]),
+                  float(j["axis_origin_distance"]),
+                  "yes" if j.get("flipped") else "no"))
+
+
+def _sw2urdf_directed_joints(swcfg):
+    """SW2URDF mapping -> directed config entries for ``_config_parent_map``."""
+    out = []
+    for j in swcfg["joints"]:
+        child_origin = np.asarray(
+            swcfg["links"][j["child"]]["origin"][:3, 3], float)
+        # a configured FIXED joint may carry no axis at all
+        axis_dir = j.get("axis_direction")
+        if axis_dir is not None:
+            axis_dir = [float(x) for x in np.asarray(axis_dir, float)]
+        out.append({
+            "name": safe_name(str(j["name"])),
+            "parent": j["parent"],
+            "child": j["child"],
+            # the payload route carries the full joint spec; the name and
+            # geometric routes only ever produce bare revolute entries
+            "type": j.get("type", "revolute"),
+            "lower": j.get("lower"),
+            "upper": j.get("upper"),
+            "axis_point": [float(x) for x in child_origin],
+            "axis_dir": axis_dir,
+            "mimic": j.get("mimic"),
+            "effort": j.get("effort"),
+            "velocity": j.get("velocity"),
+            "dynamics": j.get("dynamics"),
+            "safety": j.get("safety"),
+            "calibration": j.get("calibration"),
+        })
+    # SW2URDF links may bundle several loose components; the main one carries
+    # the joint tree and the rest ride along as rigid FIXED children.
+    for main_comp, rec in sorted(swcfg["links"].items()):
+        for member in rec.get("extra_components") or []:
+            out.append({
+                "name": None, "parent": main_comp, "child": member,
+                "type": "fixed", "lower": None, "upper": None,
+                "axis_point": None, "axis_dir": None,
+                "mimic": None, "effort": None, "velocity": None,
+                "dynamics": None, "safety": None, "calibration": None,
+            })
+    return out
+
+
+def _sw2urdf_merge_directed(sw2_directed, user_directed):
+    """Merge user ``joints:`` entries onto the SW2URDF directed tree.
+
+    The generated joints.yaml snapshots the applied tree, so a user entry
+    repeating a configured joint (same child, parent and type) contributes
+    only its explicit overrides; an entry that RE-WIRES a configured child
+    replaces that joint.  Returns ``(directed, replaced_names)``.
+    """
+    by_child = {d["child"]: dict(d) for d in sw2_directed}
+    extra, replaced = [], []
+    for u in user_directed:
+        s = by_child.get(u["child"])
+        if s is None:
+            extra.append(u)
+            continue
+        if u["parent"] == s["parent"] and u.get("type") == s.get("type"):
+            for k, v in u.items():
+                if k in ("parent", "child", "type") or v is None:
+                    continue
+                s[k] = v
+        else:
+            replaced.append(s["name"])
+            by_child[u["child"]] = u
+    ordered = [by_child[d["child"]] for d in sw2_directed]
+    return ordered + extra, replaced
+
+
+def from_graph(graph, exclude=None, expand=None, no_expand=None,
+               force_no_expand=None):
     """GraphState -> (comps, adjacency, ground), applying ``exclude`` and
     expanding sub-assemblies whose internals move (see
     :func:`_expand_subassemblies`)."""
@@ -3092,7 +3396,8 @@ def from_graph(graph, exclude=None, expand=None, no_expand=None):
     ground = {g for g in graph.ground if g in names}
     _snap_unsolved_mates(comps, adjacency)
     comps, adjacency, ground = _expand_subassemblies(
-        graph, comps, adjacency, ground, expand=expand, no_expand=no_expand)
+        graph, comps, adjacency, ground, expand=expand, no_expand=no_expand,
+        force_no_expand=force_no_expand)
     if exclude:
         # Apply `exclude` AGAIN after expansion: the filter at the top of this
         # function only sees top-level graph.components, so a part excluded from
@@ -3299,19 +3604,27 @@ def _expand_one(inst, sub, comps, adjacency, ground, deep=None, hidden=None):
 
 
 def _expand_subassemblies(graph, comps, adjacency, ground,
-                          expand=None, no_expand=None):
-    """Expand instances whose internals move; ``expand``/``no_expand`` are
-    case-insensitive substring overrides from the joint config."""
+                          expand=None, no_expand=None,
+                          force_no_expand=None):
+    """Expand instances whose internals move.
+
+    ``expand``/``no_expand`` are case-insensitive substring overrides from the
+    joint config. ``force_no_expand`` is an exact-name hold list used by
+    auto-applied SW2URDF link components; explicit ``expand`` still wins.
+    """
     subs = getattr(graph, "subassemblies", None) or {}
     if not subs:
         return comps, adjacency, ground
     expand = [s.lower() for s in (expand or [])]
     no_expand = [s.lower() for s in (no_expand or [])]
+    force_no_expand = {s.lower() for s in (force_no_expand or [])}
     movable = {}
 
     def want(inst):
         nm = inst.name.lower()
         if any(s in nm for s in no_expand):
+            return False
+        if nm in force_no_expand and not any(s in nm for s in expand):
             return False
         sub = subs.get(inst.part_path)
         if sub is None:
@@ -3343,10 +3656,122 @@ def build_model(graph, robot_name=None, base_hint=None, config=None,
     exclude = list(exclude or [])
     if config and config.get("exclude"):
         exclude += list(config["exclude"])
+
+    sw2_mode = "auto"
+    if config and config.get("sw2urdf_config") is not None:
+        sw2_mode = str(config.get("sw2urdf_config")).strip().lower() or "auto"
+    if sw2_mode not in ("auto", "off", "require"):
+        print(f"      WARN: sw2urdf_config={sw2_mode!r} is unknown; using 'auto'")
+        sw2_mode = "auto"
+
+    sw2_present = detect_sw2urdf_reference_geometry(
+        graph.components,
+        graph.coordinate_systems,
+        graph.reference_axes,
+    )
+    sw2_marker = str(getattr(graph, "sw2urdf_marker", "") or "").strip() or None
+    sw2_payload_xml = str(
+        getattr(graph, "sw2urdf_config_xml", "") or "").strip() or None
+    sw2cfg = None
+    sw2_link_names = None
+    sw2_force_no_expand = None
+    sw2_route = None
+    if sw2_mode != "off":
+        if sw2_payload_xml:
+            payload = parse_sw2urdf_payload(sw2_payload_xml)
+            if payload is not None:
+                sw2cfg = reconstruct_sw2urdf_config_from_payload(
+                    payload,
+                    graph.components,
+                    graph.coordinate_systems,
+                    graph.reference_axes,
+                    subassemblies=getattr(graph, "subassemblies", None),
+                )
+            if sw2cfg is not None:
+                sw2_route = "payload"
+            else:
+                print("      !!! SW2URDF payload route failed; "
+                      "trying other routes")
+    if sw2_mode != "off" and sw2cfg is None:
+        sw2cfg = reconstruct_sw2urdf_config(
+            graph.components,
+            graph.coordinate_systems,
+            graph.reference_axes,
+            graph.edges,
+            graph.ground,
+        )
+        if sw2cfg is not None:
+            sw2_route = "name"
+        if sw2cfg is None and sw2_marker is not None:
+            print("      !!! SW2URDF marker found; name route failed, "
+                  "trying geometric reconstruction")
+            sw2cfg = reconstruct_sw2urdf_config_geometric(
+                graph.components,
+                graph.coordinate_systems,
+                graph.reference_axes,
+                graph.edges,
+                graph.ground,
+            )
+            if sw2cfg is not None:
+                sw2_route = "geometric"
+    # post-processing runs for whichever route produced the mapping
+    if sw2_mode != "off":
+        if sw2cfg is None:
+            if sw2_mode == "require":
+                if sw2_marker is not None:
+                    raise RuntimeError(
+                        "sw2urdf_config=require but the embedded SW2URDF "
+                        "mapping could not be reconstructed by any route")
+                raise RuntimeError(
+                    "sw2urdf_config=require but embedded SW2URDF mapping "
+                    "could not be reconstructed")
+            if sw2_marker is not None:
+                print("      !!! SW2URDF marker found but reconstruction "
+                      "failed in every applicable route; falling back to "
+                      "normal mate inference")
+            elif sw2_present:
+                print("      !!! SW2URDF config detected but reconstruction "
+                      "failed; falling back to normal mate inference")
+        else:
+            try:
+                sw2_link_names = _sw2urdf_sanitized_link_names(
+                    sw2cfg, graph.components)
+            except ValueError as e:
+                if sw2_mode == "require":
+                    raise RuntimeError(
+                        "sw2urdf_config=require but " + str(e)) from e
+                print("      !!! SW2URDF config warning: "
+                      f"{e}; falling back to normal mate inference")
+                sw2cfg = None
+                sw2_link_names = None
+            if sw2cfg is not None:
+                _sw2urdf_print_mapping(sw2cfg, route=sw2_route or "name")
+                sw2_force_no_expand = set(sw2cfg["links"])
+                for rec in sw2cfg["links"].values():
+                    sw2_force_no_expand.update(
+                        rec.get("extra_components") or [])
+                exp = [s.lower() for s in
+                       ((config.get("expand") if config else None) or [])]
+                if exp:
+                    overridden = sorted(
+                        name for name in sw2_force_no_expand
+                        if any(s in name.lower() for s in exp))
+                    if overridden:
+                        print("      SW2URDF config: user `expand:` override "
+                              "keeps expansion for: "
+                              + ", ".join(repr(x) for x in overridden))
+
     comps, adjacency, ground = from_graph(
         graph, exclude=exclude,
         expand=config.get("expand") if config else None,
-        no_expand=config.get("no_expand") if config else None)
+        no_expand=config.get("no_expand") if config else None,
+        force_no_expand=sw2_force_no_expand)
+
+    if sw2cfg is not None and sw2_link_names is not None:
+        for c in comps:
+            ln = sw2_link_names.get(c.name)
+            if ln:
+                c.link_name = ln
 
     # SolidWorks LimitDistance/LimitAngle mates ARE the assembly's real DOFs --
     # promote those edges to prismatic/revolute with the CAD axis + travel
@@ -3485,15 +3910,53 @@ def build_model(graph, robot_name=None, base_hint=None, config=None,
         if "root_link_name" in config:
             # falsy -> keep the component's own link name (no rename)
             root_link_name = config.get("root_link_name") or ""
+
+    if sw2cfg is not None:
+        # component-less config links become ports (empty dummy links); their
+        # pose is the authored frame expressed in the parent link's anchor
+        for fl in sw2cfg.get("frame_links") or []:
+            parent_comp = fl["parent_component"]
+            parent_rec = sw2cfg["links"].get(parent_comp) or {}
+            parent_anchor = np.asarray(
+                parent_rec.get("origin", np.eye(4)), float).reshape(4, 4)
+            rel = matrix_relative(parent_anchor,
+                                  np.asarray(fl["origin"], float))
+            xyz, rpy = matrix_to_xyz_rpy(rel)
+            parent_link = next((c.link_name for c in comps
+                                if c.name == parent_comp), None)
+            if parent_link is None:
+                print(f"      WARN: frame link {fl['link_name']!r} parent "
+                      f"{parent_comp!r} is not in the model; skipping")
+                continue
+            ports.append(Port(name=safe_name(fl["link_name"]),
+                              parent_link=parent_link,
+                              xyz=list(xyz), rpy=list(rpy),
+                              joint_name=safe_name(fl["joint_name"] or "")))
+        base_hint = sw2cfg["root_link"]
+        directed, replaced = _sw2urdf_merge_directed(
+            _sw2urdf_directed_joints(sw2cfg), directed or [])
+        print("      SW2URDF config: using directed revolute tree "
+              f"({len(directed)} joints)")
     root_z_offset = (config.get("root_z_offset", 0.0) if config else 0.0)
     root_xyz = (config.get("root_xyz") if config else None)
 
     base = choose_base(comps, ground, base_hint, adjacency)
     print(f"      base link: {base.link_name}")
     closures_out = []
+    # authored link frames (CoordSys) -> anchors, so the URDF comes out in
+    # the frames the SW2URDF config declares
+    anchor_frames = None
+    if sw2cfg is not None:
+        anchor_frames = {comp: rec["origin"]
+                         for comp, rec in sw2cfg["links"].items()
+                         if rec.get("origin_name")}
+        if anchor_frames:
+            print(f"      SW2URDF config: {len(anchor_frames)} authored link "
+                  "frame(s) used as anchors")
     joints = build_tree(comps, adjacency, base, directed=directed,
                         root_rpy=root_rpy, root_z_offset=root_z_offset,
-                        root_xyz=root_xyz, closures_out=closures_out)
+                        root_xyz=root_xyz, closures_out=closures_out,
+                        anchor_frames=anchor_frames)
     nrev = sum(1 for j in joints if j.jtype == "revolute")
     npri = sum(1 for j in joints if j.jtype == "prismatic")
     print(f"      joint types: {nrev} revolute, {npri} prismatic, "
@@ -3530,8 +3993,17 @@ def build_model(graph, robot_name=None, base_hint=None, config=None,
     n_ports = ", ".join(p.name for p in ports)
     if ports:
         print(f"      output ports: {n_ports}")
+    lumped = []
+    if sw2cfg is not None:
+        by_comp = {c.name: c.link_name for c in comps}
+        for rec in sw2cfg["links"].values():
+            for member in rec.get("extra_components") or []:
+                ln = by_comp.get(member)
+                if ln:
+                    lumped.append(ln)
     return RobotModel(name=robot_name, components=comps, joints=joints,
                       detected_edges=detected, base_link=base.link_name,
                       ports=ports,
                       root_link_name=root_link_name or base.link_name,
-                      loop_closures=closures_out[0] if closures_out else None)
+                      loop_closures=closures_out[0] if closures_out else None,
+                      lumped_links=lumped)

--- a/sw2robot/exporter/state.py
+++ b/sw2robot/exporter/state.py
@@ -160,6 +160,13 @@ class GraphState(BaseModel):
     # correspond to the official SolidWorks URDF Exporter's Reference Joint
     # choices and are intentionally separate from mate-derived joint axes.
     reference_axes: list[ReferenceAxisState] = []
+    # Definitive SW2URDF fingerprint: top-level feature name
+    # "URDF Export Configuration (vX.Y)". None on older extracts / assemblies
+    # not authored with the add-in.
+    sw2urdf_marker: str | None = None
+    # Raw SW2URDF DataContract XML payload from the marker attribute's
+    # "data" parameter. None when unreadable or absent.
+    sw2urdf_config_xml: str | None = None
     # part_path -> internals (newer extracts; empty on graphs from older ones)
     subassemblies: dict[str, SubGraph] = {}
     # full nested Name2 ("inst-1/child-2/...") -> row-major 4x4 in the ROOT

--- a/sw2robot/exporter/sw2urdf_import/__init__.py
+++ b/sw2robot/exporter/sw2urdf_import/__init__.py
@@ -1,0 +1,38 @@
+"""Import the configuration the classic SW2URDF add-in left in the document.
+
+An assembly configured with ``ros/solidworks_urdf_exporter`` carries its whole
+URDF configuration inside the SolidWorks file: an attribute feature holding
+the add-in's serialized link/joint tree, plus the reference geometry (CoordSys
+link frames, RefAxis joint axes) that tree points at.  This package rebuilds
+that configuration so sw2robot can export the URDF the author intended instead
+of inferring one from mates.
+
+Three routes, most to least authoritative -- the caller tries them in order
+and each says loudly why it declined:
+
+``payload``
+    :func:`parse_sw2urdf_payload` + :func:`reconstruct_sw2urdf_config_from_payload`
+    read the add-in's own serialized tree.  Nothing is inferred.
+``naming``
+    :func:`reconstruct_sw2urdf_config` rebuilds from the ``<link>_origin``
+    dialog-default feature names.
+``geometric``
+    :func:`reconstruct_sw2urdf_config_geometric` matches reference axes to
+    mate edges, so no naming convention is needed.
+
+Every route returns the same mapping: ``links`` (component -> link name,
+authored frame, member components), ``root_link`` and ``joints``.
+"""
+
+from .bridge import reconstruct_sw2urdf_config_from_payload
+from .geometric import reconstruct_sw2urdf_config_geometric
+from .naming import detect_sw2urdf_reference_geometry, reconstruct_sw2urdf_config
+from .payload import parse_sw2urdf_payload
+
+__all__ = [
+    "detect_sw2urdf_reference_geometry",
+    "parse_sw2urdf_payload",
+    "reconstruct_sw2urdf_config",
+    "reconstruct_sw2urdf_config_from_payload",
+    "reconstruct_sw2urdf_config_geometric",
+]

--- a/sw2robot/exporter/sw2urdf_import/_common.py
+++ b/sw2robot/exporter/sw2urdf_import/_common.py
@@ -1,0 +1,162 @@
+"""Shared primitives for reading an embedded SW2URDF configuration.
+
+Geometry predicates (point-to-line distance, parallel / collinear tests),
+component-name handling and the deterministic axis sign normalisation that
+every reconstruction route relies on.  Imports nothing from its siblings, so
+it stays the bottom of the package's import graph.
+"""
+
+from __future__ import annotations
+
+import re
+
+import numpy as np
+from skrobot.coordinates.math import normalize_vector
+
+_INSTANCE_SUFFIX_RE = re.compile(r"-\d+$")
+# Payload CoordSys reference scoped to a component instance: "name <comp-1>"
+_SCOPED_COORDSYS_RE = re.compile(r"^(.*) <([^<>]+)>$")
+_EPS = 1e-12
+
+
+def _warn(msg):
+    print("      !!! SW2URDF config warning: " + str(msg))
+
+
+def _field(obj, key, default=None):
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _component_stem(name):
+    return _INSTANCE_SUFFIX_RE.sub("", str(name or ""))
+
+
+def _origin_name_candidates(stem):
+    names = [f"{stem}_origin"]
+    if stem.endswith("_link"):
+        names.append(f"{stem[:-5]}_origin")
+    return names
+
+
+def _coord_matrix(coord):
+    vals = np.asarray(_field(coord, "document_from_frame"), float)
+    return vals.reshape(4, 4)
+
+
+def _unit(v):
+    """Unit vector, or None when ``v`` is degenerate.
+
+    ``normalize_vector`` returns a zero vector unchanged rather than
+    raising, and a zero-length "direction" here means the CAD feature is
+    unusable -- so the caller must be able to tell the two apart.
+    """
+    arr = np.asarray(v, float)
+    if float(np.linalg.norm(arr)) < _EPS:
+        return None
+    return normalize_vector(arr)
+
+
+def _axis_line(axis):
+    p = np.asarray(_field(axis, "document_point"), float)
+    d = _unit(_field(axis, "document_direction"))
+    if d is None:
+        return None
+    return p, d
+
+
+def _point_line_distance(point, line_point, line_dir):
+    v = np.asarray(point, float) - np.asarray(line_point, float)
+    return float(np.linalg.norm(np.cross(v, line_dir)))
+
+
+def _parallel(d1, d2, tol):
+    # NOT skrobot's is_parallel_two_vectors: that one tests the cross
+    # product for EXACT zero, which no CAD-derived direction ever is.
+    u1, u2 = _unit(d1), _unit(d2)
+    if u1 is None or u2 is None:
+        return False
+    return float(np.linalg.norm(np.cross(u1, u2))) <= tol
+
+
+def _line_matches(line_a, line_b, tol):
+    pa, da = line_a
+    pb, db = line_b
+    if not _parallel(da, db, tol):
+        return False
+    ub = _unit(db)
+    if ub is None:
+        return False
+    return _point_line_distance(pa, pb, ub) <= tol
+
+
+def _normalize_axis_direction(d):
+    dn = _unit(d)
+    if dn is None:
+        return np.asarray(d, float), False
+    i = int(np.argmax(np.abs(dn)))
+    flipped = bool(dn[i] < 0.0)
+    if flipped:
+        dn = -dn
+    # Snap float noise (and negative zeros from the flip) so the URDF text
+    # never carries '-0' or 1e-16 residue.
+    dn[np.abs(dn) < 1e-12] = 0.0
+    return dn, flipped
+
+
+def _edge_line_candidates(edge):
+    out = []
+    p = _field(edge, "axis_point")
+    d = _field(edge, "axis_dir")
+    if p is not None and d is not None:
+        unit = _unit(d)
+        if unit is not None:
+            out.append((np.asarray(p, float), unit))
+    for mate in _field(edge, "mates", []) or []:
+        raw = mate.model_dump() if hasattr(mate, "model_dump") else mate
+        pts = list(_field(raw, "points", []) or [])
+        dirs = list(_field(raw, "dirs", []) or [])
+        for i, dv in enumerate(dirs):
+            unit = _unit(dv)
+            if unit is None:
+                continue
+            if i < len(pts):
+                pv = np.asarray(pts[i], float)
+            elif pts:
+                pv = np.asarray(pts[0], float)
+            else:
+                continue
+            out.append((pv, unit))
+    return out
+
+
+def _edge_supports_axis(edge, axis_line, tol):
+    for cand in _edge_line_candidates(edge):
+        if _line_matches(cand, axis_line, tol):
+            return True
+    return False
+
+
+def _link_component_candidates(components, coordinate_systems):
+    coord_names = {str(_field(cs, "name")) for cs in coordinate_systems or []}
+    out = {}
+    for comp in components or []:
+        cname = str(_field(comp, "name"))
+        stem = _component_stem(cname)
+        matches = [n for n in _origin_name_candidates(stem) if n in coord_names]
+        if matches:
+            out[cname] = {"stem": stem, "origin_names": matches}
+    return out
+
+
+def _component_translation(component):
+    """Return component world translation in document coordinates."""
+    if hasattr(component, "world_matrix"):
+        mat = np.asarray(component.world_matrix(), float)
+        return np.asarray(mat[:3, 3], float)
+    world = _field(component, "world")
+    if world is None:
+        return np.zeros(3, float)
+    mat = np.asarray(world, float).reshape(4, 4)
+    return np.asarray(mat[:3, 3], float)

--- a/sw2robot/exporter/sw2urdf_import/bridge.py
+++ b/sw2robot/exporter/sw2urdf_import/bridge.py
@@ -1,0 +1,525 @@
+"""Turn a parsed SW2URDF payload into a link/joint mapping.
+
+The payload states the configuration outright, so this route infers nothing:
+it resolves each payload link to its top-level component(s), each joint to
+the named RefAxis / CoordSys features, and mirrors limits when the axis sign
+is normalised.  Everything it cannot resolve is reported and refused rather
+than guessed.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import (
+    _SCOPED_COORDSYS_RE,
+    _axis_line,
+    _component_translation,
+    _coord_matrix,
+    _field,
+    _normalize_axis_direction,
+    _point_line_distance,
+    _unit,
+    _warn,
+)
+
+
+def _payload_component_name(pid_value):
+    return str(pid_value or "").split("@", 1)[0].strip()
+
+
+def _payload_float(value):
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _payload_number_dict(data, numeric_keys, text_keys=()):
+    if not isinstance(data, dict):
+        return None
+    out = {}
+    for key in text_keys:
+        raw = data.get(key)
+        if raw is None:
+            continue
+        text = str(raw).strip()
+        if text:
+            out[key] = text
+    for key in numeric_keys:
+        val = _payload_float(data.get(key))
+        if val is not None:
+            out[key] = val
+    return out or None
+
+
+def reconstruct_sw2urdf_config_from_payload(payload, components,
+                                            coordinate_systems, reference_axes,
+                                            tolerance=1e-5,
+                                            subassemblies=None):
+    """Reconstruct SW2URDF mapping from parsed SW2URDF payload data.
+
+    Parameters
+    ----------
+    payload : dict
+        Parsed payload returned by ``parse_sw2urdf_payload``.
+    components : sequence
+        Top-level components with ``name``.
+    coordinate_systems : sequence
+        Top-level coordinate systems with ``name`` and
+        ``document_from_frame``.
+    reference_axes : sequence
+        Top-level reference axes with ``name``, ``document_point``,
+        ``document_direction``.
+    tolerance : float, optional
+        Distance tolerance for duplicate-origin sanity checks.
+    subassemblies : mapping, optional
+        ``{part_path: SubGraph}`` from ``GraphState.subassemblies``.  The
+        add-in may reference a CoordSys that lives INSIDE a link
+        sub-assembly, in which case the payload scopes its name as
+        ``"<name> <component-N>"``; those are resolved through the owning
+        component's sub-assembly and composed into the document frame.
+
+    Returns
+    -------
+    dict | None
+        Mapping with keys ``links``, ``root_link``, ``joints`` when
+        reconstruction succeeds, else None.
+    """
+    if not isinstance(payload, dict):
+        _warn("payload step 1 failed: parsed payload is not a dict")
+        return None
+
+    root_payload = payload.get("root")
+    link_payloads = payload.get("links")
+    if not isinstance(root_payload, dict) or not isinstance(link_payloads, list):
+        _warn("payload step 1 failed: payload must contain dict root and list links")
+        return None
+
+    component_by_name = {
+        str(_field(component, "name")): component
+        for component in (components or [])
+    }
+    coord_by_name = {
+        str(_field(coord, "name")): coord
+        for coord in (coordinate_systems or [])
+    }
+    axis_by_name = {
+        str(_field(axis, "name")): axis
+        for axis in (reference_axes or [])
+    }
+
+    def resolve_component(payload_link_name, pid_values, main_pid=None):
+        """(main_component, member_components) for one payload link.
+
+        SW2URDF allows selecting SEVERAL loose components for one link; the
+        MAIN one (SWMainComponentPID, mirrored as the first PID entry)
+        anchors the joint tree and the rest ride along as rigid members.
+        """
+        candidates = []
+        for pid_value in pid_values or []:
+            top = _payload_component_name(pid_value)
+            if top and top not in candidates:
+                candidates.append(top)
+        matches = [name for name in candidates if name in component_by_name]
+        if not matches:
+            _warn("payload step 1 failed: link "
+                  f"{payload_link_name!r} resolved to zero top-level components "
+                  f"from PIDs {candidates!r}")
+            return None, []
+        main = None
+        if main_pid:
+            main_name = _payload_component_name(main_pid)
+            if main_name in matches:
+                main = main_name
+        if main is None:
+            main = matches[0]
+            if len(matches) > 1:
+                _warn("payload step 1 warning: link "
+                      f"{payload_link_name!r} has {len(matches)} member "
+                      "components and no resolvable main; using first PID "
+                      f"entry {main!r}")
+        members = [name for name in matches if name != main]
+        return main, members
+
+    def resolve_coordsys_matrix(coordsys_name):
+        """Document-frame 4x4 for a payload CoordSys reference, or None.
+
+        Tries, in order: exact top-level name; a scoped
+        ``"<name> <component-N>"`` reference resolved through that
+        component's sub-assembly coordinate systems (composed with the
+        component's world transform); the bare name at top level.
+        """
+        coord = coord_by_name.get(coordsys_name)
+        if coord is not None:
+            return _coord_matrix(coord)
+        m = _SCOPED_COORDSYS_RE.match(coordsys_name)
+        if m:
+            base = m.group(1)
+            component = component_by_name.get(m.group(2))
+            if component is not None:
+                part_path = _field(component, "part_path")
+                sub = (subassemblies or {}).get(part_path)
+                for cs in _field(sub, "coordinate_systems", None) or []:
+                    if str(_field(cs, "name")) == base:
+                        world = np.asarray(
+                            _field(component, "world"), float).reshape(4, 4)
+                        return world @ _coord_matrix(cs)
+            coord = coord_by_name.get(base)
+            if coord is not None:
+                return _coord_matrix(coord)
+        return None
+
+    def origin_from_coordsys(component_name, coordsys_name, axis_point=None,
+                             context="link"):
+        if coordsys_name:
+            mat = resolve_coordsys_matrix(coordsys_name)
+            if mat is not None:
+                return mat, coordsys_name
+            _warn("payload step 2 warning: CoordSys "
+                  f"{coordsys_name!r} for {context} is missing; "
+                  "falling back to axis point")
+        if axis_point is not None:
+            mat = np.eye(4)
+            mat[:3, 3] = np.asarray(axis_point, float)
+            return mat, None
+        _warn("payload step 2 warning: "
+              f"{context} has no CoordSys and no axis point; "
+              "falling back to component translation")
+        mat = np.eye(4)
+        component = component_by_name.get(component_name)
+        if component is not None:
+            mat[:3, 3] = _component_translation(component)
+        return mat, None
+
+    root_link_name = str(root_payload.get("link_name") or "").strip()
+    if not root_link_name:
+        _warn("payload step 1 failed: root link_name is empty")
+        return None
+
+    root_component, root_members = resolve_component(
+        root_link_name,
+        root_payload.get("components") or [],
+        root_payload.get("main_component"))
+    if root_component is None:
+        return None
+
+    link_to_component = {root_link_name: root_component}
+    members_by_component = {root_component: root_members}
+    frame_links = []
+    ordered_links = []
+    for rec in link_payloads:
+        if not isinstance(rec, dict):
+            _warn("payload step 1 failed: non-dict entry in payload links list")
+            return None
+        child_link_name = str(rec.get("link_name") or "").strip()
+        parent_link_name = str(rec.get("parent_link_name") or "").strip()
+        if not child_link_name or not parent_link_name:
+            _warn("payload step 1 failed: payload link entry is missing "
+                  "link_name or parent_link_name")
+            return None
+        if not (rec.get("components") or []):
+            # SW2URDF lets a link carry NO component: a pure coordinate frame
+            # (NejiNeji's `dummy_link` connector).  Keep it as a frame link
+            # rather than failing the whole route.
+            frame_links.append(rec)
+            continue
+        child_component, child_members = resolve_component(
+            child_link_name,
+            rec.get("components") or [],
+            rec.get("main_component"))
+        if child_component is None:
+            return None
+        members_by_component[child_component] = child_members
+        if (child_link_name in link_to_component and
+                link_to_component[child_link_name] != child_component):
+            _warn("payload step 1 failed: payload link "
+                  f"{child_link_name!r} maps to multiple components")
+            return None
+        link_to_component[child_link_name] = child_component
+        ordered_links.append(rec)
+
+    # The payload's links must PARTITION the components: a component shared
+    # between links (gear-train / transmission-style configs encode couplings
+    # this way) cannot become a URDF tree.
+    usage = {}
+    for link_name, comp in link_to_component.items():
+        usage.setdefault(comp, set()).add(link_name)
+    for comp, members in members_by_component.items():
+        owner = next((ln for ln, c in link_to_component.items() if c == comp),
+                     None)
+        for member in members:
+            usage.setdefault(member, set()).add(owner or comp)
+    shared = {c: sorted(ls) for c, ls in usage.items() if len(ls) > 1}
+    if shared:
+        _warn("payload step 1 failed: components shared between links "
+              f"(not a tree partition; transmission-style config?): {shared!r}")
+        return None
+
+    root_coordsys_name = str(root_payload.get("coordsys_name") or "").strip() or None
+    root_origin, root_origin_name = origin_from_coordsys(
+        root_component,
+        root_coordsys_name,
+        axis_point=None,
+        context=f"root link {root_link_name!r}",
+    )
+    links = {
+        root_component: {
+            "link_name": root_link_name,
+            "origin_name": root_origin_name,
+            "origin": root_origin,
+            "extra_components": list(root_members),
+        }
+    }
+
+    joints = []
+    for rec in ordered_links:
+        child_link_name = str(rec.get("link_name") or "").strip()
+        parent_link_name = str(rec.get("parent_link_name") or "").strip()
+        child_component = link_to_component.get(child_link_name)
+        parent_component = link_to_component.get(parent_link_name)
+        if child_component is None or parent_component is None:
+            _warn("payload step 3 failed: could not resolve parent/child "
+                  f"components for {parent_link_name!r}->{child_link_name!r}")
+            return None
+        if child_component == parent_component:
+            _warn("payload step 3 failed: parent/child collapse to same "
+                  f"component {child_component!r}")
+            return None
+        if child_component == root_component:
+            _warn("payload step 3 failed: root component cannot be a non-root child")
+            return None
+
+        joint = rec.get("joint") or {}
+        joint_name = str(joint.get("name") or "").strip()
+        if not joint_name:
+            _warn("payload step 3 warning: missing joint name for "
+                  f"{parent_link_name!r}->{child_link_name!r}; using fallback")
+            joint_name = f"{parent_link_name}__{child_link_name}"
+
+        joint_type = str(joint.get("type") or "revolute").strip().lower()
+        if joint_type not in ("revolute", "continuous", "prismatic", "fixed"):
+            _warn("payload step 3 warning: unknown joint type "
+                  f"{joint_type!r} for {joint_name!r}; using 'fixed'")
+            joint_type = "fixed"
+
+        axis_name = str(joint.get("axis_name") or "").strip() or None
+        coordsys_name = str(joint.get("coordsys_name") or "").strip() or None
+
+        axis_point = None
+        axis_direction = None
+        if axis_name:
+            axis_feature = axis_by_name.get(axis_name)
+            if axis_feature is not None:
+                line = _axis_line(axis_feature)
+                if line is None:
+                    _warn("payload step 3 failed: reference axis "
+                          f"{axis_name!r} has degenerate direction")
+                    return None
+                axis_point = line[0].copy()
+                axis_direction = line[1].copy()
+            else:
+                _warn("payload step 3 warning: reference axis "
+                      f"{axis_name!r} is missing; falling back to payload axis "
+                      "(joint-frame values)")
+
+        if axis_direction is None:
+            axis_xyz = joint.get("axis_xyz")
+            if axis_xyz is not None:
+                try:
+                    axis_direction = _unit(axis_xyz)
+                except Exception:
+                    axis_direction = None
+            if axis_direction is None:
+                if joint_type in ("revolute", "continuous", "prismatic"):
+                    _warn("payload step 3 failed: movable joint "
+                          f"{joint_name!r} has no usable axis data")
+                    return None
+
+        origin, origin_name = origin_from_coordsys(
+            child_component,
+            coordsys_name,
+            axis_point=axis_point,
+            context=f"link {child_link_name!r}",
+        )
+
+        if child_component in links:
+            prev = links[child_component]
+            if prev["link_name"] != child_link_name:
+                _warn("payload step 2 failed: component "
+                      f"{child_component!r} is assigned to multiple payload links")
+                return None
+            prev_origin = np.asarray(prev["origin"][:3, 3], float)
+            cur_origin = np.asarray(origin[:3, 3], float)
+            if float(np.linalg.norm(prev_origin - cur_origin)) > tolerance:
+                _warn("payload step 2 failed: conflicting origins for component "
+                      f"{child_component!r}")
+                return None
+        else:
+            links[child_component] = {
+                "link_name": child_link_name,
+                "origin_name": origin_name,
+                "origin": origin,
+                "extra_components": list(
+                    members_by_component.get(child_component) or []),
+            }
+
+        if axis_direction is not None and axis_point is None:
+            axis_point = np.asarray(origin[:3, 3], float)
+
+        joint_rec = {
+            "name": joint_name,
+            "type": joint_type,
+            "parent": parent_component,
+            "child": child_component,
+        }
+        if axis_direction is not None and axis_point is not None:
+            axis_direction, flipped = _normalize_axis_direction(axis_direction)
+            child_origin = np.asarray(origin[:3, 3], float)
+            joint_rec.update({
+                "axis_point": np.asarray(axis_point, float).copy(),
+                "axis_direction": axis_direction,
+                "axis_origin_distance": _point_line_distance(
+                    child_origin, axis_point, axis_direction),
+                "flipped": bool(flipped),
+            })
+
+        limit = _payload_number_dict(
+            joint.get("limit"), ("lower", "upper", "effort", "velocity"))
+        if limit:
+            for key in ("lower", "upper", "effort", "velocity"):
+                if key in limit:
+                    joint_rec[key] = limit[key]
+
+        dynamics = _payload_number_dict(joint.get("dynamics"),
+                                        ("damping", "friction"))
+        mimic = _payload_number_dict(joint.get("mimic"),
+                                     ("multiplier", "offset"),
+                                     text_keys=("joint",))
+        safety = _payload_number_dict(
+            joint.get("safety"),
+            ("soft_lower_limit", "soft_upper_limit",
+             "k_position", "k_velocity"),
+        )
+        calibration = _payload_number_dict(joint.get("calibration"),
+                                           ("rising", "falling"))
+        if dynamics:
+            joint_rec["dynamics"] = dynamics
+        if mimic:
+            joint_rec["mimic"] = mimic
+        if safety:
+            joint_rec["safety"] = safety
+        if calibration:
+            joint_rec["calibration"] = calibration
+
+        joints.append(joint_rec)
+
+    # Axis sign normalization NEGATES the joint coordinate, so every
+    # payload quantity expressed in that coordinate must be mirrored
+    # (the old add-in kept the raw sign and never needed this).
+    flipped_by_name = {j["name"]: bool(j.get("flipped")) for j in joints}
+    for j in joints:
+        s_self = -1.0 if j.get("flipped") else 1.0
+        if s_self < 0:
+            lo = j.get("lower")
+            up = j.get("upper")
+            if lo is not None or up is not None:
+                # +0.0 snaps IEEE negative zero so URDF text never shows -0
+                j["lower"] = (-up + 0.0) if up is not None else None
+                j["upper"] = (-lo + 0.0) if lo is not None else None
+            safety = j.get("safety")
+            if isinstance(safety, dict):
+                sl = safety.pop("soft_lower_limit", None)
+                su = safety.pop("soft_upper_limit", None)
+                if su is not None:
+                    safety["soft_lower_limit"] = -su
+                if sl is not None:
+                    safety["soft_upper_limit"] = -sl
+            calibration = j.get("calibration")
+            if isinstance(calibration, dict):
+                rising = calibration.pop("rising", None)
+                falling = calibration.pop("falling", None)
+                if falling is not None:
+                    calibration["rising"] = -falling
+                if rising is not None:
+                    calibration["falling"] = -rising
+        mimic = j.get("mimic")
+        if isinstance(mimic, dict) and mimic.get("joint"):
+            s_driver = -1.0 if flipped_by_name.get(mimic["joint"]) else 1.0
+            if s_self * s_driver < 0:
+                mimic["multiplier"] = -float(mimic.get("multiplier", 1.0))
+            if s_self < 0 and mimic.get("offset") is not None:
+                mimic["offset"] = -float(mimic["offset"])
+
+    if len(joints) != len(links) - 1:
+        _warn("payload step 4 failed: joint count mismatch, got "
+              f"{len(joints)} for {len(links)} links")
+        return None
+
+    parent_of = {}
+    for joint in joints:
+        child = joint["child"]
+        if child in parent_of:
+            _warn("payload step 4 failed: duplicate child in payload joints: "
+                  f"{child!r}")
+            return None
+        parent_of[child] = joint["parent"]
+
+    children_of = {}
+    for child, parent in parent_of.items():
+        children_of.setdefault(parent, []).append(child)
+
+    seen = {root_component}
+    queue = [root_component]
+    while queue:
+        cur = queue.pop()
+        for child in children_of.get(cur, []):
+            if child in seen:
+                continue
+            seen.add(child)
+            queue.append(child)
+
+    if seen != set(links):
+        _warn("payload step 4 failed: some payload links are not reachable "
+              f"from root {root_component!r}: {sorted(set(links) - seen)!r}")
+        return None
+
+    frame_out = []
+    frame_names = {str(r.get("link_name") or "").strip() for r in frame_links}
+    for rec in frame_links:
+        name = str(rec.get("link_name") or "").strip()
+        parent_name = str(rec.get("parent_link_name") or "").strip()
+        if any(str(other.get("parent_link_name") or "").strip() == name
+               for other in link_payloads):
+            _warn("payload step 3 failed: frame link "
+                  f"{name!r} has children; cannot express as a port")
+            return None
+        parent_component = link_to_component.get(parent_name)
+        if parent_component is None:
+            _warn("payload step 3 failed: frame link "
+                  f"{name!r} hangs off unknown parent {parent_name!r}")
+            return None
+        joint = rec.get("joint") or {}
+        coordsys_name = str(joint.get("coordsys_name") or "").strip() or None
+        origin, _origin_name = origin_from_coordsys(
+            parent_component, coordsys_name, axis_point=None,
+            context=f"frame link {name!r}")
+        frame_out.append({
+            "link_name": name,
+            "parent_component": parent_component,
+            "origin": origin,
+            "joint_name": str(joint.get("name") or "").strip(),
+        })
+    if frame_out:
+        print(f"      SW2URDF config: {len(frame_out)} component-less frame "
+              "link(s) emitted as ports: "
+              + ", ".join(sorted(frame_names)))
+
+    return {
+        "links": links,
+        "root_link": root_component,
+        "joints": joints,
+        "frame_links": frame_out,
+    }

--- a/sw2robot/exporter/sw2urdf_import/geometric.py
+++ b/sw2robot/exporter/sw2urdf_import/geometric.py
@@ -1,0 +1,318 @@
+"""Name-free reconstruction from reference geometry.
+
+Matches each RefAxis against the mate edges that lie on it to recover the
+joint tree, so an assembly whose features follow no naming convention still
+yields the configured kinematics.  Gated on the SW2URDF marker by the
+caller: stray reference axes in an unconfigured assembly must not trigger it.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+
+import numpy as np
+
+from ._common import (
+    _axis_line,
+    _component_stem,
+    _component_translation,
+    _coord_matrix,
+    _edge_line_candidates,
+    _field,
+    _line_matches,
+    _normalize_axis_direction,
+    _point_line_distance,
+    _warn,
+)
+
+
+def reconstruct_sw2urdf_config_geometric(components, coordinate_systems,
+                                         reference_axes, edges, ground,
+                                         tolerance=1e-5):
+    """Reconstruct SW2URDF mapping from marker-gated geometric evidence.
+
+    Parameters
+    ----------
+    components : sequence
+        Top-level components with ``name``.
+    coordinate_systems : sequence
+        Top-level coordinate systems with ``name`` and
+        ``document_from_frame``.
+    reference_axes : sequence
+        Top-level reference axes with ``name``, ``document_point``,
+        ``document_direction``.
+    edges : sequence
+        Top-level mate edges with ``a``, ``b``, axis and/or mate geometry.
+    ground : sequence[str]
+        Grounded top-level component names.
+    tolerance : float, optional
+        Distance/parallel tolerance in metres.
+
+    Returns
+    -------
+    dict | None
+        Mapping with keys ``links``, ``root_link``, ``joints`` when
+        reconstruction succeeds, else None.
+    """
+    if not (reference_axes or []):
+        _warn("geometric step 1 failed: no reference axes found")
+        return None
+
+    component_by_name = {
+        str(_field(component, "name")): component
+        for component in (components or [])
+    }
+
+    axis_meta = {}
+    pair_to_axis = {}
+    for axis in reference_axes or []:
+        axis_name = str(_field(axis, "name"))
+        line = _axis_line(axis)
+        if line is None:
+            _warn("geometric step 1 failed: reference axis "
+                  f"{axis_name!r} has degenerate direction")
+            return None
+
+        matched_pairs = {}
+        for edge in edges or []:
+            a = str(_field(edge, "a"))
+            b = str(_field(edge, "b"))
+            if a == b:
+                continue
+            support = [cand for cand in _edge_line_candidates(edge)
+                       if _line_matches(cand, line, tolerance)]
+            if not support:
+                continue
+            dist = min(float(np.linalg.norm(np.asarray(pv, float) - line[0]))
+                       for pv, _dv in support)
+            key = frozenset((a, b))
+            matched_pairs[key] = min(matched_pairs.get(key, float("inf")),
+                                     dist)
+
+        if not matched_pairs:
+            _warn("geometric step 1 failed: axis "
+                  f"{axis_name!r} matched no mate edge")
+            return None
+        # Mirrored limbs make pitch axes COLLINEAR across the robot, so
+        # several component pairs can sit on one line.  The owning pair's
+        # mate geometry lies at the axis feature's own definition point --
+        # rank by that distance and require a clear winner.
+        ranked = sorted(matched_pairs.items(),
+                        key=lambda kv: (kv[1], tuple(sorted(kv[0]))))
+        if len(ranked) > 1 and ranked[1][1] - ranked[0][1] <= tolerance:
+            pairs = [tuple(sorted(kv[0])) for kv in ranked[:2]]
+            _warn("geometric step 1 failed: axis "
+                  f"{axis_name!r} is equidistant to component pairs "
+                  f"{pairs!r}")
+            return None
+
+        pair = ranked[0][0]
+        if pair in pair_to_axis:
+            _warn("geometric step 1 failed: component pair "
+                  f"{tuple(sorted(pair))!r} matched by multiple axes "
+                  f"{pair_to_axis[pair]!r} and {axis_name!r}")
+            return None
+        pair_to_axis[pair] = axis_name
+        axis_meta[axis_name] = {
+            "pair": pair,
+            "axis_point": line[0].copy(),
+            "axis_direction": line[1].copy(),
+        }
+
+    link_set = set()
+    for pair in pair_to_axis:
+        link_set.update(pair)
+    if not link_set:
+        _warn("geometric step 2 failed: no link components matched by axes")
+        return None
+
+    ground_set = {str(name) for name in (ground or [])}
+    grounded_in_links = sorted(name for name in link_set if name in ground_set)
+    fixed_links = sorted(
+        name for name in link_set
+        if bool(_field(component_by_name.get(name), "fixed", False)))
+
+    # Root identification, most to least specific.  ``ground`` alone is NOT
+    # enough: the mate solver marks every immobile component as grounded, so
+    # a fully-constrained robot lists nearly all links there.
+    root = None
+    if len(fixed_links) == 1:
+        root = fixed_links[0]
+    if root is None:
+        # SW2URDF gives every link an origin CoordSys; the non-root ones sit
+        # ON their joint's axis line, so a frame claimed by NO axis is the
+        # root's.  Take the link component nearest to it, with a clear margin.
+        lines = [(meta["axis_point"], meta["axis_direction"])
+                 for meta in axis_meta.values()]
+        leftovers = []
+        for cs in coordinate_systems or []:
+            p = _coord_matrix(cs)[:3, 3]
+            if not any(_point_line_distance(p, lp, ld) <= tolerance
+                       for lp, ld in lines):
+                leftovers.append(p)
+        if len(leftovers) == 1:
+            dists = []
+            for name in sorted(link_set):
+                comp = component_by_name.get(name)
+                world = np.asarray(_field(comp, "world"), float).reshape(4, 4)
+                dists.append(
+                    (float(np.linalg.norm(world[:3, 3] - leftovers[0])),
+                     name))
+            dists.sort()
+            if len(dists) == 1 or dists[1][0] - dists[0][0] > tolerance:
+                root = dists[0][1]
+    if root is None and len(grounded_in_links) == 1:
+        root = grounded_in_links[0]
+    if root is None and not grounded_in_links and len(ground_set) == 1:
+        root = next(iter(ground_set))
+        link_set.add(root)
+    if root is None:
+        _warn("geometric step 3 failed: could not identify a unique root "
+              f"(fixed={fixed_links!r}, grounded-in-links="
+              f"{grounded_in_links!r})")
+        return None
+
+    if root not in component_by_name:
+        _warn("geometric step 3 failed: root component "
+              f"{root!r} is not present in components")
+        return None
+
+    neighbors = {name: [] for name in link_set}
+    for pair, axis_name in pair_to_axis.items():
+        a, b = tuple(pair)
+        if a not in link_set or b not in link_set:
+            continue
+        neighbors[a].append((b, axis_name))
+        neighbors[b].append((a, axis_name))
+    for name in neighbors:
+        neighbors[name].sort(key=lambda item: (item[0], item[1]))
+
+    parent = {}
+    axis_for_child = {}
+    child_order = []
+    seen = {root}
+    queue = deque([root])
+    while queue:
+        current = queue.popleft()
+        for neighbor, axis_name in neighbors.get(current, []):
+            if parent.get(current) == neighbor:
+                continue
+            if neighbor in seen:
+                _warn("geometric step 3 failed: axis-edge graph has a cycle")
+                return None
+            seen.add(neighbor)
+            parent[neighbor] = current
+            axis_for_child[neighbor] = axis_name
+            child_order.append(neighbor)
+            queue.append(neighbor)
+
+    if seen != link_set:
+        _warn("geometric step 3 failed: axis-edge graph is disconnected from "
+              f"root {root!r}; unreachable={sorted(link_set - seen)!r}")
+        return None
+    if len(axis_for_child) != len(link_set) - 1:
+        _warn("geometric step 3 failed: expected a tree with "
+              f"{len(link_set) - 1} edges, got {len(axis_for_child)}")
+        return None
+
+    coord_entries = []
+    for coord in coordinate_systems or []:
+        try:
+            coord_entries.append((str(_field(coord, "name")), _coord_matrix(coord)))
+        except Exception as e:
+            _warn(f"geometric step 4 warning: skipping invalid CoordSys: {e!r}")
+
+    claimed_coords = set()
+    links = {}
+
+    child_by_axis = {}
+    for child in child_order:
+        axis_name = axis_for_child[child]
+        child_by_axis[axis_name] = child
+        meta = axis_meta[axis_name]
+        axis_point = meta["axis_point"]
+        axis_direction = meta["axis_direction"]
+
+        candidates = []
+        for coord_name, coord_matrix in coord_entries:
+            if coord_name in claimed_coords:
+                continue
+            point = np.asarray(coord_matrix[:3, 3], float)
+            if _point_line_distance(point, axis_point, axis_direction) <= tolerance:
+                candidates.append((
+                    float(np.linalg.norm(point - axis_point)),
+                    coord_name,
+                    coord_matrix,
+                ))
+        candidates.sort(key=lambda item: (item[0], item[1]))
+
+        if candidates:
+            if (len(candidates) > 1 and
+                    abs(candidates[1][0] - candidates[0][0]) <= tolerance):
+                _warn("geometric step 4 failed: child "
+                      f"{child!r} has ambiguous CoordSys anchors on axis "
+                      f"{axis_name!r}")
+                return None
+            _, origin_name, origin = candidates[0]
+            claimed_coords.add(origin_name)
+        else:
+            origin_name = None
+            origin = np.eye(4)
+            origin[:3, 3] = axis_point
+
+        links[child] = {
+            "link_name": _component_stem(child),
+            "origin_name": origin_name,
+            "origin": origin,
+        }
+
+    leftover = [(name, mat) for name, mat in coord_entries
+                if name not in claimed_coords]
+    if len(leftover) == 1:
+        root_origin_name, root_origin = leftover[0]
+    else:
+        root_origin_name = None
+        root_origin = np.eye(4)
+        root_origin[:3, 3] = _component_translation(component_by_name[root])
+
+    links[root] = {
+        "link_name": _component_stem(root),
+        "origin_name": root_origin_name,
+        "origin": root_origin,
+    }
+
+    joints = []
+    for axis in reference_axes or []:
+        axis_name = str(_field(axis, "name"))
+        child = child_by_axis.get(axis_name)
+        if child is None:
+            continue
+        parent_name = parent.get(child)
+        if parent_name is None:
+            _warn("geometric step 3 failed: child "
+                  f"{child!r} has no parent for axis {axis_name!r}")
+            return None
+        meta = axis_meta[axis_name]
+        axis_dir, flipped = _normalize_axis_direction(meta["axis_direction"])
+        child_origin = np.asarray(links[child]["origin"][:3, 3], float)
+        joints.append({
+            "name": axis_name,
+            "parent": parent_name,
+            "child": child,
+            "axis_point": meta["axis_point"].copy(),
+            "axis_direction": axis_dir,
+            "axis_origin_distance": _point_line_distance(
+                child_origin, meta["axis_point"], meta["axis_direction"]),
+            "flipped": bool(flipped),
+        })
+
+    if len(joints) != len(link_set) - 1:
+        _warn("geometric step 3 failed: joint count mismatch, got "
+              f"{len(joints)} for {len(link_set)} links")
+        return None
+
+    return {
+        "links": links,
+        "root_link": root,
+        "joints": joints,
+    }

--- a/sw2robot/exporter/sw2urdf_import/naming.py
+++ b/sw2robot/exporter/sw2urdf_import/naming.py
@@ -1,0 +1,255 @@
+"""Reconstruction from the SW2URDF *naming convention*.
+
+The add-in's dialog defaults name a link's coordinate system ``<link>_origin``
+and the root's ``base_origin``; assemblies authored that way can be rebuilt
+from the feature names alone.  Assemblies that used other names need
+:mod:`.geometric` or the authoritative :mod:`.bridge` payload route.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._common import (
+    _axis_line,
+    _coord_matrix,
+    _edge_supports_axis,
+    _field,
+    _link_component_candidates,
+    _normalize_axis_direction,
+    _point_line_distance,
+    _warn,
+)
+
+
+def detect_sw2urdf_reference_geometry(components, coordinate_systems,
+                                      reference_axes):
+    """Return True when SW2URDF-style reference geometry is present.
+
+    Parameters
+    ----------
+    components : sequence
+        Top-level components.
+    coordinate_systems : sequence
+        Top-level coordinate systems.
+    reference_axes : sequence
+        Top-level reference axes.
+
+    Returns
+    -------
+    bool
+        True when at least two link components (matched by ``*_origin``) and
+        at least one reference axis exist.
+    """
+    links = _link_component_candidates(components, coordinate_systems)
+    return len(links) >= 2 and len(reference_axes or []) >= 1
+
+
+def reconstruct_sw2urdf_config(components, coordinate_systems, reference_axes,
+                               edges, ground, tolerance=1e-5):
+    """Reconstruct SW2URDF mapping from graph-level data.
+
+    Parameters
+    ----------
+    components : sequence
+        Top-level components with ``name``.
+    coordinate_systems : sequence
+        Top-level coordinate systems with ``name`` and
+        ``document_from_frame``.
+    reference_axes : sequence
+        Top-level reference axes with ``name``, ``document_point``,
+        ``document_direction``.
+    edges : sequence
+        Top-level mate edges with ``a``, ``b``, axis and/or mate geometry.
+    ground : sequence[str]
+        Grounded top-level component names.
+    tolerance : float, optional
+        Distance/parallel tolerance in metres.
+
+    Returns
+    -------
+    dict | None
+        Mapping with keys ``links``, ``root_link``, ``joints`` when
+        reconstruction succeeds, else None.
+    """
+    triggered = detect_sw2urdf_reference_geometry(
+        components, coordinate_systems, reference_axes)
+    if not triggered:
+        return None
+
+    coord_by_name = {str(_field(cs, "name")): cs for cs in coordinate_systems or []}
+    link_candidates = _link_component_candidates(components, coordinate_systems)
+
+    links = {}
+    stems = {}
+    for comp_name, rec in sorted(link_candidates.items()):
+        origin_names = rec["origin_names"]
+        if len(origin_names) != 1:
+            _warn("step 1 failed: ambiguous origin mapping for component "
+                  f"{comp_name!r}: {origin_names!r}")
+            return None
+        stem = rec["stem"]
+        if stem in stems and stems[stem] != comp_name:
+            _warn("step 1 failed: non-unique link stem "
+                  f"{stem!r} for {stems[stem]!r} and {comp_name!r}")
+            return None
+        stems[stem] = comp_name
+        origin_name = origin_names[0]
+        links[comp_name] = {
+            "link_name": stem,
+            "origin_name": origin_name,
+            "origin": _coord_matrix(coord_by_name[origin_name]),
+        }
+
+    if "base_origin" not in coord_by_name:
+        _warn("step 1 failed: base_origin coordinate system not found")
+        return None
+    roots = [name for name, rec in links.items()
+             if rec["origin_name"] == "base_origin"]
+    if len(roots) != 1:
+        _warn("step 1 failed: base_origin must map to exactly one link "
+              f"component, got {roots!r}")
+        return None
+    root = roots[0]
+    if root not in set(ground or []):
+        _warn("step 1 failed: base_origin link "
+              f"{root!r} is not grounded (ground={sorted(set(ground or []))!r})")
+        return None
+
+    origins = {name: rec["origin"][:3, 3].copy() for name, rec in links.items()}
+
+    axis_meta = {}
+    child_to_axis = {}
+    for axis in reference_axes or []:
+        axis_name = str(_field(axis, "name"))
+        line = _axis_line(axis)
+        if line is None:
+            _warn("step 2 failed: reference axis "
+                  f"{axis_name!r} has degenerate direction")
+            return None
+        dists = []
+        for comp_name, point in origins.items():
+            d = _point_line_distance(point, line[0], line[1])
+            dists.append((comp_name, d))
+        dists.sort(key=lambda x: (x[1], x[0]))
+        if dists[0][1] > tolerance:
+            _warn("step 2 failed: axis "
+                  f"{axis_name!r} is {dists[0][1]:.3e} m away from nearest "
+                  f"origin ({dists[0][0]!r}); tolerance={tolerance:g}")
+            return None
+        # Mirrored limbs make pitch axes COLLINEAR across the robot (both
+        # thigh origins sit on one Y-line), so several origins can lie on
+        # the axis line.  Disambiguate by 3D distance to the RefAxis's own
+        # definition point, which sits in the owning link's geometry.
+        on_line = [(name, float(np.linalg.norm(origins[name] - line[0])))
+                   for name, d in dists if d <= tolerance]
+        on_line.sort(key=lambda x: (x[1], x[0]))
+        child = on_line[0][0]
+        dmin = dict(dists)[child]
+        if len(on_line) > 1 and on_line[1][1] - on_line[0][1] <= tolerance:
+            _warn("step 2 failed: axis "
+                  f"{axis_name!r} child assignment is not unique between "
+                  f"{on_line[0][0]!r} and {on_line[1][0]!r} (both on the "
+                  "axis line, equidistant from the axis point)")
+            return None
+        if child == root:
+            _warn("step 2 failed: axis "
+                  f"{axis_name!r} mapped to root link {root!r}")
+            return None
+        if child in child_to_axis:
+            _warn("step 2 failed: link "
+                  f"{child!r} received multiple axes "
+                  f"{child_to_axis[child]!r} and {axis_name!r}")
+            return None
+        child_to_axis[child] = axis_name
+        axis_meta[axis_name] = {
+            "child": child,
+            "axis_point": line[0].copy(),
+            "axis_direction": line[1].copy(),
+            "axis_origin_distance": float(dmin),
+        }
+
+    non_root = sorted(name for name in links if name != root)
+    missing_children = [name for name in non_root if name not in child_to_axis]
+    if missing_children:
+        _warn("step 4 failed: non-root links without reference axis: "
+              f"{missing_children!r}")
+        return None
+
+    edge_by_pair = {}
+    link_names = set(links)
+    for edge in edges or []:
+        a = str(_field(edge, "a"))
+        b = str(_field(edge, "b"))
+        if a in link_names and b in link_names and a != b:
+            edge_by_pair[frozenset((a, b))] = edge
+
+    joints = []
+    for axis in reference_axes or []:
+        axis_name = str(_field(axis, "name"))
+        meta = axis_meta.get(axis_name)
+        if meta is None:
+            continue
+        child = meta["child"]
+        axis_line = (meta["axis_point"], meta["axis_direction"])
+        neighbors = sorted(
+            name for name in link_names
+            if name != child and frozenset((child, name)) in edge_by_pair)
+        matches = []
+        for nb in neighbors:
+            edge = edge_by_pair[frozenset((child, nb))]
+            if _edge_supports_axis(edge, axis_line, tolerance):
+                matches.append(nb)
+        if len(matches) != 1:
+            _warn("step 3 failed: child "
+                  f"{child!r} axis {axis_name!r} expected exactly one parent "
+                  f"neighbor on-axis, got {matches!r} from neighbors "
+                  f"{neighbors!r}")
+            return None
+        axis_dir, flipped = _normalize_axis_direction(meta["axis_direction"])
+        joints.append({
+            "name": axis_name,
+            "parent": matches[0],
+            "child": child,
+            "axis_point": meta["axis_point"].copy(),
+            "axis_direction": axis_dir,
+            "axis_origin_distance": meta["axis_origin_distance"],
+            "flipped": bool(flipped),
+        })
+
+    if len(joints) != len(links) - 1:
+        _warn("step 4 failed: joint count mismatch, got "
+              f"{len(joints)} for {len(links)} links")
+        return None
+
+    parent_of = {}
+    for joint in joints:
+        child = joint["child"]
+        if child in parent_of:
+            _warn("step 4 failed: duplicate child in reconstructed joints: "
+                  f"{child!r}")
+            return None
+        parent_of[child] = joint["parent"]
+
+    children_of = {}
+    for child, parent in parent_of.items():
+        children_of.setdefault(parent, []).append(child)
+    seen = {root}
+    queue = [root]
+    while queue:
+        cur = queue.pop()
+        for child in children_of.get(cur, []):
+            if child in seen:
+                continue
+            seen.add(child)
+            queue.append(child)
+    if seen != set(links):
+        _warn("step 4 failed: some links are not reachable from root "
+              f"{root!r}: {sorted(set(links) - seen)!r}")
+        return None
+
+    return {
+        "links": links,
+        "root_link": root,
+        "joints": joints,
+    }

--- a/sw2robot/exporter/sw2urdf_import/payload.py
+++ b/sw2robot/exporter/sw2urdf_import/payload.py
@@ -1,0 +1,412 @@
+"""SW2URDF DataContract payload parsing helpers."""
+
+from __future__ import annotations
+
+import base64
+import re
+import xml.etree.ElementTree as ET
+
+_Z_NS = "http://schemas.microsoft.com/2003/10/Serialization/"
+_I_NS = "http://www.w3.org/2001/XMLSchema-instance"
+_ZID = f"{{{_Z_NS}}}Id"
+_ZREF = f"{{{_Z_NS}}}Ref"
+_INIL = f"{{{_I_NS}}}nil"
+_ITYPE = f"{{{_I_NS}}}type"
+
+_PID_ENTRY_RE = re.compile(rb"\xff\xfe\xff(.)", re.DOTALL)
+
+
+def _warn(msg):
+    print("      !!! SW2URDF config warning: " + str(msg))
+
+
+def _local_name(tag):
+    if not isinstance(tag, str):
+        return ""
+    return tag.rsplit("}", 1)[-1]
+
+
+def _text(elem):
+    if elem is None:
+        return None
+    txt = (elem.text or "").strip()
+    return txt if txt != "" else ""
+
+
+def _is_nil(elem):
+    if elem is None:
+        return False
+    raw = str(elem.attrib.get(_INIL, "")).strip().lower()
+    return raw in ("true", "1")
+
+
+def _child(elem, name):
+    if elem is None:
+        return None
+    for ch in list(elem):
+        if _local_name(ch.tag) == name:
+            return ch
+    return None
+
+
+def _children(elem, name):
+    if elem is None:
+        return []
+    return [ch for ch in list(elem) if _local_name(ch.tag) == name]
+
+
+def _resolve_ref(elem, id_map, context="element"):
+    if elem is None:
+        return None
+    ref = elem.attrib.get(_ZREF)
+    if not ref:
+        return elem
+    target = id_map.get(ref)
+    if target is None:
+        _warn(f"{context} references missing z:Ref={ref!r}")
+        return None
+    return target
+
+
+def _parse_value(value_elem, id_map):
+    value_elem = _resolve_ref(value_elem, id_map, "Value")
+    if value_elem is None:
+        return None
+    if _is_nil(value_elem):
+        return None
+
+    itype = str(value_elem.attrib.get(_ITYPE, "")).lower()
+    if "arrayofdouble" in itype:
+        vals = []
+        for child in list(value_elem):
+            if _local_name(child.tag) != "double":
+                continue
+            txt = (child.text or "").strip()
+            if txt == "":
+                continue
+            try:
+                vals.append(float(txt))
+            except ValueError:
+                _warn(f"invalid array double value {txt!r}")
+                return None
+        return vals
+
+    txt = (value_elem.text or "").strip()
+    if "double" in itype:
+        if txt == "":
+            return None
+        try:
+            return float(txt)
+        except ValueError:
+            _warn(f"invalid numeric value {txt!r}")
+            return None
+
+    if txt != "":
+        return txt
+
+    if len(list(value_elem)) == 0:
+        return ""
+
+    parts = []
+    for child in list(value_elem):
+        if child.text:
+            parts.append(child.text)
+    return "".join(parts).strip()
+
+
+def _parse_attributes(owner_elem, id_map):
+    attrs = {}
+    attr_block = _resolve_ref(_child(owner_elem, "Attributes"), id_map, "Attributes")
+    for attr in _children(attr_block, "Attribute"):
+        attr = _resolve_ref(attr, id_map, "Attribute")
+        if attr is None:
+            continue
+        attr_type = _text(_child(attr, "AttributeType"))
+        if not attr_type:
+            continue
+        attrs[str(attr_type)] = _parse_value(_child(attr, "Value"), id_map)
+    return attrs
+
+
+def _decode_pid_blob(blob_text):
+    if not blob_text:
+        return []
+    try:
+        raw = base64.b64decode(blob_text.strip())
+    except Exception as exc:
+        _warn(f"invalid SW PID base64 payload: {exc!r}")
+        return []
+
+    out = []
+    for match in _PID_ENTRY_RE.finditer(raw):
+        nch = match.group(1)[0]
+        start = match.end()
+        end = start + (2 * nch)
+        if end > len(raw):
+            _warn("truncated SW PID entry in base64 payload")
+            break
+        payload = raw[start:end]
+        try:
+            text = payload.decode("utf-16le")
+        except UnicodeDecodeError:
+            text = payload.decode("utf-16le", errors="ignore")
+        text = text.strip("\x00")
+        if text:
+            out.append(text)
+
+    deduped = []
+    for item in out:
+        if item not in deduped:
+            deduped.append(item)
+    return deduped
+
+
+def _parse_pid_values(link_elem, field_name, id_map):
+    field = _resolve_ref(_child(link_elem, field_name), id_map, field_name)
+    if field is None or _is_nil(field):
+        return []
+
+    blobs = []
+    if _local_name(field.tag) == "base64Binary":
+        txt = (field.text or "").strip()
+        if txt:
+            blobs.append(txt)
+    for node in field.iter():
+        if _local_name(node.tag) != "base64Binary":
+            continue
+        txt = (node.text or "").strip()
+        if txt:
+            blobs.append(txt)
+
+    out = []
+    for blob in blobs:
+        out.extend(_decode_pid_blob(blob))
+
+    deduped = []
+    for item in out:
+        if item not in deduped:
+            deduped.append(item)
+    return deduped
+
+
+def _joint_type_name(elem):
+    raw = str(elem.attrib.get(_ITYPE, "") or "")
+    return raw.split(":", 1)[-1]
+
+
+def _joint_urdf_child(joint_elem, id_map, prop_name, itype_name):
+    direct = _resolve_ref(_child(joint_elem, prop_name), id_map, prop_name)
+    if direct is not None and _local_name(direct.tag) == "URDFElement":
+        return direct
+
+    child_block = _resolve_ref(_child(joint_elem, "ChildElements"), id_map, "ChildElements")
+    for child in _children(child_block, "URDFElement"):
+        child = _resolve_ref(child, id_map, "URDFElement")
+        if child is None:
+            continue
+        if _joint_type_name(child).lower() == itype_name.lower():
+            return child
+    return None
+
+
+def _joint_ref_attribute_value(joint_elem, id_map, field_name):
+    attr = _resolve_ref(_child(joint_elem, field_name), id_map, field_name)
+    if attr is None:
+        return None
+    if _local_name(attr.tag) != "Attribute":
+        return None
+    return _parse_value(_child(attr, "Value"), id_map)
+
+
+def _non_nil_subset(data, keys):
+    if not isinstance(data, dict):
+        return None
+    out = {}
+    for key in keys:
+        if key not in data:
+            continue
+        val = data.get(key)
+        if val is None:
+            continue
+        if isinstance(val, str) and val.strip() == "":
+            continue
+        out[key] = val
+    return out or None
+
+
+def _parse_joint(link_elem, id_map):
+    joint = _resolve_ref(_child(link_elem, "Joint"), id_map, "Joint")
+    if joint is None or _local_name(joint.tag) != "URDFElement":
+        child_block = _resolve_ref(_child(link_elem, "ChildElements"), id_map, "ChildElements")
+        for elem in _children(child_block, "URDFElement"):
+            elem = _resolve_ref(elem, id_map, "URDFElement")
+            if elem is None:
+                continue
+            if _joint_type_name(elem).lower() == "joint":
+                joint = elem
+                break
+    if joint is None:
+        return None
+
+    name_val = _joint_ref_attribute_value(joint, id_map, "NameAttribute")
+    type_val = _joint_ref_attribute_value(joint, id_map, "TypeAttribute")
+    name_text = str(name_val).strip() if name_val is not None else ""
+    type_text = str(type_val).strip().lower() if type_val is not None else ""
+
+    origin_attrs = _parse_attributes(_joint_urdf_child(joint, id_map, "Origin", "Origin"), id_map)
+    axis_attrs = _parse_attributes(_joint_urdf_child(joint, id_map, "Axis", "Axis"), id_map)
+    limit_attrs = _parse_attributes(_joint_urdf_child(joint, id_map, "Limit", "Limit"), id_map)
+    dynamics_attrs = _parse_attributes(_joint_urdf_child(joint, id_map, "Dynamics", "Dynamics"), id_map)
+    mimic_attrs = _parse_attributes(_joint_urdf_child(joint, id_map, "Mimic", "Mimic"), id_map)
+    safety_elem = _joint_urdf_child(joint, id_map, "Safety", "SafetyController")
+    safety_attrs = _parse_attributes(safety_elem, id_map)
+    calib_attrs = _parse_attributes(_joint_urdf_child(joint, id_map, "Calibration", "Calibration"), id_map)
+
+    axis_name = (_text(_child(joint, "AxisName")) or "").strip()
+    coordsys_name = (_text(_child(joint, "CoordinateSystemName")) or "").strip()
+
+    return {
+        "name": name_text or None,
+        "type": type_text or None,
+        "axis_name": axis_name or None,
+        "coordsys_name": coordsys_name or None,
+        "origin_xyz": origin_attrs.get("xyz"),
+        "origin_rpy": origin_attrs.get("rpy"),
+        "axis_xyz": axis_attrs.get("xyz"),
+        "limit": _non_nil_subset(limit_attrs, ("lower", "upper", "effort", "velocity")),
+        "dynamics": _non_nil_subset(dynamics_attrs, ("damping", "friction")),
+        "mimic": _non_nil_subset(mimic_attrs, ("joint", "multiplier", "offset")),
+        "safety": _non_nil_subset(
+            safety_attrs,
+            ("soft_lower_limit", "soft_upper_limit", "k_position", "k_velocity"),
+        ),
+        "calibration": _non_nil_subset(calib_attrs, ("rising", "falling")),
+    }
+
+
+def _parse_link_tree(link_elem, id_map, parent_link_name, out_rows):
+    link_elem = _resolve_ref(link_elem, id_map, "Link")
+    if link_elem is None or _local_name(link_elem.tag) != "Link":
+        _warn("encountered invalid Link node in SW2URDF payload")
+        return None
+
+    attrs = _parse_attributes(link_elem, id_map)
+    link_name = str(attrs.get("name") or "").strip()
+    if not link_name:
+        _warn("payload link is missing AttributeType='name'")
+        return None
+
+    components = _parse_pid_values(link_elem, "SWComponentPIDs", id_map)
+    main_components = _parse_pid_values(link_elem, "SWMainComponentPID", id_map)
+    for main in reversed(main_components):
+        if main not in components:
+            components.insert(0, main)
+
+    joint = _parse_joint(link_elem, id_map)
+    rec = {
+        "link_name": link_name,
+        "parent_link_name": parent_link_name,
+        "components": components,
+        "main_component": main_components[0] if main_components else None,
+        "joint": joint,
+    }
+
+    if parent_link_name is None:
+        root_rec = rec
+    else:
+        out_rows.append(rec)
+        root_rec = None
+
+    children_block = _resolve_ref(_child(link_elem, "Children"), id_map, "Children")
+    for child in _children(children_block, "Link"):
+        child_root = _parse_link_tree(child, id_map, link_name, out_rows)
+        if parent_link_name is None and child_root is not None:
+            _warn("unexpected nested root while parsing SW2URDF payload")
+
+    return root_rec
+
+
+def _empty_joint():
+    return {
+        "name": None,
+        "type": None,
+        "axis_name": None,
+        "coordsys_name": None,
+        "origin_xyz": None,
+        "origin_rpy": None,
+        "axis_xyz": None,
+        "limit": None,
+        "dynamics": None,
+        "mimic": None,
+        "safety": None,
+        "calibration": None,
+    }
+
+
+def parse_sw2urdf_payload(xml_text):
+    """Parse the SW2URDF payload XML into a compact link/joint tree.
+
+    Parameters
+    ----------
+    xml_text : str
+        Raw DataContract XML payload from the SW2URDF attribute feature.
+
+    Returns
+    -------
+    dict | None
+        Parsed payload dict on success, else None.
+    """
+    if not isinstance(xml_text, str) or not xml_text.strip():
+        _warn("payload XML text is empty")
+        return None
+
+    try:
+        root_elem = ET.fromstring(xml_text)
+    except ET.ParseError as exc:
+        _warn(f"payload XML is malformed: {exc}")
+        return None
+
+    if _local_name(root_elem.tag) != "Link":
+        _warn(f"unexpected payload root element: {_local_name(root_elem.tag)!r}")
+        return None
+
+    id_map = {}
+    for elem in root_elem.iter():
+        zid = elem.attrib.get(_ZID)
+        if zid:
+            id_map[zid] = elem
+
+    rows = []
+    root_rec = _parse_link_tree(root_elem, id_map, None, rows)
+    if not isinstance(root_rec, dict):
+        _warn("could not parse SW2URDF root link")
+        return None
+
+    root_joint = root_rec.get("joint") or {}
+    out = {
+        "root": {
+            "link_name": root_rec.get("link_name"),
+            "components": list(root_rec.get("components") or []),
+            "main_component": root_rec.get("main_component"),
+            "coordsys_name": root_joint.get("coordsys_name"),
+        },
+        "links": [],
+    }
+
+    if not out["root"]["link_name"]:
+        _warn("root link name is missing in payload")
+        return None
+
+    for row in rows:
+        joint = row.get("joint") or _empty_joint()
+        if row.get("parent_link_name") is None:
+            _warn(f"non-root payload link {row.get('link_name')!r} has no parent name")
+        out["links"].append({
+            "link_name": row.get("link_name"),
+            "parent_link_name": row.get("parent_link_name"),
+            "components": list(row.get("components") or []),
+            "main_component": row.get("main_component"),
+            "joint": joint,
+        })
+
+    return out

--- a/tests/test_sw2urdf_config.py
+++ b/tests/test_sw2urdf_config.py
@@ -1,0 +1,418 @@
+import base64
+import json
+
+import numpy as np
+import pytest
+
+from sw2robot.exporter.model import build_model
+from sw2robot.exporter.state import (
+    ComponentState,
+    CoordinateSystemState,
+    GraphState,
+    MateEdge,
+    ReferenceAxisState,
+)
+from sw2robot.exporter.sw2urdf_import import reconstruct_sw2urdf_config
+
+
+def _m4(xyz):
+    mat = np.eye(4)
+    mat[:3, 3] = np.asarray(xyz, float)
+    return [float(x) for x in mat.flatten()]
+
+
+def _comp(name, xyz):
+    return ComponentState(
+        name=name,
+        link_name=name.replace("-", "_"),
+        world=_m4(xyz),
+    )
+
+
+def _coord(name, xyz):
+    return CoordinateSystemState(
+        name=name,
+        document_from_frame=_m4(xyz),
+    )
+
+
+def _axis(name, point, direction):
+    return ReferenceAxisState(
+        name=name,
+        document_point=[float(x) for x in point],
+        document_direction=[float(x) for x in direction],
+    )
+
+
+def _edge(a, b, point, direction, mtype="CONCENTRIC"):
+    return MateEdge(
+        a=a,
+        b=b,
+        types=[mtype],
+        axis_point=[float(x) for x in point],
+        axis_dir=[float(x) for x in direction],
+        mates=[],
+    )
+
+
+def _graph(include_knee_axis=True):
+    comps = [
+        _comp("base_link-1", [0.0, 0.0, 0.0]),
+        _comp("hip_link-1", [0.0, 0.0, 0.1]),
+        _comp("shin-1", [0.0, 0.0, 0.2]),
+    ]
+    coords = [
+        _coord("base_origin", [0.0, 0.0, 0.0]),
+        _coord("hip_origin", [0.0, 0.0, 0.1]),   # hip_link-1 -> hip_origin
+        _coord("shin_origin", [0.0, 0.0, 0.2]),  # shin-1 -> shin_origin
+    ]
+    axes = [
+        _axis("hip_y", [0.0, 0.0, 0.1], [-1.0, 0.0, 0.0]),
+    ]
+    if include_knee_axis:
+        axes.append(_axis("knee_p", [0.0, 0.0, 0.2], [0.0, -2.0, 0.0]))
+    edges = [
+        _edge("base_link-1", "hip_link-1", [0.0, 0.0, 0.1], [1.0, 0.0, 0.0]),
+        _edge("hip_link-1", "shin-1", [0.0, 0.0, 0.2], [0.0, 1.0, 0.0]),
+        # Off-axis contact edge; must NOT be chosen as shin's parent.
+        _edge("base_link-1", "shin-1", [0.2, 0.0, 0.2], [0.0, 0.0, 1.0],
+              mtype="COINCIDENT"),
+    ]
+    return GraphState(
+        robot_name="sw2",
+        source_assembly="sw2.SLDASM",
+        components=comps,
+        edges=edges,
+        ground=["base_link-1"],
+        coordinate_systems=coords,
+        reference_axes=axes,
+    )
+
+
+def _graph_convention_free(marker=None):
+    graph = _graph(include_knee_axis=True)
+    graph.coordinate_systems = [
+        _coord("Origin_global", [0.0, 0.0, 0.0]),
+        _coord("frameA", [0.0, 0.0, 0.1]),
+        _coord("frameB", [0.0, 0.0, 0.2]),
+    ]
+    graph.sw2urdf_marker = marker
+    return graph
+
+
+def _reconstruct(graph):
+    return reconstruct_sw2urdf_config(
+        graph.components,
+        graph.coordinate_systems,
+        graph.reference_axes,
+        graph.edges,
+        graph.ground,
+    )
+
+
+def test_sw2urdf_detection_and_reconstruction():
+    graph = _graph(include_knee_axis=True)
+    cfg = _reconstruct(graph)
+    assert cfg is not None
+    assert cfg["root_link"] == "base_link-1"
+
+    # Both origin naming forms are accepted:
+    # - hip_link-1 -> hip_origin (drop _link)
+    # - shin-1 -> shin_origin (exact stem)
+    assert cfg["links"]["hip_link-1"]["origin_name"] == "hip_origin"
+    assert cfg["links"]["shin-1"]["origin_name"] == "shin_origin"
+
+    by_name = {joint["name"]: joint for joint in cfg["joints"]}
+    assert set(by_name) == {"hip_y", "knee_p"}
+
+    # Child assignment is by axis-line distance to origins.
+    assert by_name["hip_y"]["child"] == "hip_link-1"
+    assert by_name["knee_p"]["child"] == "shin-1"
+    assert by_name["hip_y"]["axis_origin_distance"] == pytest.approx(0.0)
+    assert by_name["knee_p"]["axis_origin_distance"] == pytest.approx(0.0)
+
+    # Parent selection rejects the off-axis contact edge base<->shin.
+    assert by_name["hip_y"]["parent"] == "base_link-1"
+    assert by_name["knee_p"]["parent"] == "hip_link-1"
+
+    # Sign normalization: largest-|component| must be positive.
+    np.testing.assert_allclose(by_name["hip_y"]["axis_direction"], [1.0, 0.0, 0.0])
+    np.testing.assert_allclose(by_name["knee_p"]["axis_direction"], [0.0, 1.0, 0.0])
+    assert by_name["hip_y"]["flipped"] is True
+    assert by_name["knee_p"]["flipped"] is True
+
+
+def test_sw2urdf_detection_negative_without_origins():
+    graph = _graph(include_knee_axis=True)
+    graph.coordinate_systems = []
+    assert _reconstruct(graph) is None
+
+
+def test_sw2urdf_geometric_route_with_marker():
+    graph = _graph_convention_free(marker="URDF Export Configuration (v1.4)")
+    model = build_model(graph, config={"sw2urdf_config": "auto"})
+    by_name = {j.name: j for j in model.joints}
+    assert set(by_name) == {"hip_y", "knee_p"}
+    assert by_name["hip_y"].parent == "base_link"
+    assert by_name["hip_y"].child == "hip_link"
+    assert by_name["knee_p"].parent == "hip_link"
+    assert by_name["knee_p"].child == "shin"
+
+
+def test_sw2urdf_geometric_route_not_attempted_without_marker():
+    graph = _graph_convention_free(marker=None)
+    model = build_model(graph, config={"sw2urdf_config": "auto"})
+    assert [j.name for j in model.joints] == [
+        "base_link_1__hip_link_1",
+        "hip_link_1__shin_1",
+    ]
+
+
+def test_sw2urdf_geometric_route_falls_back_when_axis_has_no_edge():
+    graph = _graph_convention_free(marker="URDF Export Configuration (v1.4)")
+    graph.reference_axes = [
+        _axis("hip_y", [0.0, 0.0, 0.1], [-1.0, 0.0, 0.0]),
+        _axis("knee_p", [1.0, 1.0, 1.0], [0.0, 1.0, 0.0]),
+    ]
+    model = build_model(graph, config={"sw2urdf_config": "auto"})
+    assert [j.name for j in model.joints] == [
+        "base_link_1__hip_link_1",
+        "hip_link_1__shin_1",
+    ]
+
+
+def test_sw2urdf_require_vs_auto_fallback():
+    # Trigger detection but force inconsistency: shin has no axis.
+    graph = _graph(include_knee_axis=False)
+
+    model = build_model(graph, config={"sw2urdf_config": "auto"})
+    assert len(model.joints) == len(model.components) - 1
+
+    with pytest.raises(RuntimeError, match="sw2urdf_config=require"):
+        build_model(graph, config={"sw2urdf_config": "require"})
+
+
+def test_sw2urdf_user_joint_echo_keeps_config_and_merges_limits():
+    # The generated joints.yaml snapshots the applied tree; feeding it back
+    # (same parent/child/type) must keep the configured joint name/axis and
+    # only take the user's explicit limits.
+    graph = _graph(include_knee_axis=True)
+    cfg = {"sw2urdf_config": "auto", "joints": [
+        {"parent": "base_link-1", "child": "hip_link-1", "type": "revolute",
+         "lower": -0.5, "upper": 0.5},
+    ]}
+    model = build_model(graph, config=cfg)
+    by_name = {j.name: j for j in model.joints}
+    assert "hip_y" in by_name and "knee_p" in by_name
+    assert by_name["hip_y"].lower == -0.5
+    assert by_name["hip_y"].upper == 0.5
+
+
+def test_sw2urdf_user_joint_rewire_overrides_config():
+    # A user entry that re-wires a configured child (different parent/type)
+    # replaces that configured joint; the others stay.
+    graph = _graph(include_knee_axis=True)
+    cfg = {"sw2urdf_config": "auto", "joints": [
+        {"parent": "base_link-1", "child": "shin-1", "type": "fixed"},
+    ]}
+    model = build_model(graph, config=cfg)
+    by_name = {j.name: j for j in model.joints}
+    assert "hip_y" in by_name
+    assert "knee_p" not in by_name
+    fixed = [j for j in model.joints if j.jtype == "fixed"]
+    assert len(fixed) == 1
+    assert fixed[0].child == "shin"
+
+
+def test_sw2urdf_marker_defaults_none_on_older_graph_json():
+    payload = json.loads(_graph(include_knee_axis=True).model_dump_json())
+    payload.pop("sw2urdf_marker", None)
+    payload.pop("sw2urdf_config_xml", None)
+    graph = GraphState.model_validate_json(json.dumps(payload))
+    assert graph.sw2urdf_marker is None
+    assert graph.sw2urdf_config_xml is None
+
+
+def test_sw2urdf_link_name_collision_falls_back():
+    # A non-SW2URDF component whose link name equals a reconstructed stem
+    # must not silently produce duplicate URDF link names.
+    graph = _graph(include_knee_axis=True)
+    stray = _comp("stray-9", [0.5, 0.5, 0.5])
+    stray.link_name = "shin"
+    graph.components.append(stray)
+
+    model = build_model(graph, config={"sw2urdf_config": "auto"})
+    joint_names = {j.name for j in model.joints}
+    assert not joint_names & {"hip_y", "knee_p"}
+
+    with pytest.raises(RuntimeError, match="sw2urdf_config=require"):
+        build_model(graph, config={"sw2urdf_config": "require"})
+
+
+def _pid_blob(name):
+    raw = (b"\x10\x00\x00\x00\x01\x00\x00\x00" + b"\xff\xfe\xff"
+           + bytes([len(name)]) + name.encode("utf-16-le"))
+    return base64.b64encode(raw).decode()
+
+
+def _payload_xml():
+    # Minimal SW2URDF DataContract payload: base_link -> hip_link, one
+    # revolute joint naming its RefAxis/CoordSys features explicitly.
+    return f'''<Link xmlns:z="http://schemas.microsoft.com/2003/10/Serialization/" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Attributes>
+    <Attribute><AttributeType>name</AttributeType><Value>base_link</Value></Attribute>
+  </Attributes>
+  <ChildElements/>
+  <ElementName>link</ElementName>
+  <Children>
+    <Link>
+      <Attributes>
+        <Attribute><AttributeType>name</AttributeType><Value>hip_link</Value></Attribute>
+      </Attributes>
+      <ChildElements>
+        <URDFElement i:type="Joint">
+          <Attributes>
+            <Attribute z:Id="j1"><AttributeType>name</AttributeType><Value>hip_y</Value></Attribute>
+            <Attribute z:Id="j2"><AttributeType>type</AttributeType><Value>revolute</Value></Attribute>
+          </Attributes>
+          <ChildElements/>
+          <ElementName>joint</ElementName>
+          <AxisName>hip_y</AxisName>
+          <CoordinateSystemName>frameA</CoordinateSystemName>
+          <NameAttribute z:Ref="j1"/>
+          <TypeAttribute z:Ref="j2"/>
+        </URDFElement>
+      </ChildElements>
+      <ElementName>link</ElementName>
+      <Children/>
+      <SWComponentPIDs><base64Binary>{_pid_blob("hip_link-1@asm")}</base64Binary></SWComponentPIDs>
+    </Link>
+  </Children>
+  <SWComponentPIDs><base64Binary>{_pid_blob("base_link-1@asm")}</base64Binary></SWComponentPIDs>
+</Link>'''
+
+
+def _payload_graph(config_xml):
+    # Convention-free coordsys names and NO marker: neither the name route
+    # nor the geometric route can apply, so only the payload route can
+    # produce the configured joint names.
+    graph = GraphState(
+        robot_name="sw2", source_assembly="sw2.SLDASM",
+        components=[_comp("base_link-1", [0.0, 0.0, 0.0]),
+                    _comp("hip_link-1", [0.0, 0.0, 0.1])],
+        edges=[_edge("base_link-1", "hip_link-1",
+                     [0.0, 0.0, 0.1], [1.0, 0.0, 0.0])],
+        ground=["base_link-1"],
+        coordinate_systems=[_coord("Origin_global", [0.0, 0.0, 0.0]),
+                            _coord("frameA", [0.0, 0.0, 0.1])],
+        reference_axes=[_axis("hip_y", [0.0, 0.0, 0.1], [-1.0, 0.0, 0.0])],
+        sw2urdf_config_xml=config_xml,
+    )
+    return graph
+
+
+def test_sw2urdf_payload_route_wins_without_naming_convention():
+    model = build_model(_payload_graph(_payload_xml()),
+                        config={"sw2urdf_config": "auto"})
+    by_name = {j.name: j for j in model.joints}
+    assert set(by_name) == {"hip_y"}
+    assert by_name["hip_y"].jtype == "revolute"
+    assert by_name["hip_y"].parent == "base_link"
+    assert by_name["hip_y"].child == "hip_link"
+    # axis from the NAMED RefAxis feature, sign-normalized to +X
+    np.testing.assert_allclose(by_name["hip_y"].axis, [1.0, 0.0, 0.0])
+
+
+def test_sw2urdf_payload_malformed_falls_back():
+    model = build_model(_payload_graph("<not-a-link/>"),
+                        config={"sw2urdf_config": "auto"})
+    assert [j.name for j in model.joints] == ["base_link_1__hip_link_1"]
+
+
+def test_sw2urdf_payload_scoped_coordsys_resolves_via_subassembly():
+    # The add-in may reference a CoordSys inside a link sub-assembly; the
+    # payload then scopes the name as "frameA <hip_link-1>".  It must resolve
+    # through that component's sub-assembly frames (composed with the
+    # component world), not fall back to the axis point: the sub coordsys
+    # here sits 0.02 ALONG the axis, so the joint anchor lands at x=0.02.
+    from sw2robot.exporter.state import SubGraph
+
+    xml = _payload_xml().replace(
+        "<CoordinateSystemName>frameA</CoordinateSystemName>",
+        "<CoordinateSystemName>frameA &lt;hip_link-1&gt;"
+        "</CoordinateSystemName>")
+    graph = _payload_graph(xml)
+    graph.coordinate_systems = [_coord("Origin_global", [0.0, 0.0, 0.0])]
+    for c in graph.components:
+        if c.name == "hip_link-1":
+            c.part_path = r"C:\cad\hip_link.SLDASM"
+    graph.subassemblies = {
+        r"C:\cad\hip_link.SLDASM": SubGraph(coordinate_systems=[
+            _coord("frameA", [0.02, 0.0, 0.0])]),
+    }
+    model = build_model(graph, config={"sw2urdf_config": "auto"})
+    by_name = {j.name: j for j in model.joints}
+    assert set(by_name) == {"hip_y"}
+    np.testing.assert_allclose(by_name["hip_y"].xyz, [0.02, 0.0, 0.1],
+                               atol=1e-12)
+
+
+def _pid_blob2(*names):
+    raw = b"\x10\x00\x00\x00\x02\x00\x00\x00"
+    for name in names:
+        raw += (b"\xff\xfe\xff" + bytes([len(name)])
+                + name.encode("utf-16-le"))
+    return base64.b64encode(raw).decode()
+
+
+def test_sw2urdf_payload_multi_component_link_gets_fixed_members():
+    # SW2URDF allows several loose components per link: the first PID acts
+    # as the main (tree) component, the rest become rigid FIXED children.
+    xml = _payload_xml().replace(
+        _pid_blob("hip_link-1@asm"),
+        _pid_blob2("hip_link-1@asm", "bracket-1@asm"))
+    graph = _payload_graph(xml)
+    graph.components.append(_comp("bracket-1", [0.0, 0.1, 0.1]))
+    model = build_model(graph, config={"sw2urdf_config": "auto"})
+    by_name = {j.name: j for j in model.joints}
+    assert "hip_y" in by_name
+    fixed = [j for j in model.joints if j.jtype == "fixed"]
+    assert len(fixed) == 1
+    assert fixed[0].parent == "hip_link"
+    assert fixed[0].child == "bracket_1"
+
+
+def test_sw2urdf_payload_shared_component_fails_partition_check():
+    # A component claimed by TWO links (transmission-style config) cannot
+    # form a URDF tree; the payload route must fail loudly and fall back.
+    xml = _payload_xml().replace(
+        _pid_blob("hip_link-1@asm"),
+        _pid_blob2("hip_link-1@asm", "base_link-1@asm"))
+    graph = _payload_graph(xml)
+    model = build_model(graph, config={"sw2urdf_config": "auto"})
+    assert [j.name for j in model.joints] == ["base_link_1__hip_link_1"]
+
+
+def test_sw2urdf_payload_limits_mirrored_on_axis_flip():
+    # The synthetic hip_y axis points -X, so normalization flips it to +X;
+    # payload limits are expressed in the ORIGINAL joint coordinate and must
+    # be mirrored: (lower, upper) -> (-upper, -lower).
+    xml = _payload_xml().replace(
+        "<ElementName>joint</ElementName>",
+        '''<ChildElements><URDFElement z:Id="LIM" i:type="Limit">
+          <Attributes>
+            <Attribute z:Id="L1"><AttributeType>lower</AttributeType><Value i:type="a:double" xmlns:a="http://www.w3.org/2001/XMLSchema">-1.0</Value></Attribute>
+            <Attribute z:Id="L2"><AttributeType>upper</AttributeType><Value i:type="a:double" xmlns:a="http://www.w3.org/2001/XMLSchema">0.5</Value></Attribute>
+          </Attributes>
+          <ChildElements/><ElementName>limit</ElementName>
+          <LowerAttribute z:Ref="L1"/><UpperAttribute z:Ref="L2"/>
+        </URDFElement></ChildElements><ElementName>joint</ElementName>
+        <Limit z:Ref="LIM"/>''',
+        1)
+    graph = _payload_graph(xml)
+    model = build_model(graph, config={"sw2urdf_config": "auto"})
+    by_name = {j.name: j for j in model.joints}
+    assert "hip_y" in by_name
+    np.testing.assert_allclose(by_name["hip_y"].axis, [1.0, 0.0, 0.0])
+    assert by_name["hip_y"].lower == pytest.approx(-0.5)
+    assert by_name["hip_y"].upper == pytest.approx(1.0)


### PR DESCRIPTION
An assembly configured with the classic ros/solidworks_urdf_exporter add-in carries its whole URDF configuration inside the SolidWorks document, so read it and build the link/joint tree from it instead of inferring one from mates. Routes, most to least authoritative: the add-in's serialized attribute payload, the <link>_origin naming convention, a name-free geometric reconstruction, then the usual mate inference -- each fallback says why.
