### PR TITLE
Fix two silent failures: the joint name filter, and `sw2urdf_config: off`

### DIFF
--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -4414,6 +4414,12 @@ function buildJointRows(robot) {
   jointsEl.innerHTML = '';
   rows.clear();
   syncTreeModeControls();
+  // the child/parent link of a joint, read off its URDF node.  buildPlayRows
+  // and the rename list each declare their own copy; this one was MISSING, so
+  // the name filter below threw ReferenceError -- silently, because that path
+  // only runs once the user types something into #jfilter.
+  const linkOf = (j, tag) => [...(j.urdfNode?.children ?? [])]
+    .find(el => el.tagName === tag)?.getAttribute('link') ?? '';
   const movable = Object.values(robot?.joints ?? {})
     .filter(j => j.jointType !== 'fixed').length;
   if (effectiveTreeViewMode() === 'subassembly') {

--- a/sw2robot/exporter/model.py
+++ b/sw2robot/exporter/model.py
@@ -3660,6 +3660,11 @@ def build_model(graph, robot_name=None, base_hint=None, config=None,
     sw2_mode = "auto"
     if config and config.get("sw2urdf_config") is not None:
         sw2_mode = str(config.get("sw2urdf_config")).strip().lower() or "auto"
+    # YAML reads a bare `off:` as the boolean False (and `on:`/`yes:` as True),
+    # so `sw2urdf_config: off` -- the spelling the generated joints.yaml
+    # documents -- arrived here as 'false', was rejected as unknown, and the
+    # embedded config stayed applied.
+    sw2_mode = {"false": "off", "true": "auto"}.get(sw2_mode, sw2_mode)
     if sw2_mode not in ("auto", "off", "require"):
         print(f"      WARN: sw2urdf_config={sw2_mode!r} is unknown; using 'auto'")
         sw2_mode = "auto"

--- a/tests/e2e/run.mjs
+++ b/tests/e2e/run.mjs
@@ -294,6 +294,32 @@ if (colReady) {
   }
 }
 
+// ---- 8b. the joint-name filter --------------------------------------------
+// Typing in #jfilter takes a DIFFERENT branch of buildJointRows, and nothing
+// else in this suite ever enters it -- which is how it stayed broken (an
+// undefined `linkOf`) without the load-time "no page errors" check noticing.
+const beforeFilter = pageErrors.length;
+const filterRows = await page.evaluate(async () => {
+  const el = document.getElementById('jfilter');
+  const anyChild = Object.values(document.getElementById('viewer').robot?.joints ?? {})
+    .map(j => [...(j.urdfNode?.children ?? [])]
+      .find(c => c.tagName === 'child')?.getAttribute('link') ?? '')
+    .find(Boolean) ?? '';
+  el.value = anyChild.slice(0, 6);
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+  await new Promise(r => setTimeout(r, 300));
+  const n = document.querySelectorAll('.joint:not(.root)').length;
+  el.value = '';
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+  await new Promise(r => setTimeout(r, 300));
+  return { n, restored: document.querySelectorAll('.joint:not(.root)').length };
+});
+check('jfilter: matches at least one joint', filterRows.n >= 1,
+      `matched ${filterRows.n}`);
+check('jfilter: clearing restores the tree', filterRows.restored >= filterRows.n);
+check('jfilter: no page errors', pageErrors.length === beforeFilter,
+      pageErrors.slice(beforeFilter).join(' | '));
+
 // ---- 9. auto joint limits (self-collision sweep) ---------------------------
 // reuses the collision model from section 8 (already reloaded, non-drop).
 // The flow does an async rebuild+reload (~20s for 126 meshes), so POLL for

--- a/tests/test_sw2urdf_config.py
+++ b/tests/test_sw2urdf_config.py
@@ -416,3 +416,27 @@ def test_sw2urdf_payload_limits_mirrored_on_axis_flip():
     np.testing.assert_allclose(by_name["hip_y"].axis, [1.0, 0.0, 0.0])
     assert by_name["hip_y"].lower == pytest.approx(-0.5)
     assert by_name["hip_y"].upper == pytest.approx(1.0)
+
+
+def test_sw2urdf_config_off_accepts_the_yaml_boolean():
+    """`sw2urdf_config: off` is the spelling the generated joints.yaml
+    documents, and YAML turns a bare `off` into the boolean False -- which
+    used to be rejected as an unknown mode, leaving the embedded config
+    APPLIED when the user had asked for the opposite."""
+    import yaml
+
+    graph = _graph_convention_free(marker="URDF Export Configuration (v1.4)")
+    cfg = yaml.safe_load("sw2urdf_config: off\n")
+    assert cfg == {"sw2urdf_config": False}
+
+    applied = build_model(graph, config={"sw2urdf_config": "auto"})
+    assert {j.name for j in applied.joints} == {"hip_y", "knee_p"}
+
+    off = build_model(graph, config=cfg)
+    assert [j.name for j in off.joints] == [
+        "base_link_1__hip_link_1",
+        "hip_link_1__shin_1",
+    ]
+    # and the boolean TRUE keeps the default
+    on = build_model(graph, config=yaml.safe_load("sw2urdf_config: yes\n"))
+    assert {j.name for j in on.joints} == {"hip_y", "knee_p"}


### PR DESCRIPTION
The joint name filter has thrown ReferenceError since it was added.
buildJointRows reads a joint's child link through `linkOf`, which buildPlayRows
and the rename list each declare for themselves but which was never declared
there, so typing in the filter empties the list and the error only reaches the
console. The e2e suite already asserts that the page raises no errors, but no
test had ever typed into the filter, so nothing entered that branch.

Separately, the generated joints.yaml documents `sw2urdf_config: off`, and YAML
reads a bare `off` as the boolean False. build_model saw the string 'false',
warned that the mode was unknown and fell back to 'auto', so the embedded
SW2URDF configuration stayed applied when the user had asked for it to be
ignored.

Both fixes are one line each and change nothing else; each comes with a test
that goes red when the fix is reverted.
