### PR TITLE
Use a CAD reference axis to define a joint, and show why each joint came out that way

### DIFF
--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -251,6 +251,14 @@
                      background: #3d3556; color: #c5b3ff; }
   .joint .motag { font-size: 10px; padding: 0 4px; border-radius: 3px;
                   background: #4a3d22; color: #d6b36b; }
+  /* a joint the classifier GUESSED at: the note says why, and clicking it
+     marks the joint reviewed (persisted as joints.yaml `joint_reviewed:`) */
+  .joint .chktag { font-size: 10px; padding: 0 4px; border-radius: 3px;
+                   background: #5a2f2f; color: #ffb3b3; cursor: help;
+                   border: 1px solid #7a4141; }
+  .joint .chktag:hover { background: #6d3838; }
+  .joint .chktag.done { background: #2f4a35; color: #9fe0ad;
+                        border-color: #3f6046; }
   button { background: #3a3f48; color: #ddd; border: 1px solid #555;
            border-radius: 4px; padding: 4px 10px; cursor: pointer; }
   button:hover { background: #474d58; }
@@ -745,6 +753,12 @@
                style="flex:1;min-width:0;background:#15171a;color:#cfe3ff;
                       border:1px solid #444;border-radius:3px;padding:2px 6px;
                       font-size:11px">
+        <button id="jcheckonly"
+                title="Show only the joints the classifier guessed at"
+                style="display:none;background:#5a2f2f;color:#ffb3b3;
+                       border:1px solid #7a4141;border-radius:3px;
+                       padding:1px 6px;font-size:10px;white-space:nowrap;
+                       cursor:pointer">?</button>
         <span id="jfiltercount" style="color:#8a93a3;font-size:10px;
               white-space:nowrap"></span>
         <select id="treemode" data-i18n-title="t.treeMode"
@@ -1250,6 +1264,12 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     'row.jnameTitle': { en: a => `joint: ${a.name}\n${a.parent} → ${a.child}`,
                         ja: a => `関節: ${a.name}\n${a.parent} → ${a.child}` },
     'row.eyeTitle': { en: 'show/hide this link', ja: 'このリンクを表示/非表示' },
+    'row.chkHint': { en: 'Click to mark this joint reviewed.',
+                     ja: 'クリックで確認済みにします。' },
+    'row.chkDone': { en: 'reviewed - click to flag it again',
+                     ja: '確認済み — クリックで戻します' },
+    'jfilter.checkCount': { en: a => `${a.n} to check`,
+                            ja: a => `要確認 ${a.n} 件` },
     'row.eyeMassOnly': { en: 'mass-only link: no geometry to show/hide',
                          ja: '質量のみリンク: 表示/非表示できる形状がありません' },
     'row.mkrootTitle': { en: 'make this link the root (re-roots the tree + rebuilds)',
@@ -2170,6 +2190,10 @@ let dropMode = false;          // meshes come from dropped blobs, not /pkg/
 let currentInfo = null;        // {name, urdf} of the open server package
 let mergedView = false;        // viewer shows the fixed-joint-lumped URDF
 let compMeta = {};             // link -> {material, density, name, override}
+// HTML-attribute escape for text that goes into a title="" (classifier notes
+// carry quotes and angle brackets)
+const escAttr = v => String(v ?? '').replace(/[&<>"]/g,
+  c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
 let linkColors = {};           // URDF/viewer link name -> '#rrggbb' override
 let excludedList = [];         // component names excluded from the URDF
 let massOnlyLinks = new Set(); // links flagged mass-only (weight kept, no mesh)
@@ -2748,6 +2772,9 @@ viewer.loadMeshFunc = (path, manager, done) => {
 // ---- joint rows: slider (movable) + type select + bulk checkbox ---------
 const fmt = v => (Math.abs(v) < 1e-10 ? 0 : v).toFixed(2);
 const rows = new Map();        // joint name -> row record
+// when on, the joint list shows ONLY the joints the classifier flagged as
+// guesses (compMeta[...].joint_attention) -- the review worklist
+let jointCheckOnly = false;
 let jointFilter = '';          // substring filter: when set, the tree collapses
                                // to a FLAT list of joints whose link/joint name
                                // matches -- so select-all / Set / Delete scope
@@ -4496,6 +4523,16 @@ function buildJointRows(robot) {
       `${child}</span>` +
       (isMimic ? `<span class="mimictag">mimic</span>` : '') +
       (massOnlyLinks.has(child) ? `<span class="motag">mass</span>` : '') +
+      // the classifier's own reason, and a badge when it is one of the
+      // guesses worth checking (the server decides -- _JOINT_ATTENTION)
+      (compMeta[child]?.joint_attention
+        ? `<span class="chktag" title="${escAttr(compMeta[child].joint_attention)}` +
+          `&#10;&#10;${escAttr(compMeta[child].joint_note)}` +
+          `&#10;&#10;${escAttr(t('row.chkHint'))}">?</span>`
+        : (compMeta[child]?.joint_reviewed
+            ? `<span class="chktag done" title="${escAttr(t('row.chkDone'))}` +
+              `&#10;&#10;${escAttr(compMeta[child].joint_note)}">✓</span>`
+            : '')) +
       // a mass-only link reads as 'mass_only' (its joint is fixed underneath);
       // picking any real type clears the flag, picking mass_only sets it
       `<select class="jtypesel t-${massOnlyLinks.has(child)
@@ -4547,6 +4584,20 @@ function buildJointRows(robot) {
                             child: rec.child, type: t }]);
       }
     });
+    const chk = row.querySelector('.chktag');
+    if (chk) {
+      chk.addEventListener('click', async ev => {
+        ev.stopPropagation();
+        const on = !compMeta[child]?.joint_reviewed;
+        // acknowledgement only -- it changes nothing about the model, so
+        // there is no rebuild (same contract as /api/set_mass_reviewed)
+        await fetch('/api/set_joint_reviewed', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ link: child, reviewed: on }) });
+        await refreshCompMeta();
+        if (viewer.robot) { buildJointRows(viewer.robot); }
+      });
+    }
     row.querySelector('.mkroot').addEventListener('click',
       () => reRoot(child));
     row.classList.toggle('hiddenlink', hiddenLinks.has(child));
@@ -4589,6 +4640,23 @@ function buildJointRows(robot) {
   // holds exactly the matches, so select-all / Set / Delete scope to them.
   const q = jointFilter.trim().toLowerCase();
   const countEl = document.getElementById('jfiltercount');
+  // "needs check": the joints the server flagged as guesses
+  const flagged = Object.values(robot?.joints ?? {}).filter(
+    j => compMeta[linkOf(j, 'child')]?.joint_attention);
+  const chkBtn = document.getElementById('jcheckonly');
+  if (chkBtn) {
+    chkBtn.style.display = flagged.length ? '' : 'none';
+    chkBtn.textContent = t('jfilter.checkCount', { n: flagged.length });
+    chkBtn.style.opacity = jointCheckOnly ? '1' : '.55';
+  }
+  if (jointCheckOnly && flagged.length) {
+    for (const j of flagged.sort(
+        (a, b) => linkOf(a, 'child').localeCompare(linkOf(b, 'child')))) {
+      jointRow(j, 0, true);
+    }
+    if (countEl) { countEl.textContent = ''; }
+    return movable;
+  }
   if (q) {
     const matches = Object.values(robot.joints)
       .filter(j => linkOf(j, 'child').toLowerCase().includes(q)
@@ -6492,7 +6560,13 @@ viewer.addEventListener('joint-mouseout',
 const _jfilterEl = document.getElementById('jfilter');
 _jfilterEl.addEventListener('input', () => {
   jointFilter = _jfilterEl.value;
+  jointCheckOnly = false;         // typing a name means "search", not "review"
   document.getElementById('selall').checked = false;
+  if (viewer.robot) { buildJointRows(viewer.robot); }
+});
+document.getElementById('jcheckonly').addEventListener('click', () => {
+  jointCheckOnly = !jointCheckOnly;
+  if (jointCheckOnly) { jointFilter = ''; _jfilterEl.value = ''; }
   if (viewer.robot) { buildJointRows(viewer.robot); }
 });
 // Esc clears the filter (without bubbling to the global Escape handler)

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1004,6 +1004,82 @@ def _urdf_link_masses(pkg_dir, urdf_rel):
     return out
 
 
+# Why a joint came out the way it did, and whether the user should check it.
+# The classifier's reason is emitted as a `<!-- sw2robot-note: ... -->` comment
+# inside each <joint> (exporter/urdf_writer) and as a trailing comment on the
+# `type:` line of joints.yaml (exporter/jointcfg.write_template).  The URDF is
+# the live copy -- every build rewrites it -- while the yaml template is only
+# written when the build has no --config, so its notes freeze once a package is
+# configured.  Changing either format silently empties the parser below, so the
+# two must move together.  A YAML round-trip is not an option: every reader
+# here is yaml.safe_load, which drops comments, and ruamel is not a dependency.
+_JOINT_NOTE_RE = re.compile(
+    r"(?m)^\s*child:\s*(\S+)\s*$\n"
+    r"\s*type:\s*(\S+)[^\n#]*#\s*(.*)$")
+
+# Reasons worth a second pair of eyes, worst first: (substring, why).
+# Everything else the classifier can say -- a clean 1-DOF rotation, an
+# author-drawn reference axis, a type the config set deliberately -- is a
+# statement, not a guess, and is deliberately NOT flagged.
+_JOINT_ATTENTION = (
+    ("under-constrained",
+     "the mates leave motion the classifier could not name; welded shut"),
+    ("fastener welded fixed",
+     "welded because the part NAME looks like hardware"),
+    ("some mates unmodelled",
+     "a mate type the classifier cannot model was ignored"),
+    ("mirror", "copied from a mirrored twin"),
+)
+
+
+def _classify_note(note):
+    note = (note or "").strip()
+    if not note:
+        return None
+    why = next((msg for key, msg in _JOINT_ATTENTION if key in note), None)
+    return {"note": note, "attention": why}
+
+
+def _joint_notes_from_urdf(pkg_dir, urdf_rel):
+    """``{child link -> {"note", "attention"}}`` from the built URDF."""
+    if not pkg_dir or not urdf_rel:
+        return {}
+    path = os.path.join(pkg_dir, urdf_rel)
+    if not os.path.exists(path):
+        return {}
+    import xml.etree.ElementTree as ET
+    out = {}
+    try:
+        parser = ET.XMLParser(target=ET.TreeBuilder(insert_comments=True))
+        root = ET.parse(path, parser=parser).getroot()
+    except Exception:
+        return {}
+    for j in root.findall("joint"):
+        child = j.find("child")
+        if child is None or not child.get("link"):
+            continue
+        for node in j:
+            if not callable(node.tag):          # comments have a callable tag
+                continue
+            text = (node.text or "").strip()
+            if text.startswith("sw2robot-note:"):
+                rec = _classify_note(text.split(":", 1)[1])
+                if rec:
+                    out[child.get("link")] = rec
+    return out
+
+
+def _joint_notes(yml_txt):
+    """The joints.yaml copy -- the fallback for packages built before the
+    note was written into the URDF."""
+    out = {}
+    for child, _jtype, note in _JOINT_NOTE_RE.findall(yml_txt or ""):
+        rec = _classify_note(note)
+        if rec:
+            out[child] = rec
+    return out
+
+
 def _urdf_child_joint_types(pkg_dir, urdf_rel):
     """``{child link name -> parent joint type}`` from the built URDF, so the
     mass editor can offer mass-only only on a fixed child without needing the
@@ -4763,10 +4839,19 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                             except ValueError:
                                 pass
                 reviewed = set()
+                jreviewed = set()
                 if yml_txt:
                     _, reviewed_list = _set_yaml_list_block(
                         yml_txt, "mass_reviewed")
                     reviewed = set(reviewed_list)
+                    _, jr = _set_yaml_list_block(yml_txt, "joint_reviewed")
+                    jreviewed = set(jr)
+                # why each joint came out as it did + whether it is one of the
+                # guesses the user should check (see _JOINT_ATTENTION).  Prefer
+                # the URDF copy: the yaml one freezes once a package has a
+                # config, and the editor always rebuilds with one.
+                jnotes = dict(_joint_notes(yml_txt))
+                jnotes.update(_joint_notes_from_urdf(cls.pkg_dir, cls.urdf_rel))
                 colors = _read_colors(cls.pkg_dir, cls.urdf_rel)
                 # the actual per-link mass in the built URDF (after density /
                 # target-mass resolution) + which links still need review
@@ -4803,7 +4888,14 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                         "default_mass": (c.link_name in default_links) if c else False,
                         "reviewed": bool(c and (c.link_name in reviewed
                                                 or c.name in reviewed)),
-                        "parent_joint": joint_types.get(dl)}
+                        "parent_joint": joint_types.get(dl),
+                        # keyed by the COMPONENT name joints.yaml uses, so a
+                        # renamed link keeps its note and its acknowledgement
+                        "joint_note": (jnotes.get(key) or {}).get("note"),
+                        "joint_attention": (
+                            None if key in jreviewed
+                            else (jnotes.get(key) or {}).get("attention")),
+                        "joint_reviewed": key in jreviewed}
                 excluded = []
                 if yml_txt:
                     m = re.search(r"(?m)^exclude:\n((?:- .*\n)*)", yml_txt)
@@ -6513,6 +6605,40 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                 print(f"[sw2robot.web] set_mass_reviewed: {link} on={on}")
                 return self._send_json({"link": link, "reviewed": on,
                                         "mass_reviewed": reviewed})
+            if parsed.path == "/api/set_joint_reviewed":
+                # acknowledge that one of the classifier's guesses has been
+                # looked at: clears its attention badge without changing the
+                # model, so no rebuild is needed.  Mirrors
+                # /api/set_mass_reviewed; stored as `joint_reviewed:`.
+                cls = type(self)
+                n = int(self.headers.get("Content-Length", 0))
+                body = json.loads(self.rfile.read(n) or b"{}")
+                link = body.get("link")
+                on = bool(body.get("reviewed", True))
+                if not cls.pkg_dir or not link:
+                    return self._send_json({"error": "no package/link"}, 400)
+                if not _cad_mode(cls.pkg_dir):
+                    return self._send_json(
+                        {"error": "joint review is a CAD-mode concept"}, 400)
+                name = os.path.splitext(os.path.basename(cls.urdf_rel))[0]
+                yml = os.path.join(cls.pkg_dir, name + ".joints.yaml")
+                if not os.path.exists(yml):
+                    return self._send_json(
+                        {"error": "joints.yaml not found"}, 400)
+                with open(yml, encoding="utf-8") as f:
+                    txt = f.read()
+                # joints.yaml keys off the COMPONENT name; the browser sends
+                # the display name, which differs after a rename
+                link = _link_names_inverse(txt).get(link, link)
+                _snapshot(cls.pkg_dir, yml, f"review joint of {link[:30]}")
+                txt, jrev = _set_yaml_list_block(
+                    txt, "joint_reviewed",
+                    add=[link] if on else (), remove=[link])
+                with open(yml, "w", encoding="utf-8") as f:
+                    f.write(txt)
+                print(f"[sw2robot.web] set_joint_reviewed: {link} on={on}")
+                return self._send_json({"link": link, "reviewed": on,
+                                        "joint_reviewed": jrev})
             if parsed.path == "/api/set_mass_only":
                 # toggle a link's mass-only flag (keep the weight, drop the
                 # geometry).  Stored in the `mass_only:` list; the build enforces

--- a/sw2robot/exporter/jointcfg.py
+++ b/sw2robot/exporter/jointcfg.py
@@ -94,6 +94,9 @@ def write_template(model, path):
         "# override with  expand: [name-substr]  /  no_expand: [name-substr]",
         "# Embedded SW2URDF CoordSys/RefAxis config auto-applies when present;",
         "# set sw2urdf_config: off | require  to disable or enforce it",
+        "# A CAD reference axis can define ONE joint the mates do not show:",
+        "#   axis_joints: [{axis: <RefAxis name>, parent: <part>, child: <part>}]",
+        "#   (the pair may have no mate at all -- a forgotten constraint)",
         "# Optional per-joint actuator/physics (movable joints only):",
         "#   effort: 5   velocity: 2   dynamics: {damping: 0.1, friction: 0.0}",
         "#   safety_controller: {soft_lower_limit: -1, soft_upper_limit: 1,"

--- a/sw2robot/exporter/model.py
+++ b/sw2robot/exporter/model.py
@@ -46,6 +46,7 @@ from .sw2urdf_import import (
     reconstruct_sw2urdf_config_from_payload,
     reconstruct_sw2urdf_config_geometric,
 )
+from .sw2urdf_import._common import _axis_line
 from .swcom import as_iface, safe_call, safe_prop
 
 MATE_TYPES = {0: "COINCIDENT", 1: "CONCENTRIC", 2: "PERPENDICULAR",
@@ -1301,6 +1302,14 @@ def classify_edge_auto(rec):
     lj = rec.get("limit_joint")
     if lj:                                  # SolidWorks LimitDistance/LimitAngle
         return lj["type"], lj["axis"], "limit mate (SolidWorks slider/hinge)"
+    ra = rec.get("reference_axis")
+    if ra:
+        # a reference axis the DESIGNER drew across this pair: the mates are
+        # whatever they are, but the author has said where the joint is.  Wins
+        # over the fastener heuristic -- an axis drawn through a shoulder bolt
+        # means it turns.
+        return "revolute", ra["axis"], \
+            f"reference axis {ra['name']!r} drawn in CAD"
     if rec.get("fastener"):
         return "fixed", None, "fastener welded fixed"
     mates = rec.get("mates")
@@ -1394,8 +1403,10 @@ def _demote_globally_locked(comps, adjacency, edge):
             continue
         # a SolidWorks limit mate IS a slider/hinge -- its DISTANCE/ANGLE mate
         # rows would (over-)constrain the global system and falsely lock the
-        # mechanism, so keep them out (and never demote it, below)
-        if rec.get("limit_joint"):
+        # mechanism, so keep them out (and never demote it, below).  An edge
+        # the designer drew a reference axis across is the same kind of
+        # statement, made by hand: the mates there are known to be incomplete.
+        if rec.get("limit_joint") or rec.get("reference_axis"):
             continue
         # CLOCKING mates encode a display pose, not structure, yet they
         # really do freeze the mechanism in SolidWorks.  Two shapes:
@@ -1444,8 +1455,10 @@ def _demote_globally_locked(comps, adjacency, edge):
     rigid = set()
     for key in list(edge.keys()):
         a, b = tuple(key)
-        if adjacency.get(key, {}).get("limit_joint"):
-            continue                          # authoritative slider/hinge
+        arec = adjacency.get(key, {})
+        if arec.get("limit_joint") or arec.get("reference_axis"):
+            continue                # authoritative: a limit mate or an
+                                    # author-drawn reference axis
         rel = N[6 * idx[b]:6 * idx[b] + 6, :] - N[6 * idx[a]:6 * idx[a] + 6, :]
         if np.linalg.norm(rel) < 1e-6:
             rigid.add(key)
@@ -1630,6 +1643,88 @@ def _mirror_axis_fallback(comps, edge_info, inherit_type=False):
     return edge_info
 
 
+def apply_reference_axis_overrides(comps, adjacency, reference_axes,
+                                   assignments):
+    """Let a CAD reference axis define ONE joint.
+
+    Designers draw a reference axis exactly where the mates say least -- a
+    joint whose constraints were never modelled.  The SW2URDF import routes
+    already read these axes, but only as part of an all-or-nothing
+    reconstruction of the WHOLE tree, which needs the add-in's naming or its
+    payload; when any part of that fails, the axes are extracted and then
+    ignored.  This is the partial form: one axis overrides one pair's verdict
+    and every other edge keeps its inferred one.
+
+    Which pair an axis belongs to has to be SAID, via ``axis_joints`` in the
+    joint config::
+
+        axis_joints:
+          - {axis: knee_axis, parent: thigh-1, child: calf-1}
+
+    The pair may have no mate at all -- the case where the constraint was
+    forgotten outright, which is what a hand-drawn axis is usually for.
+    Deriving the pair from the axis geometry is deliberately not attempted:
+    an axis through a clevis passes through fork, pin and fork alike, so the
+    geometry does not identify the joint.  That is also why the official
+    add-in has the user assign each axis to a joint in a dialog.
+
+    Returns the number of edges overridden.
+    """
+    axes = list(reference_axes or [])
+    if not axes:
+        return 0
+    alias = {}
+    for c in comps:
+        alias[c.name] = c.name
+        alias[c.link_name] = c.name
+
+    applied, notes = 0, []
+    for entry in (assignments or []):
+        entry = entry or {}
+        name = str(entry.get("axis") or "").strip()
+        pa = alias.get(str(entry.get("parent") or "").strip())
+        ch = alias.get(str(entry.get("child") or "").strip())
+        if not name or pa is None or ch is None:
+            notes.append(f"axis_joints entry {entry!r} names an unknown "
+                         "axis/parent/child")
+            continue
+        if pa == ch:
+            # a 1-element frozenset is not an edge key: every consumer does
+            # `a, b = tuple(key)` and would raise
+            notes.append(f"axis_joints entry for {name!r} has the same parent "
+                         "and child")
+            continue
+        line = next((_axis_line(ax) for ax in axes
+                     if str(getattr(ax, "name", "")) == name), None)
+        if line is None:
+            notes.append(f"axis {name!r} is not a reference axis in this "
+                         "extract (or its direction is degenerate)")
+            continue
+        key = frozenset((pa, ch))
+        rec = adjacency.setdefault(key, {"types": [], "axis": None,
+                                         "mates": []})
+        rec["reference_axis"] = {"name": name, "axis": line}
+        applied += 1
+    if applied:
+        print(f"      reference axes: {applied} joint(s) taken from "
+              "author-drawn CAD reference axes")
+    for msg in notes:
+        print(f"      WARN: {msg}")
+    # an axis nobody claimed is a hint the author left in the CAD: say it is
+    # there rather than dropping it silently
+    used = {str((e or {}).get("axis") or "").strip()
+            for e in (assignments or [])}
+    idle = sorted(str(getattr(ax, "name", "?")) for ax in axes
+                  if str(getattr(ax, "name", "")) not in used)
+    if idle:
+        print(f"      note: {len(idle)} CAD reference axis/axes define no "
+              "joint; assign one with axis_joints "
+              "[{axis: <name>, parent: <part>, child: <part>}]: "
+              + ", ".join(repr(x) for x in idle[:6])
+              + (" ..." if len(idle) > 6 else ""))
+    return applied
+
+
 def _auto_parent_map(comps, adjacency, base):
     """Spanning forest rooted at base -> (parent_of, edge_info).
 
@@ -1700,7 +1795,16 @@ def _auto_parent_map(comps, adjacency, base):
     locked = {key for key, rec in adjacency.items()
               if key in edge and "LOCK" in (rec.get("types") or [])}
 
+    # An author-drawn reference axis is an explicit statement that these two
+    # bodies MOVE relative to each other.  Without this the BFS often reaches
+    # both ends first through a chain of rigid edges and the authored joint
+    # degenerates into a loop closure instead of becoming a tree edge.
+    authored = {key for key, rec in adjacency.items()
+                if rec.get("reference_axis") and key in edge}
+
     def tier(key):
+        if key in authored:
+            return 0
         if key in forced or key in locked:
             return 0
         if key in loop_closure:
@@ -2434,9 +2538,24 @@ def _config_parent_map(comps, adjacency, base, directed):
             _, olo, ohi = _oriented_limit(lj, by_name[child], by_name[parent])
             lo = olo if lo is None else lo
             up = ohi if up is None else up
+        # Carry the classifier's reason through even though the CONFIG decided
+        # the type: the editor uses it to flag the joints a human should still
+        # look at, and without it a configured build (which is every build once
+        # a package has a joints.yaml) reports nothing at all.  Say so when the
+        # config disagrees -- that is the user's own decision, not a guess.
+        note = None
+        if rec:
+            try:
+                inferred, _iax, inote = classify_edge_auto(rec)
+            except Exception:
+                inferred, inote = None, None
+            note = inote
+            if inferred and inferred != jtype:
+                note = ((note + "; ") if note else "") + \
+                    f"config sets {jtype} (inference said {inferred})"
         edge_info[(child, parent)] = {
             "name": d.get("name"),
-            "type": jtype, "axis": ax,
+            "type": jtype, "axis": ax, "note": note,
             "lower": -3.141592 if lo is None else lo,
             "upper": 3.141592 if up is None else up,
             "mimic": d.get("mimic"),
@@ -3834,6 +3953,21 @@ def build_model(graph, robot_name=None, base_hint=None, config=None,
                     rec["fastener"] = True
             print(f"      fasteners welded fixed: {len(fastener_names)} "
                   f"parts (screws/nuts/washers/pins)")
+
+    # CAD reference axes as a PER-JOINT override: `axis_joints:` says which
+    # pair each axis belongs to.  Skipped when an SW2URDF route already
+    # supplied the tree (its axes come from the same features, via the
+    # author's own mapping).
+    ra_mode = str((config or {}).get("reference_axes") or "auto").strip().lower()
+    # YAML reads a bare `off:` as the boolean False
+    ra_mode = {"false": "off", "true": "auto"}.get(ra_mode, ra_mode)
+    if ra_mode not in ("auto", "off"):
+        print(f"      WARN: reference_axes={ra_mode!r} is unknown; using 'auto'")
+        ra_mode = "auto"
+    if ra_mode != "off" and sw2cfg is None:
+        apply_reference_axis_overrides(
+            comps, adjacency, graph.reference_axes,
+            (config or {}).get("axis_joints"))
 
     if config and config.get("force_fixed"):
         # weld these edges and REBUILD the auto tree around them (editing a

--- a/sw2robot/exporter/urdf_writer.py
+++ b/sw2robot/exporter/urdf_writer.py
@@ -254,6 +254,15 @@ def _joint_xml(joint, rn=lambda n: n, jn=lambda n: n):
                      f'offset="{off:g}"/>')
     if joint.mate_types:
         lines.append(f'    <!-- mates: {", ".join(joint.mate_types)} -->')
+    # WHY this joint came out as it did.  It also goes into the joints.yaml
+    # template, but that file is only written when the build has no --config,
+    # so once the user configures anything its notes freeze at the first build.
+    # The URDF is rewritten every time, so this copy is the one the editor
+    # reads to decide which joints still need a human look.
+    if getattr(joint, "geo_note", None):
+        # `--` cannot appear inside an XML comment
+        note = str(joint.geo_note).replace("--", "- -")
+        lines.append(f'    <!-- sw2robot-note: {note} -->')
     lines.append("  </joint>")
     return "\n".join(lines)
 

--- a/tests/e2e/run.mjs
+++ b/tests/e2e/run.mjs
@@ -319,6 +319,46 @@ check('jfilter: matches at least one joint', filterRows.n >= 1,
 check('jfilter: clearing restores the tree', filterRows.restored >= filterRows.n);
 check('jfilter: no page errors', pageErrors.length === beforeFilter,
       pageErrors.slice(beforeFilter).join(' | '));
+// ---- 8c. the joint-review worklist ----------------------------------------
+// Every joint carries the classifier's reason; the ones it GUESSED at also get
+// a `?` badge, a "needs check" chip that filters the list down to them, and a
+// click that marks the joint reviewed.  The bundled fixture has no guessed
+// joint, so this checks the parts that must hold either way: the reason
+// reaches the browser, and the chip is hidden exactly when nothing is flagged.
+const reviewState = await page.evaluate(async () => {
+  const r = await (await fetch('/api/components')).json();
+  const links = Object.values(r.links ?? {});
+  const chip = document.getElementById('jcheckonly');
+  const flagged = links.filter(l => l.joint_attention).length;
+  return {
+    withNote: links.filter(l => l.joint_note).length,
+    flagged,
+    badges: document.querySelectorAll('.chktag').length,
+    chipHidden: !chip || chip.style.display === 'none',
+  };
+});
+check('review: joints carry the classifier reason',
+      reviewState.withNote >= 1, `${reviewState.withNote} with a note`);
+check('review: a badge per flagged joint',
+      reviewState.badges === reviewState.flagged,
+      `${reviewState.badges} badges vs ${reviewState.flagged} flagged`);
+check('review: the chip appears only when something is flagged',
+      reviewState.chipHidden === (reviewState.flagged === 0));
+
+// acknowledging is a pure round-trip through joints.yaml -- no rebuild
+const ack = await page.evaluate(async () => {
+  const r = await (await fetch('/api/components')).json();
+  const link = Object.keys(r.links ?? {}).find(k => r.links[k].joint_note);
+  if (!link) { return { skipped: true }; }
+  const post = reviewed => fetch('/api/set_joint_reviewed', {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ link, reviewed }) }).then(x => x.json());
+  const on = await post(true);
+  const after = await (await fetch('/api/components')).json();
+  await post(false);
+  return { ok: on.reviewed === true && after.links[link].joint_reviewed === true };
+});
+check('review: acknowledging a joint round-trips', ack.skipped || ack.ok);
 
 // ---- 9. auto joint limits (self-collision sweep) ---------------------------
 // reuses the collision model from section 8 (already reloaded, non-drop).

--- a/tests/golden/fingertip_base.urdf
+++ b/tests/golden/fingertip_base.urdf
@@ -54,6 +54,7 @@
     <child link="screwlock_male_hard_jointbase_v4_1"/>
     <axis xyz="0 0 1"/>
     <!-- mates: CONCENTRIC, COINCIDENT, PARALLEL, CONCENTRIC, COINCIDENT, PARALLEL -->
+    <!-- sw2robot-note: geo: fully constrained -->
   </joint>
   <joint name="fingertip_front_2__fingertip_back_1" type="revolute">
     <origin xyz="0.02103948669 -0.0155 0.031" rpy="3.141592654 0 0"/>
@@ -62,5 +63,6 @@
     <axis xyz="0 1 0"/>
     <limit lower="-3.14159" upper="3.14159" effort="10" velocity="3.14"/>
     <!-- mates: COINCIDENT, COINCIDENT, COINCIDENT, COINCIDENT -->
+    <!-- sw2robot-note: geo: 1 DOF rotation (derived axis) -->
   </joint>
 </robot>

--- a/tests/golden/fingertip_edited.urdf
+++ b/tests/golden/fingertip_edited.urdf
@@ -55,6 +55,7 @@
     <axis xyz="0 -1 0"/>
     <limit lower="-0.5" upper="0.5" effort="10" velocity="3.14"/>
     <!-- mates: CONCENTRIC, COINCIDENT, PARALLEL, CONCENTRIC, COINCIDENT, PARALLEL -->
+    <!-- sw2robot-note: geo: fully constrained; config sets revolute (inference said fixed) -->
   </joint>
   <joint name="bend" type="revolute">
     <origin xyz="0.02103948669 -0.0155 0.031" rpy="3.141592654 0 0"/>
@@ -64,5 +65,6 @@
     <limit lower="-1" upper="1.5" effort="10" velocity="3.14"/>
     <mimic joint="fingertip_front_2__screwlock_male_hard_jointbase_v4_1" multiplier="0.5" offset="0.1"/>
     <!-- mates: COINCIDENT, COINCIDENT, COINCIDENT, COINCIDENT -->
+    <!-- sw2robot-note: geo: 1 DOF rotation (derived axis) -->
   </joint>
 </robot>

--- a/tests/golden/fingertip_flip.urdf
+++ b/tests/golden/fingertip_flip.urdf
@@ -54,6 +54,7 @@
     <child link="screwlock_male_hard_jointbase_v4_1"/>
     <axis xyz="0 0 1"/>
     <!-- mates: CONCENTRIC, COINCIDENT, PARALLEL, CONCENTRIC, COINCIDENT, PARALLEL -->
+    <!-- sw2robot-note: geo: fully constrained -->
   </joint>
   <joint name="fingertip_front_2__fingertip_back_1" type="revolute">
     <origin xyz="0.02103948669 -0.0155 0.031" rpy="3.141592654 0 0"/>
@@ -62,5 +63,6 @@
     <axis xyz="0 -1 0"/>
     <limit lower="-3.14159" upper="3.14159" effort="10" velocity="3.14"/>
     <!-- mates: COINCIDENT, COINCIDENT, COINCIDENT, COINCIDENT -->
+    <!-- sw2robot-note: geo: 1 DOF rotation (derived axis) -->
   </joint>
 </robot>

--- a/tests/golden/fingertip_rename_direct.urdf
+++ b/tests/golden/fingertip_rename_direct.urdf
@@ -54,6 +54,7 @@
     <child link="screwlock_male_hard_jointbase_v4_1"/>
     <axis xyz="0 0 1"/>
     <!-- mates: CONCENTRIC, COINCIDENT, PARALLEL, CONCENTRIC, COINCIDENT, PARALLEL -->
+    <!-- sw2robot-note: geo: fully constrained -->
   </joint>
   <joint name="bend" type="revolute">
     <origin xyz="0.02103948669 -0.0155 0.031" rpy="3.141592654 0 0"/>
@@ -62,5 +63,6 @@
     <axis xyz="0 1 0"/>
     <limit lower="-3.14159" upper="3.14159" effort="10" velocity="3.14"/>
     <!-- mates: COINCIDENT, COINCIDENT, COINCIDENT, COINCIDENT -->
+    <!-- sw2robot-note: geo: 1 DOF rotation (derived axis) -->
   </joint>
 </robot>

--- a/tests/test_joint_attention.py
+++ b/tests/test_joint_attention.py
@@ -1,0 +1,220 @@
+"""The joint-review worklist: why a joint came out that way, and whether to check it.
+
+The classifier already explains itself -- `Joint.geo_note` -- but that reason
+only ever reached a trailing comment in joints.yaml, so the editor showed the
+user a type dropdown and no evidence.  These pin the server half: parsing the
+reason back out, flagging the judgement calls, and acknowledging one.
+"""
+import json
+import shutil
+import threading
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from sw2robot.editor.webserver import _joint_notes
+
+REPO = Path(__file__).resolve().parent.parent
+FINGERTIP = REPO / "examples" / "fingertip"
+
+
+def test_note_is_parsed_per_child_link():
+    yml = (
+        "joints:\n"
+        "  - parent: a_1\n"
+        "    child:  b_1\n"
+        "    type:   fixed # mates: COINCIDENT | geo: fully constrained\n"
+        "  - parent: b_1\n"
+        "    child:  c_1\n"
+        "    type:   revolute # mates: CONCENTRIC | geo: 1 DOF rotation\n"
+    )
+    notes = _joint_notes(yml)
+    assert set(notes) == {"b_1", "c_1"}
+    assert "fully constrained" in notes["b_1"]["note"]
+    # neither of these is a judgement call, so neither is flagged
+    assert notes["b_1"]["attention"] is None
+    assert notes["c_1"]["attention"] is None
+
+
+@pytest.mark.parametrize("note,expect", [
+    ("geo: under-constrained (3 DOF) -> fixed; verify", "could not name"),
+    ("fastener welded fixed", "NAME"),
+    ("geo: fully constrained; some mates unmodelled", "cannot model"),
+    ("geo: 1 DOF rotation (derived axis)", None),
+    ("geo: fully constrained", None),
+    ("reference axis 'knee' drawn in CAD", None),
+])
+def test_which_reasons_are_flagged(note, expect):
+    yml = f"joints:\n  - parent: a_1\n    child:  b_1\n    type: fixed # {note}\n"
+    got = _joint_notes(yml)["b_1"]["attention"]
+    if expect is None:
+        assert got is None, got
+    else:
+        assert got is not None and expect in got
+
+
+def test_a_joint_with_no_comment_is_absent():
+    assert _joint_notes("joints:\n  - parent: a\n    child:  b_1\n"
+                        "    type:   fixed\n") == {}
+
+
+# --- end to end through the server -----------------------------------------
+
+def _free_port():
+    import socket
+    s = socket.socket()
+    s.bind(("", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+@pytest.fixture
+def server(tmp_path):
+    if not (FINGERTIP / "graph.json").exists():
+        pytest.skip("fingertip fixture not present")
+    from sw2robot.editor import webserver
+    from sw2robot.exporter.export import build
+
+    pkg = tmp_path / "pkg"
+    (pkg / "meshes").mkdir(parents=True)
+    shutil.copy2(FINGERTIP / "graph.json", pkg / "graph.json")
+    for f in (FINGERTIP / "meshes").iterdir():
+        if f.is_file():
+            shutil.copy2(f, pkg / "meshes" / f.name)
+    build(str(pkg))
+    httpd, port = webserver._bind_free_port(webserver._Handler, _free_port())
+    httpd.daemon_threads = True
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{port}"
+    try:
+        with urllib.request.urlopen(f"{base}/api/open?path={pkg}") as r:
+            assert json.loads(r.read())["mode"] == "cad"
+        yield base, pkg
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        webserver._um["state"] = None
+
+
+def _get(base, path):
+    with urllib.request.urlopen(base + path) as r:
+        return json.loads(r.read().decode())
+
+
+def _post(base, path, body):
+    req = urllib.request.Request(
+        base + path, data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"}, method="POST")
+    with urllib.request.urlopen(req) as r:
+        return json.loads(r.read().decode())
+
+
+SCREW = "screwlock_male_hard_jointbase_v4_1"
+TIP = "fingertip_back_1"          # the fixture's one inferred revolute
+
+
+def test_components_carries_the_reason(server):
+    """Every joint reaches the browser with the reason it came out that way.
+
+    This fixture happens to have no GUESSED joint -- both of its joints are
+    confident calls -- so what is pinned here is the plumbing; which reasons
+    raise a flag is covered by test_which_reasons_are_flagged above."""
+    base, _pkg = server
+    links = _get(base, "/api/components")["links"]
+    assert "geo:" in (links[SCREW]["joint_note"] or "")
+    assert links[SCREW]["joint_attention"] is None    # a confident call
+    assert links[SCREW]["joint_reviewed"] is False
+
+
+def test_reviewing_persists_without_a_rebuild(server):
+    base, pkg = server
+    assert _post(base, "/api/set_joint_reviewed",
+                 {"link": SCREW, "reviewed": True})["reviewed"] is True
+    links = _get(base, "/api/components")["links"]
+    assert links[SCREW]["joint_reviewed"] is True
+    assert links[SCREW]["joint_attention"] is None
+    # the reason itself stays visible -- reviewing hides the badge, not the why
+    assert "geo:" in links[SCREW]["joint_note"]
+    assert "joint_reviewed:" in (pkg / "fingertip.joints.yaml").read_text(
+        encoding="utf-8")
+
+    _post(base, "/api/set_joint_reviewed", {"link": SCREW, "reviewed": False})
+    assert _get(base, "/api/components")["links"][SCREW]["joint_reviewed"] \
+        is False
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))
+
+
+def test_note_and_review_survive_a_rename(server):
+    """joints.yaml keys off the COMPONENT name; the browser sends the DISPLAY
+    name.  Before the fix the read side looked the note up under the display
+    name and the write side stored the display name, so renaming a link lost
+    both the badge and any acknowledgement of it."""
+    base, pkg = server
+    assert _post(base, "/api/rename",
+                 {"kind": "link", "old": SCREW, "new": "quick_connect"}
+                 ).get("ok", True) is not False
+    links = _get(base, "/api/components")["links"]
+    assert "quick_connect" in links, sorted(links)
+    assert "geo:" in (links["quick_connect"]["joint_note"] or "")
+
+    _post(base, "/api/set_joint_reviewed",
+          {"link": "quick_connect", "reviewed": True})
+    links = _get(base, "/api/components")["links"]
+    assert links["quick_connect"]["joint_reviewed"] is True
+    # stored under the COMPONENT name, so a further rename keeps it
+    assert SCREW in (pkg / "fingertip.joints.yaml").read_text(encoding="utf-8")
+
+
+def test_the_note_survives_a_configured_rebuild(server):
+    """The reason lives in the URDF, which every build rewrites.
+
+    It is ALSO written into the joints.yaml template -- but only when the build
+    has no --config, and the editor always rebuilds WITH one, so that copy
+    freezes at the first build.  Before this, a configured build produced no
+    reason at all (`_config_parent_map` dropped it), which is every build once a
+    package has a joints.yaml.
+    """
+    from sw2robot.editor.webserver import _joint_notes_from_urdf
+    from sw2robot.exporter.export import build
+
+    base, pkg = server
+    yml = pkg / "fingertip.joints.yaml"
+    urdf_rel = "urdf/fingertip.urdf"
+    before = _joint_notes_from_urdf(str(pkg), urdf_rel)
+    assert before, "the built URDF carries no sw2robot-note comment"
+
+    build(str(pkg), config_path=str(yml))          # a CONFIGURED rebuild
+    after = _joint_notes_from_urdf(str(pkg), urdf_rel)
+    assert set(after) == set(before), (sorted(before), sorted(after))
+    assert all(after[k]["note"] for k in after)
+    # and it reaches the API the browser reads
+    links = _get(base, "/api/components")["links"]
+    assert any(v.get("joint_note") for v in links.values())
+
+
+def test_a_type_the_config_overrode_says_so(server):
+    """Changing a type by hand is the user's decision, not a guess -- the note
+    records both so the badge can stop nagging about it."""
+    from sw2robot.editor.webserver import _joint_notes_from_urdf
+    from sw2robot.exporter.export import build
+
+    _base, pkg = server
+    yml = pkg / "fingertip.joints.yaml"
+    txt = yml.read_text(encoding="utf-8")
+    lines, seen = [], False
+    for line in txt.splitlines(True):
+        if line.strip().startswith("child:") and TIP in line:
+            seen = True
+        elif seen and line.strip().startswith("type:"):
+            line, seen = "    type:   fixed\n", False
+        lines.append(line)
+    yml.write_text("".join(lines), encoding="utf-8")
+    build(str(pkg), config_path=str(yml))
+
+    note = _joint_notes_from_urdf(str(pkg), "urdf/fingertip.urdf")[TIP]["note"]
+    assert "config sets fixed" in note and "inference said revolute" in note

--- a/tests/test_reference_axis_override.py
+++ b/tests/test_reference_axis_override.py
@@ -1,0 +1,136 @@
+"""Per-joint override from a CAD reference axis (`axis_joints:`).
+
+A designer who never used the SW2URDF add-in still draws SolidWorks reference
+axes where the joints are.  The add-in import routes read those axes only as
+part of an all-or-nothing reconstruction of the whole tree; this is the partial
+form -- one axis names one joint, everything else keeps its inferred verdict.
+
+Which pair an axis belongs to has to be SAID: an axis through a clevis passes
+through fork, pin and fork alike, so the geometry does not identify the joint.
+"""
+import numpy as np
+import pytest
+from test_classify_geo import O, Z, coinc_planes, conc, dup
+
+from sw2robot.exporter.model import build_model
+from sw2robot.exporter.state import (
+    ComponentState,
+    GraphState,
+    MateEdge,
+    MateGeo,
+    ReferenceAxisState,
+)
+
+
+def _comp(name, xyz=(0, 0, 0), fixed=False):
+    w = np.eye(4)
+    w[:3, 3] = xyz
+    return ComponentState(name=name, link_name=name.replace("-", "_"),
+                          part_path=None, is_subassembly=False,
+                          world=[float(x) for x in w.flatten()], fixed=fixed)
+
+
+def _welded_graph():
+    """Two parts bolted together -- a pair of concentric axes, so inference
+    says fixed."""
+    a = _comp("frame-1", fixed=True)
+    b = _comp("arm-1", (0, 0, 0.05))
+    mates = dup(conc([0.01, 0, 0], Z), conc([-0.01, 0, 0], Z),
+                coinc_planes(O, Z))
+    edge = MateEdge(a="frame-1", b="arm-1",
+                    types=[m["type"] for m in mates],
+                    axis_point=list(O), axis_dir=list(Z),
+                    mates=[MateGeo(**m) for m in mates])
+    return GraphState(robot_name="t", source_assembly="t.SLDASM",
+                      components=[a, b], edges=[edge], ground=["frame-1"])
+
+
+AXIS = ReferenceAxisState(name="elbow_axis", document_point=[0.0, 0.0, 0.0],
+                          document_direction=[0.0, 0.0, 1.0])
+
+
+def _joint(model, child):
+    return next(j for j in model.joints if j.child == child)
+
+
+def test_baseline_is_fixed():
+    # a bolt pair: two concentric axes leave no rotation at all
+    model = build_model(_welded_graph())
+    assert _joint(model, "arm_1").jtype == "fixed"
+
+
+def test_assigned_axis_makes_the_joint():
+    g = _welded_graph()
+    g.reference_axes = [AXIS]
+    model = build_model(g, config={"axis_joints": [
+        {"axis": "elbow_axis", "parent": "frame-1", "child": "arm-1"}]})
+    j = _joint(model, "arm_1")
+    assert j.jtype == "revolute"
+    assert abs(abs(float(np.dot(j.axis, [0, 0, 1]))) - 1.0) < 1e-6
+    assert "elbow_axis" in (j.geo_note or "")
+
+
+def test_assignment_accepts_link_names_too():
+    g = _welded_graph()
+    g.reference_axes = [AXIS]
+    model = build_model(g, config={"axis_joints": [
+        {"axis": "elbow_axis", "parent": "frame_1", "child": "arm_1"}]})
+    assert _joint(model, "arm_1").jtype == "revolute"
+
+
+def test_axis_joins_a_pair_with_no_mate_at_all():
+    # the constraint was forgotten outright -- the commonest reason a designer
+    # reaches for a reference axis
+    g = _welded_graph()
+    g.components.append(_comp("hand-1", (0, 0, 0.12)))
+    g.reference_axes = [ReferenceAxisState(
+        name="wrist", document_point=[0.0, 0.0, 0.12],
+        document_direction=[1.0, 0.0, 0.0])]
+    model = build_model(g, config={"axis_joints": [
+        {"axis": "wrist", "parent": "arm-1", "child": "hand-1"}]})
+    j = _joint(model, "hand_1")
+    assert j.jtype == "revolute" and j.parent == "arm_1"
+    assert abs(abs(float(np.dot(j.axis, [1, 0, 0]))) - 1.0) < 1e-6
+
+
+def test_unassigned_axis_is_reported_not_guessed(capsys):
+    g = _welded_graph()
+    g.reference_axes = [AXIS]
+    model = build_model(g)
+    assert _joint(model, "arm_1").jtype == "fixed"     # unchanged
+    out = capsys.readouterr().out
+    assert "define no joint" in out and "axis_joints" in out
+
+
+def test_reference_axes_off_ignores_even_an_assignment(capsys):
+    g = _welded_graph()
+    g.reference_axes = [AXIS]
+    model = build_model(g, config={
+        "reference_axes": "off",
+        "axis_joints": [{"axis": "elbow_axis", "parent": "frame-1",
+                         "child": "arm-1"}]})
+    assert _joint(model, "arm_1").jtype == "fixed"
+
+
+def test_bad_assignment_warns_and_leaves_inference_alone(capsys):
+    g = _welded_graph()
+    g.reference_axes = [AXIS]
+    model = build_model(g, config={"axis_joints": [
+        {"axis": "elbow_axis", "parent": "frame-1", "child": "nosuchpart-9"}]})
+    assert _joint(model, "arm_1").jtype == "fixed"
+    assert "axis_joints" in capsys.readouterr().out
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))
+
+
+def test_self_pair_is_refused_not_crashed(capsys):
+    # frozenset(("a", "a")) has ONE element, and every consumer does
+    # `a, b = tuple(key)` -- so this used to raise instead of warning
+    g = _welded_graph()
+    g.reference_axes = [AXIS]
+    model = build_model(g, config={"axis_joints": [
+        {"axis": "elbow_axis", "parent": "arm-1", "child": "arm-1"}]})
+    assert _joint(model, "arm_1").jtype == "fixed"
+    assert "same parent and child" in capsys.readouterr().out


### PR DESCRIPTION
A designer who never used the SW2URDF add-in still draws reference axes where
the joints are. sw2robot extracts them but only feeds them to the add-in import
routes, which reconstruct the whole tree or nothing, so when any part of that
fails the axes are read and then ignored. `axis_joints: {axis, parent, child}`
applies one axis to one pair, which may carry no mate at all -- the forgotten
constraint a hand-drawn axis is usually for. Which pair an axis belongs to has
to be said rather than inferred: an axis through a clevis passes through fork,
pin and fork alike, which is also why the add-in has the user assign each axis
in a dialog. An axis no entry claims is reported rather than dropped silently.

Separately, the classifier has always explained itself through geo_note, but
that reason only reached a comment in the joints.yaml template, so the editor
offered a type dropdown and no evidence. /api/components now carries the reason
per joint, the ones it guessed at get a badge and a "needs check" filter, and
clicking the badge records the joint as reviewed without a rebuild. The reason
is written into the URDF too, because the template is only regenerated when the
build has no --config -- so its copy freezes as soon as a package is configured,
which in the editor is always.

The e2e suite gains four checks for the above; the goldens gain one comment line
per joint and nothing else moves.
