### PR TITLE
fix(exporter): follow each instance's SolidWorks configuration

### DIFF
--- a/sw2robot/editor/core.py
+++ b/sw2robot/editor/core.py
@@ -175,7 +175,7 @@ def import_module(package_dir, config_path=None, base_hint=None,
 def extract_and_import(assembly_path, out_dir=None, robot_name=None,
                        base_hint=None, config_path=None,
                        visible=False, progress=None,
-                       sw=None) -> RobotCompilerState:
+                       sw=None, configuration=None) -> RobotCompilerState:
     """Drive SolidWorks to extract a live assembly, then build it into a state.
 
     This is the *whole* CAD->state pipeline in one call (the slow ``extract``
@@ -188,6 +188,12 @@ def extract_and_import(assembly_path, out_dir=None, robot_name=None,
     module stays cheap and OS-agnostic (the headless ``build`` path never needs
     them).  ``progress`` -- if given -- is called with short status strings so a
     UI can show what the (multi-minute) extract is doing.
+
+    ``configuration`` -- extract THIS assembly configuration instead of the
+    file's saved-active one.  A configuration can suppress whole components and
+    point instances at other variants of a part, so it decides what the URDF
+    contains; None keeps the file's saved-active one (see
+    :func:`sw2robot.exporter.export.configuration_names` for the choices).
     """
     from sw2robot.exporter.export import extract
 
@@ -195,7 +201,8 @@ def extract_and_import(assembly_path, out_dir=None, robot_name=None,
         progress("reusing the warm SolidWorks session ..." if sw is not None
                  else "starting SolidWorks (this can take a minute) ...")
     pkg_dir = extract(assembly_path, out_dir=out_dir, robot_name=robot_name,
-                      visible=visible, progress=progress, sw=sw)
+                      visible=visible, progress=progress, sw=sw,
+                      configuration=configuration)
     # A re-extract regenerates graph.json but extract() leaves the existing
     # <name>.joints.yaml in place.  Without a config the build would take the
     # auto path and OVERWRITE that file -- silently dropping every edit the user

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -675,6 +675,10 @@
                 title="サーバー側のファイルブラウザ（最近のファイル＋フルパス貼り付け）">
           🗄 開く…</button>
       </div>
+      <button id="clearmesh" style="display:none;width:100%;margin:2px 0"
+              data-i18n="ui.clearmesh" data-i18n-title="t.clearmesh"
+              title="meshes/ を消してSolidWorksから全メッシュを出し直す（関節設定は残る）">
+        ♻ メッシュを捨てて再抽出</button>
     </div>
     <div id="toolrow">
       <button id="reset" data-i18n="ui.reset">Reset pose</button>
@@ -4068,6 +4072,41 @@ function syncSw2urdfButton() {
           : t('sw2urdf.tNone');
   const wrap = document.getElementById('sw2urdfwrap');
   if (wrap) { wrap.title = button.title; }
+}
+
+// The mesh cache lives in the package's meshes/ and is normally self-managing:
+// a CAD edit invalidates it by mtime, a configuration change by the cache
+// manifest.  The button exists for the case those cannot cover -- ruling the
+// cache out when an export still looks wrong -- so it only appears for a CAD
+// package whose source assembly is still reachable to re-extract from.
+function syncClearMeshButton() {
+  const btn = document.getElementById('clearmesh');
+  if (!btn) { return; }
+  const usable = !!currentInfo && currentInfo.mode === 'cad'
+    && !!currentInfo.source_assembly;
+  btn.style.display = usable ? '' : 'none';
+  if (usable) { btn.title = t('t.clearmesh') + '\n' + currentInfo.source_assembly; }
+}
+
+async function clearMeshCacheAndReextract() {
+  if (!currentInfo?.source_assembly) { log(t('clearmesh.noSource'), 'err'); return; }
+  const src = currentInfo.source_assembly;
+  const cfg = currentInfo.configuration || '';
+  if (!confirm(t('clearmesh.confirm', { name: currentInfo.name, src }))) { return; }
+  let r;
+  try {
+    const resp = await fetch('/api/clear_mesh_cache', { method: 'POST' });
+    r = await resp.json();
+    if (!resp.ok || r.error) { throw new Error(r.error ?? resp.status); }
+  } catch (e) {
+    log(t('clearmesh.fail', { e: e.message ?? e }), 'err');
+    return;
+  }
+  log(t('clearmesh.done',
+        { n: r.removed, mb: (r.bytes / 1048576).toFixed(1) }), 'ok');
+  // re-extract on the SAME configuration this package came from, so the only
+  // thing that changed is that every mesh was rebuilt from scratch
+  extractFlow(src, cfg);
 }
 
 async function toggleSw2urdfVerbatim() {
@@ -9447,6 +9486,7 @@ function loadRobot(info, { drop = false, keepPose = false,
   }
   syncSubassemblyAccessButton();
   syncSw2urdfButton();
+  syncClearMeshButton();
   refreshExportName();          // export field placeholder follows the open pkg
   // cover the reload gap with a display-only clone of the current robot
   // (same world pose -> the swap is pixel-invisible); geometry/materials
@@ -9940,6 +9980,8 @@ function openFsBrowser() {
 }
 function closeFsBrowser() { fsmodal.style.display = 'none'; }
 document.getElementById('fsbrowse').addEventListener('click', openFsBrowser);
+document.getElementById('clearmesh')
+  .addEventListener('click', clearMeshCacheAndReextract);
 
 // Clicking the EMPTY viewer opens the file browser (no robot loaded -> the only
 // thing to do is open one), like pressing 🗄.  While the browser is open, a

--- a/sw2robot/editor/web/index.html
+++ b/sw2robot/editor/web/index.html
@@ -562,6 +562,24 @@
       </div>
       <div id="fslist" style="overflow-y:auto;font-size:12.5px"></div>
     </div>
+    <!-- assembly-configuration picker: shown only when the .SLDASM has more
+         than one, since the choice decides which parts the URDF gets -->
+    <div id="cfgmodal" style="position:absolute;left:50%;top:22%;
+         transform:translateX(-50%);z-index:9;display:none;width:420px;
+         background:#1c2228f5;border:1px solid #456;border-radius:8px;
+         padding:12px 14px;flex-direction:column;gap:8px">
+      <div style="font-size:13px;color:#cdd" data-i18n="cfg.title">
+        どのコンフィギュレーション？</div>
+      <div id="cfgnote" style="font-size:11px;color:#9ab;line-height:1.5"></div>
+      <select id="cfgsel" style="font-size:12px;color:#cdd;background:#0e1216;
+              border:1px solid #345;border-radius:4px;padding:4px 6px"></select>
+      <div style="display:flex;gap:6px;justify-content:flex-end">
+        <button id="cfgcancel">✕</button>
+        <button id="cfggo" data-i18n="cfg.go"
+                style="background:#2b5f8a;color:#fff;border-color:#4a86c0">
+          抽出</button>
+      </div>
+    </div>
     <div id="loadbackdrop" style="position:absolute;inset:0;z-index:6;
          display:none;background:rgba(16,19,25,0.93)"></div>
     <div id="loadbar">
@@ -1663,6 +1681,19 @@ the config and does NOT re-detect). Needs graph.json (CAD mode).">🔗 re-detect
     'extract.cancelling': { en: 'cancelling extraction … (stops at the next step)', ja: '抽出をキャンセル中 … (次の処理の区切りで停止します)' },
     'extract.cancelled': { en: 'extraction cancelled', ja: '抽出をキャンセルしました' },
     'extract.statusElapsed': { en: a => `⏳ extracting … ${a.time}`, ja: a => `⏳ 抽出中 … ${a.time}` },
+    // assembly-configuration picker (only shown when the file has >1)
+    'cfg.title': { en: 'Which configuration?', ja: 'どのコンフィギュレーション？' },
+    'cfg.note': { en: a => `${a.name} has ${a.n} configurations. A configuration can suppress whole components and swap part variants, so the choice changes what the URDF contains.`, ja: a => `${a.name} には ${a.n} 個のコンフィギュレーションがあります。コンフィギュレーションは部品を抑制したり別バリエーションに差し替えたりするので、どれを選ぶかで URDF の中身が変わります。` },
+    'cfg.saved': { en: '(the file’s saved-active one)', ja: '(ファイル保存時のアクティブ)' },
+    'cfg.go': { en: 'extract', ja: '抽出' },
+    'cfg.chose': { en: a => `configuration: ${a.c}`, ja: a => `コンフィギュレーション: ${a.c}` },
+    // clear the mesh cache + re-extract
+    'ui.clearmesh': { en: '♻ drop meshes & re-extract', ja: '♻ メッシュを捨てて再抽出' },
+    't.clearmesh': { en: 'delete meshes/ and re-export every mesh from SolidWorks (your joint edits are kept)', ja: 'meshes/ を消して SolidWorks から全メッシュを出し直す（関節の編集は残ります）' },
+    'clearmesh.confirm': { en: a => `Re-export every mesh of ${a.name} from SolidWorks?\n\n${a.src}\n\nThis takes as long as the first extraction. Nothing is deleted up front -- the current meshes stay until their replacements are written, so a failed re-extract costs time, not your package. graph.json and your <name>.joints.yaml (joint types, limits, renames) are not touched.\n\nNormally you do not need this: the cache already invalidates itself when the CAD changes or you pick another configuration.`, ja: a => `${a.name} のメッシュを SolidWorks から全部出し直しますか？\n\n${a.src}\n\n初回の抽出と同じだけ時間がかかります。先に消すことはしません — 新しいメッシュが書けるまで今のメッシュは残るので、再抽出が失敗しても失うのは時間だけです。graph.json と <name>.joints.yaml（関節タイプ・可動域・改名）には触れません。\n\n通常は不要です: CAD を編集したときやコンフィギュレーションを変えたときは、キャッシュは自動で無効化されます。` },
+    'clearmesh.done': { en: a => `mesh cache invalidated: ${a.n} mesh(es), ${a.mb} MB will be re-exported`, ja: a => `メッシュキャッシュを無効化: ${a.n} 個 / ${a.mb} MB を出し直します` },
+    'clearmesh.fail': { en: a => `could not clear the mesh cache: ${a.e}`, ja: a => `メッシュキャッシュの削除に失敗: ${a.e}` },
+    'clearmesh.noSource': { en: 'the source CAD file is gone — nothing to re-extract from', ja: '元の CAD ファイルが見つかりません — 再抽出できません' },
     // file browser
     'fs.error': { en: a => `📁 ${a.e}`, ja: a => `📁 ${a.e}` },
     'fs.packageHint': { en: '(package — click to open)', ja: '(パッケージ — クリックで開く)' },
@@ -9651,12 +9682,58 @@ async function ensureNoExtraction() {
   }
 }
 
+// Which assembly configuration to extract.  Resolves to a config name, '' for
+// "the file's saved-active one", or null when the user backed out.  The picker
+// only appears when the file genuinely offers a choice (>1 configuration and a
+// SolidWorks session that could list them) -- a single-config assembly, or a
+// machine with no SolidWorks running, goes straight through as before.
+async function pickConfiguration(p) {
+  let info;
+  try {
+    const r = await fetch('/api/configurations?path=' + encodeURIComponent(p));
+    info = await r.json();
+  } catch { return ''; }
+  const names = (info && info.configurations) || [];
+  if (names.length < 2) { return ''; }
+  const modal = document.getElementById('cfgmodal');
+  const sel = document.getElementById('cfgsel');
+  document.getElementById('cfgnote').textContent =
+    t('cfg.note', { name: p.split(/[\\/]/).pop(), n: names.length });
+  sel.innerHTML = '';
+  const dflt = document.createElement('option');
+  dflt.value = '';
+  dflt.textContent = t('cfg.saved');
+  sel.appendChild(dflt);
+  for (const n of names) {
+    const o = document.createElement('option');
+    o.value = n; o.textContent = n;       // a config name is a CAD identifier
+    sel.appendChild(o);
+  }
+  modal.style.display = 'flex';
+  return await new Promise(resolve => {
+    const done = v => {
+      modal.style.display = 'none';
+      document.getElementById('cfggo').onclick = null;
+      document.getElementById('cfgcancel').onclick = null;
+      resolve(v);
+    };
+    document.getElementById('cfggo').onclick = () => done(sel.value);
+    document.getElementById('cfgcancel').onclick = () => done(null);
+  });
+}
+
 // SolidWorks extraction: start the job, stream its progress into the log
-async function extractFlow(p) {
+async function extractFlow(p, configuration) {
   await ensureNoExtraction();           // a heavy job in flight? cancel it first
+  if (configuration === undefined) {
+    configuration = await pickConfiguration(p);
+    if (configuration === null) { return; }      // user cancelled
+  }
   log(t('extract.request', { p }), 'wrn');
+  if (configuration) { log(t('cfg.chose', { c: configuration })); }
   statusEl.textContent = t('extract.statusRunning');
-  const resp = await fetch('/api/extract?path=' + encodeURIComponent(p));
+  const resp = await fetch('/api/extract?path=' + encodeURIComponent(p) +
+    (configuration ? '&configuration=' + encodeURIComponent(configuration) : ''));
   const r = await resp.json();
   if (!resp.ok || r.error) {
     log(t('extract.startFail', { e: r.error ?? resp.status }), 'err');
@@ -10044,7 +10121,7 @@ function sw2robotDump() {
 window.sw2robot = {
   dump: sw2robotDump,
   collision: () => ({ ready: colReady, links: [...collisionLinks] }),
-  extractFlow: p => extractFlow(p),     // for E2E (fetch is mocked there)
+  extractFlow: (p, c) => extractFlow(p, c),   // for E2E (fetch is mocked there)
   boxSelect: rect => selectLinksInBox(rect ??
     { l: -1e9, t: -1e9, r: 1e9, b: 1e9 }),   // no rect => everything on screen
   boxSelected: () => [...boxSelected],

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -142,6 +142,68 @@ def _preconvert_meshes(pkg_dir):
     threading.Thread(target=run, daemon=True).start()
 
 
+def _graph_origin(pkg_dir):
+    """``(source CAD file, configuration)`` this package was extracted from.
+
+    The file is None unless it is still reachable -- that is what a re-extract
+    would re-open, so an unreachable one must not offer the choice.  The
+    configuration is None on packages from before it was recorded; re-extracting
+    those falls back to the file's saved-active one, as they were built."""
+    try:
+        with open(os.path.join(pkg_dir or "", "graph.json"),
+                  encoding="utf-8") as f:
+            g = json.load(f)
+        src, cfg = g.get("source_assembly"), g.get("configuration")
+    except (OSError, ValueError, TypeError):
+        return None, None
+    return (src if src and os.path.isfile(src) else None), cfg
+
+
+# the sidecar mesh.py writes next to the meshes, recording which
+# (part file, configuration) produced each one
+_MESH_MANIFEST = "cache_manifest.json"
+
+
+def _clear_mesh_cache(pkg_dir):
+    """Invalidate the package's mesh cache; return (meshes invalidated, bytes).
+
+    It does NOT delete the meshes -- it deletes only
+    ``meshes/cache_manifest.json``, the record of which (part, configuration)
+    each mesh came from.  Without a record a mesh is of unknown configuration,
+    which ``mesh._cache_holds_config`` refuses to reuse, so the next extract
+    re-exports every one of them from SolidWorks -- the whole point of the
+    button -- while the existing meshes stay on disk.
+
+    That difference matters: the re-extract can fail (SolidWorks busy, the
+    assembly's references unresolvable), and deleting first would leave the
+    user with a package that renders nothing and no way back.  This way a
+    failed re-extract costs time, not data.
+
+    graph.json (the extraction result) and <name>.joints.yaml (the user's joint
+    edits) are not cache and are never touched."""
+    meshes = os.path.join(pkg_dir, "meshes")
+    if not os.path.isdir(meshes):
+        return 0, 0
+    n = size = 0
+    for f in os.listdir(meshes):
+        p = os.path.join(meshes, f)
+        if os.path.isfile(p) and f != _MESH_MANIFEST:
+            try:
+                size += os.path.getsize(p)
+                n += 1
+            except OSError:
+                pass
+    manifest = os.path.join(meshes, _MESH_MANIFEST)
+    try:
+        os.remove(manifest)
+    except FileNotFoundError:
+        pass                      # already invalid; the re-extract redoes them
+    except OSError as e:
+        print(f"[sw2robot.web] could not invalidate the mesh cache: {e!r}")
+        return 0, 0
+    return n, size
+
+
 def _resolve_package(path):
     """Accept a package dir, a dir containing urdf/, or a .urdf path; return
     ``(pkg_dir, urdf_rel)`` or raise ValueError."""
@@ -4492,35 +4554,38 @@ def _run_extract(sldasm, configuration=None):
     threading.Thread(target=heartbeat, daemon=True).start()
     try:
         from . import core
-        progress(f"extracting {os.path.basename(sldasm)} -- this opens a "
-                 f"throwaway COPY in a hidden SolidWorks instance "
-                 f"(the original is never modified)")
-        sw = _warm_sw(progress)
-        if sw is None:
+        progress(f"extracting {os.path.basename(sldasm)}"
+                 + (f" @ configuration {configuration!r}" if configuration
+                    else "")
+                 + " -- this opens a throwaway COPY in a hidden SolidWorks "
+                   "instance (the original is never modified)")
+        sw = _acquire_sw(progress)
+        try:
+            state = core.extract_and_import(
+                sldasm, out_dir=_Handler.root_dir, progress=progress, sw=sw,
+                configuration=configuration)
+        except ValueError as e:
+            # "no usable components" out of the USER's SolidWorks does not mean
+            # the assembly is broken: a session busy with the user's own
+            # documents can hand back a copy whose component tree is empty.
+            # A private instance opens it from scratch, so retry there once
+            # rather than telling the user their CAD cannot be read.
+            if not (getattr(sw, "_attached", False)
+                    and "no usable components" in str(e)):
+                raise
+            progress("the running SolidWorks returned an empty assembly "
+                     "(it is busy with your own documents); retrying in a "
+                     "private instance ...")
+            _sw["sess"] = None
             from sw2robot.exporter.swcom import SolidWorks
-            # Reuse the user's ALREADY-RUNNING SolidWorks if we can attach to it
-            # (same login session): no new process to start (instant, no ~1 min
-            # cold start) and nothing to leak.  The throwaway copy is opened in
-            # that instance and closed afterwards; the user's own documents are
-            # never modified.
-            try:
-                progress("attaching to the running SolidWorks ...")
-                sw = SolidWorks(attach=True)
-                progress("attached to the running SolidWorks ✓ (reusing it)")
-            except Exception:
-                progress("no attachable SolidWorks; starting a private instance "
-                         "(this can take a minute; later extractions reuse it) ...")
-                # Create the COM object in THIS thread.  SolidWorks is STA-bound:
-                # an instance built on another thread (e.g. a timeout worker)
-                # loses its apartment when that thread ends, so OpenDoc6 then
-                # fails with CO_E_OBJNOTCONNECTED ("object not connected").
-                before = _sldworks_pids()
-                sw = SolidWorks(visible=False)
-                for pid in _sldworks_pids() - before:   # the one(s) we just spawned
-                    _record_spawned_pid(pid)
+            before = _sldworks_pids()
+            sw = SolidWorks(visible=False)
+            for pid in _sldworks_pids() - before:
+                _record_spawned_pid(pid)
             _sw["sess"] = sw
-        state = core.extract_and_import(
-            sldasm, out_dir=_Handler.root_dir, progress=progress, sw=sw)
+            state = core.extract_and_import(
+                sldasm, out_dir=_Handler.root_dir, progress=progress, sw=sw,
+                configuration=configuration)
         _job["package"] = str(state.package_dir)
         _preconvert_meshes(str(state.package_dir))
         progress(f"done -> {state.package_dir} (SolidWorks kept warm for "
@@ -4918,8 +4983,14 @@ class _Handler(http.server.BaseHTTPRequestHandler):
             return {"name": None, "urdf": None, "mode": None}
         # 'cad' = joints.yaml + build() path; 'urdf' = direct overlay editing
         # (the frontend gates URDF-only controls such as inertial editing on this)
+        src, cfg = _graph_origin(cls.pkg_dir)   # one graph.json read, not two
         return {"name": cls.robot_name, "urdf": "/pkg/" + cls.urdf_rel,
                 "mode": "cad" if _cad_mode(cls.pkg_dir) else "urdf",
+                # what a re-extract would re-open, and on which configuration.
+                # A null source disables the clear-mesh-cache control -- there
+                # would be nothing to rebuild the meshes from.
+                "source_assembly": src,
+                "configuration": cfg,
                 "sw2urdf": _sw2urdf_status(cls.pkg_dir, cls.urdf_rel)}
 
     def _um_reply(self, fn, *args):
@@ -7243,6 +7314,27 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                         {"error": f"rebuild failed: {e}"}, 500)
                 print(f"[sw2robot.web] remove_port: {pname}")
                 return self._send_json({"ok": True, "name": pname})
+            if parsed.path == "/api/clear_mesh_cache":
+                # wipe meshes/ so the next extract re-exports every mesh from
+                # SolidWorks.  Normally unnecessary -- the cache invalidates
+                # itself on a CAD edit (mtime) and on a configuration change
+                # (meshes/cache_manifest.json) -- but it is the way to rule the
+                # cache out when an export looks wrong.
+                cls = type(self)
+                if not cls.pkg_dir:
+                    return self._send_json({"error": "no package open"}, 400)
+                if _job["running"]:
+                    return self._send_json(
+                        {"error": "an extraction is running"}, 409)
+                src, cfg = _graph_origin(cls.pkg_dir)
+                n, size = _clear_mesh_cache(cls.pkg_dir)
+                print(f"[sw2robot.web] mesh cache invalidated: {n} mesh(es), "
+                      f"{size} B under {cls.pkg_dir} (files kept; the "
+                      f"re-extract rebuilds them)")
+                return self._send_json({"ok": True, "removed": n,
+                                        "bytes": size,
+                                        "source_assembly": src,
+                                        "configuration": cfg})
             if parsed.path == "/api/reset_names":
                 # drop ALL rename overlays -> every link/joint back to default
                 cls = type(self)

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -4367,8 +4367,82 @@ def _shutdown_sw():
     _reap_spawned_sw()             # belt-and-suspenders: kill any we spawned
 
 
-def _run_extract(sldasm):
-    """Background thread: SolidWorks extract + build -> module package."""
+def _acquire_sw(progress):
+    """The SolidWorks session to work in: the warm one, else the user's
+    running instance, else a private one -- cached in ``_sw['sess']``.
+
+    Split out of :func:`_run_extract` because listing an assembly's
+    configurations needs the same session (and warms it for the extract that
+    usually follows)."""
+    sw = _warm_sw(progress)
+    if sw is not None:
+        return sw
+    from sw2robot.exporter.swcom import SolidWorks
+    # Reuse the user's ALREADY-RUNNING SolidWorks if we can attach to it
+    # (same login session): no new process to start (instant, no ~1 min
+    # cold start) and nothing to leak.  The throwaway copy is opened in
+    # that instance and closed afterwards; the user's own documents are
+    # never modified.
+    try:
+        progress("attaching to the running SolidWorks ...")
+        sw = SolidWorks(attach=True)
+        progress("attached to the running SolidWorks ✓ (reusing it)")
+    except Exception:
+        progress("no attachable SolidWorks; starting a private instance "
+                 "(this can take a minute; later extractions reuse it) ...")
+        # Create the COM object in THIS thread.  SolidWorks is STA-bound:
+        # an instance built on another thread (e.g. a timeout worker)
+        # loses its apartment when that thread ends, so OpenDoc6 then
+        # fails with CO_E_OBJNOTCONNECTED ("object not connected").
+        before = _sldworks_pids()
+        sw = SolidWorks(visible=False)
+        for pid in _sldworks_pids() - before:   # the one(s) we just spawned
+            _record_spawned_pid(pid)
+    _sw["sess"] = sw
+    return sw
+
+
+def _configurations_of(cad_path):
+    """(names, source) -- the configurations ``cad_path`` offers, read WITHOUT
+    loading the document (ISldWorks::GetConfigurationNames on the closed file).
+
+    Uses the warm session when there is one, else the user's running
+    SolidWorks.  It deliberately does NOT start a private instance: a picker
+    must not cost the user a minute of cold start, and a COM object created on
+    this short-lived request thread could not be cached anyway (see
+    :func:`_acquire_sw`).  With no session reachable, returns
+    ``([], "unavailable")`` and the caller falls back to the file's
+    saved-active configuration."""
+    from sw2robot.exporter.export import configuration_names
+    from sw2robot.exporter.swcom import SolidWorks
+
+    sess = _sw.get("sess")
+    if sess is not None:
+        try:
+            if sess.app is not None and sess._responds():
+                return configuration_names(cad_path, sw=sess), "warm"
+        except Exception:
+            pass
+    try:
+        own = SolidWorks(attach=True)
+    except Exception:
+        return [], "unavailable"
+    try:
+        return configuration_names(cad_path, sw=own), "attached"
+    except Exception as e:
+        print(f"[sw2robot.web] configuration list failed: {e!r}")
+        return [], "unavailable"
+    finally:
+        own.shutdown()           # attach mode leaves the user's SolidWorks alone
+
+
+def _run_extract(sldasm, configuration=None):
+    """Background thread: SolidWorks extract + build -> module package.
+
+    ``configuration`` -- extract THIS assembly configuration instead of the
+    file's saved-active one.  Configurations can suppress whole components and
+    swap a part for another length/variant, so the choice changes what comes
+    out; None keeps the previous behaviour (whatever the file was saved on)."""
     def progress(msg):
         # cooperative cancel: the extract calls progress() between COM steps
         # (per phase, per mesh), so raising here aborts at the next checkpoint
@@ -5308,6 +5382,24 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                          "phase": _limjob["phase"], "error": _limjob["error"],
                          "results": _limjob["results"],
                          "done": not _limjob["running"]})
+            if path == "/api/configurations":
+                # what the assembly-configuration picker offers, before the
+                # (multi-minute) extract commits to one
+                target = (query.get("path") or [""])[0]
+                target = os.path.abspath(os.path.expanduser(
+                    target.strip().strip('"')))
+                if not (os.path.isfile(target)
+                        and target.lower().endswith((".sldasm", ".sldprt"))):
+                    return self._send_json(
+                        {"error": f"not a .sldasm/.sldprt file: {target}"}, 400)
+                try:
+                    names, src = _configurations_of(target)
+                except Exception as e:
+                    return self._send_json(
+                        {"configurations": [], "source": "error",
+                         "error": f"{type(e).__name__}: {e}"})
+                return self._send_json({"configurations": names,
+                                        "source": src})
             if path == "/api/extract":
                 target = (query.get("path") or [""])[0]
                 target = os.path.abspath(os.path.expanduser(
@@ -5316,6 +5408,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                         and target.lower().endswith((".sldasm", ".sldprt"))):
                     return self._send_json(
                         {"error": f"not a .sldasm/.sldprt file: {target}"}, 400)
+                # "" = keep the file's saved-active configuration
+                cfg = (query.get("configuration") or [""])[0].strip() or None
                 if not _prog_start("extract", _EXTRACT_STAGES):
                     return self._send_json(
                         {"error": "a job is already running"}, 409)
@@ -5323,7 +5417,7 @@ class _Handler(http.server.BaseHTTPRequestHandler):
                     _job.update(running=True, log=[], error=None,
                                 package=None, cancel=False, cancelled=False)
                 try:
-                    threading.Thread(target=_run_extract, args=(target,),
+                    threading.Thread(target=_run_extract, args=(target, cfg),
                                      daemon=True).start()
                 except Exception as e:
                     # release the guard the never-started worker can't (see the

--- a/sw2robot/exporter/export.py
+++ b/sw2robot/exporter/export.py
@@ -60,6 +60,29 @@ from .urdf_writer import write_ros_package, write_urdf
 GRAPH_FILE = "graph.json"
 
 
+def configuration_names(cad_path, sw=None, visible=False):
+    """Configuration names in a .SLDASM/.SLDPRT, WITHOUT opening it.
+
+    ``ISldWorks::GetConfigurationNames`` reads them straight off the closed
+    file, so a UI can offer the choice up front instead of paying the
+    multi-minute assembly load first.  Pass a live ``SolidWorks`` session as
+    ``sw`` to reuse it; otherwise a private one is started and shut down.
+
+    Returns ``[]`` when the file has none to report -- callers should treat
+    that as "just use the saved-active one", not as an error.  Which one IS
+    saved-active is not knowable without opening the document; that is why the
+    extract's ``configuration=None`` (keep whatever the file was saved on)
+    stays the default.
+    """
+    cad_path = os.path.abspath(cad_path)
+    if sw is not None:
+        names = safe_call(sw.app, "GetConfigurationNames", cad_path)
+    else:
+        with SolidWorks(visible=visible) as own:
+            names = safe_call(own.app, "GetConfigurationNames", cad_path)
+    return [str(n) for n in (names or [])]
+
+
 def _tolerant_console():
     """Don't let a non-ASCII component name (e.g. a Turkish 'gövde') crash a
     print on a legacy console code page (Japanese cp932, ...)."""
@@ -129,6 +152,7 @@ def _extract_into(sw, assembly_path, pkg_dir, meshes_dir, robot_name, _say,
     doc = sw.open_copy(assembly_path)
     # surface the choice: extracts silently follow the file's SAVED-ACTIVE
     # configuration, which is not necessarily the one on the user's screen
+    cfgs, used_cfg = [], None
     try:
         md = as_iface(doc, "IModelDoc2")
         cfgs = [str(c) for c in (safe_call(md, "GetConfigurationNames") or [])]
@@ -141,6 +165,11 @@ def _extract_into(sw, assembly_path, pkg_dir, meshes_dir, robot_name, _say,
             else:
                 print(f"      WARN: configuration {configuration!r} not found; "
                       f"staying on {active!r}")
+        # what is ACTUALLY in effect -- a rejected switch must not be recorded
+        # as if it had happened
+        used_cfg = str(md.ConfigurationManager.ActiveConfiguration.Name)
+        if len(cfgs) > 1:
+            _say(f"extracting configuration {used_cfg!r}")
     except Exception as e:
         if configuration:
             print(f"      WARN: could not switch configuration ({e!r})")
@@ -240,7 +269,8 @@ def _extract_into(sw, assembly_path, pkg_dir, meshes_dir, robot_name, _say,
                            sw2urdf_config_xml=sw2urdf_config_xml,
                            subassembly_coordinate_systems=
                            subassembly_coordinate_systems,
-                           part_coordinate_systems=part_coordinate_systems)
+                           part_coordinate_systems=part_coordinate_systems,
+                           configuration=used_cfg, configurations=cfgs)
     graph.save(os.path.join(pkg_dir, GRAPH_FILE))
     sw.close_doc(doc)
     return pkg_dir

--- a/sw2robot/exporter/export.py
+++ b/sw2robot/exporter/export.py
@@ -26,9 +26,11 @@ import sys
 from . import jointcfg
 from .mesh import (
     _SAVE_OPTS,
+    _unique_part_names,
     export_meshes,
     export_part_mesh,
     export_subgraph_meshes,
+    verify_meshes,
 )
 from .model import (
     build_model,
@@ -201,9 +203,31 @@ def _extract_into(sw, assembly_path, pkg_dir, meshes_dir, robot_name, _say,
         res = ext.SaveAs(whole, 0, _SAVE_OPTS, None, 0, 0)
         ok = res[0] if isinstance(res, (tuple, list)) else res
         if ok and os.path.exists(whole):
+            # this one SaveAs does not go through _save_3dxml, so give it the
+            # same treatment: a part used with two configurations lands as two
+            # same-named Reference3D nodes that collapse into one when the file
+            # is read back (see mesh._dedupe_reference_names)
+            n_dup = _unique_part_names(whole)
+            if n_dup:
+                _say(f"assembly mesh: disambiguated {n_dup} config "
+                     f"variant(s) sharing a part name")
             whole_rel = os.path.basename(whole)
     except Exception as e:
         print(f"      assembly 3dxml raised {e!r}")
+
+    # Read every mesh back and compare it with what the file says it holds.
+    # An export that hands geometry to a loader and never checks it can be
+    # silently WRONG -- two configuration variants of one part collapsing into
+    # one shape, superimposed, with the part COUNT still correct.  This makes
+    # that class of failure visible instead of shipping it into the URDF.
+    _say("verifying meshes read back whole ...")
+    written = sorted(
+        os.path.join(meshes_dir, f) for f in os.listdir(meshes_dir)
+        if f.lower().endswith(".3dxml"))
+    if whole_rel:
+        written.append(whole)
+    verify_meshes(written, say=_say)
+
     _say(f"{n} meshes exported; saving graph.json ...")
 
     graph = to_graph_state(comps, adjacency, ground, robot_name,

--- a/sw2robot/exporter/mesh.py
+++ b/sw2robot/exporter/mesh.py
@@ -10,6 +10,7 @@ closed afterwards.
 
 from __future__ import annotations
 
+import json
 import os
 
 from .swcom import (
@@ -126,6 +127,58 @@ def _cache_is_fresh(cand, source_path):
         return True
 
 
+# meshes/<MANIFEST>: which (part file, configuration) produced each cached
+# mesh.  The cache is keyed on the LINK NAME, and a .3dxml carries no record of
+# the configuration it was tessellated from -- so after the user switches a
+# part (or the assembly) to another configuration, the previous config's mesh
+# sits at exactly the filename the new one would take, passes the mtime gate
+# (the .SLDPRT itself did not change) and is reused: the export then MIXES
+# geometry from two configurations.  The manifest makes the cached config
+# checkable, so a config change invalidates just the meshes it affects.
+_CACHE_MANIFEST = "cache_manifest.json"
+
+
+def _manifest_load(meshes_dir):
+    try:
+        with open(os.path.join(meshes_dir, _CACHE_MANIFEST),
+                  encoding="utf-8") as f:
+            man = json.load(f)
+        return man if isinstance(man, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _manifest_record(meshes_dir, mesh_path, source_path, config):
+    """Remember that ``mesh_path`` holds ``source_path`` @ ``config``."""
+    if not meshes_dir:
+        return
+    man = _manifest_load(meshes_dir)
+    man[os.path.basename(mesh_path)] = {"source": str(source_path),
+                                        "config": config or None}
+    dst = os.path.join(meshes_dir, _CACHE_MANIFEST)
+    try:
+        tmp = dst + ".part"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(man, f, ensure_ascii=False, indent=1, sort_keys=True)
+        os.replace(tmp, dst)
+    except OSError as e:
+        print(f"    could not update the mesh cache manifest: {e!r}")
+
+
+def _cache_holds_config(meshes_dir, cand, config):
+    """Whether the cached ``cand`` is known to hold ``config``'s geometry.
+
+    A mesh with no manifest entry is of UNKNOWN configuration (written by an
+    older version, or by hand), so it is refused rather than trusted -- one
+    slower extract beats silently mixing two configurations."""
+    if not meshes_dir:
+        return False
+    rec = _manifest_load(meshes_dir).get(os.path.basename(cand))
+    if not isinstance(rec, dict):
+        return False
+    return (rec.get("config") or None) == (config or None)
+
+
 def _refresh_mass_with_config(app, comp):
     """Re-read material/density/mass properties on the instance's OWN
     configuration.  The values captured during the graph walk came from the
@@ -204,11 +257,11 @@ def export_meshes(app, doc, comps, meshes_dir, progress=None, by_path=None):
             progress(len(by_path) + 1, total, comp.link_name)
         out = os.path.join(meshes_dir, comp.link_name + ".3dxml")
         reused = False
-        # a cached file cannot say WHICH configuration it holds -- for files
-        # whose instances diverge, always re-export on the right config
-        for cand in (() if path in divergent else
-                     (out, os.path.join(meshes_dir, comp.link_name + ".glb"))):
-            if _cache_is_fresh(cand, path):
+        # a cached file cannot say WHICH configuration it holds -- the
+        # manifest can, so reuse only a mesh recorded as THIS config's
+        for cand in (out, os.path.join(meshes_dir, comp.link_name + ".glb")):
+            if _cache_is_fresh(cand, path) \
+                    and _cache_holds_config(meshes_dir, cand, cfg):
                 rel = os.path.join("meshes", os.path.basename(cand))
                 by_path[key] = rel
                 comp.mesh_file = rel
@@ -227,6 +280,13 @@ def export_meshes(app, doc, comps, meshes_dir, progress=None, by_path=None):
             # parent already fully resolved, so it exports real geometry where
             # a standalone OpenDoc6 of the same file comes up hollow
             try:
+                # ... but the shared doc opens on the file's SAVED-ACTIVE
+                # configuration, which need NOT be the one this instance
+                # references (a part saved on 'variant_b' but assembled as
+                # 'Default').  Exporting it as-is tessellates the wrong
+                # variant, so switch first -- as _export_by_opening and
+                # _compose_from_parts already do.
+                _show_config(md, cfg)
                 ok = _save_3dxml(md, out)
             except Exception as e:
                 print(f"  {comp.name}: in-session export failed ({e!r}); "
@@ -246,6 +306,7 @@ def export_meshes(app, doc, comps, meshes_dir, progress=None, by_path=None):
             by_path[key] = rel
             comp.mesh_file = rel
             n += 1
+            _manifest_record(meshes_dir, out, path, cfg)
             print(f"  mesh: {comp.link_name} <- {os.path.basename(path)} "
                   f"({os.path.getsize(out)} B)")
             if path in divergent and not comp.is_subassembly:
@@ -267,7 +328,11 @@ def export_part_mesh(md, comp, meshes_dir):
     cache of real geometry is reused when present (see :func:`_cache_is_fresh`)."""
     os.makedirs(meshes_dir, exist_ok=True)
     out = os.path.join(meshes_dir, comp.link_name + ".3dxml")
-    if _cache_is_fresh(out, comp.part_path):
+    # the part may have been re-saved on another configuration since; the
+    # manifest is what tells the cached mesh's config apart (see _CACHE_MANIFEST)
+    cfg = getattr(comp, "configuration", None) or active_config(md)
+    if _cache_is_fresh(out, comp.part_path) \
+            and _cache_holds_config(meshes_dir, out, cfg):
         comp.mesh_file = os.path.join("meshes", os.path.basename(out))
         return 1
     ok = False
@@ -277,6 +342,7 @@ def export_part_mesh(md, comp, meshes_dir):
         print(f"  part mesh in-session export failed ({e!r})")
     if ok:
         comp.mesh_file = os.path.join("meshes", os.path.basename(out))
+        _manifest_record(meshes_dir, out, comp.part_path, cfg)
         print(f"  mesh: {comp.link_name} <- {os.path.basename(comp.part_path)} "
               f"({os.path.getsize(out)} B)")
         return 1
@@ -322,11 +388,12 @@ def export_subgraph_meshes(app, subgraphs, meshes_dir, by_path=None):
             base = f"{prefix}__{sc.link_name}"
             out = os.path.join(meshes_dir, base + ".3dxml")
             ok = False
-            # config-divergent files: never trust the config-blind cache
-            for cand in (() if p in divergent else
-                         (out, os.path.join(meshes_dir, base + ".glb"))):
-                if _cache_is_fresh(cand, p):
-                    out, ok = cand, True
+            reused = False
+            # only a mesh the manifest records as THIS config may be reused
+            for cand in (out, os.path.join(meshes_dir, base + ".glb")):
+                if _cache_is_fresh(cand, p) \
+                        and _cache_holds_config(meshes_dir, cand, cfg):
+                    out, ok, reused = cand, True, True
                     break
             if not ok:
                 ok = _export_by_opening(app, p, out, config=cfg)
@@ -340,6 +407,8 @@ def export_subgraph_meshes(app, subgraphs, meshes_dir, by_path=None):
                 by_path[key] = rel
                 sc.mesh_file = rel
                 n += 1
+                if not reused:
+                    _manifest_record(meshes_dir, out, p, cfg)
                 if p in divergent and not sc.is_subassembly:
                     _refresh_mass_with_config(app, sc)
                 print(f"  sub-mesh: {base} <- {os.path.basename(p)} "
@@ -399,6 +468,7 @@ def _compose_from_parts(app, md, path, out_glb, meshes_dir=None, by_path=None):
                 os.replace(tmp, dst)
                 _persisted[dst] = key
                 by_path[key] = os.path.join("meshes", os.path.basename(dst))
+                _manifest_record(meshes_dir, dst, cpath, ccfg)
         except Exception as e:
             print(f"    compose: could not persist part mesh "
                   f"{os.path.basename(cpath)}: {e!r}")
@@ -508,9 +578,23 @@ def _mkey(path, cfg):
     return (path, cfg or None)
 
 
+def active_config(md):
+    """Name of the configuration ``md`` currently shows, or None."""
+    try:
+        return str(as_iface(md, "IModelDoc2")
+                   .ConfigurationManager.ActiveConfiguration.Name)
+    except Exception:
+        return None
+
+
 def _show_config(md, config):
-    """Activate ``config`` on ``md`` (no-op when already active / None)."""
+    """Activate ``config`` on ``md`` (no-op when already active / None).
+
+    The already-active check is not just an optimisation: ShowConfiguration2
+    forces a rebuild, and this runs once per component."""
     if not config:
+        return
+    if active_config(md) == str(config):
         return
     try:
         as_iface(md, "IModelDoc2").ShowConfiguration2(config)

--- a/sw2robot/exporter/mesh.py
+++ b/sw2robot/exporter/mesh.py
@@ -12,6 +12,9 @@ from __future__ import annotations
 
 import json
 import os
+import re
+import xml.etree.ElementTree as ET
+import zipfile
 
 from .swcom import (
     SW_OPEN_SILENT,
@@ -66,6 +69,199 @@ def _open_doc(app, path):
         return None
 
 
+_REF3D = re.compile(rb"<Reference3D\b[^>]*>")
+_XML_NAME = re.compile(rb'\bname="([^"]*)"')
+
+
+def _dedupe_reference_names(raw):
+    """``(xml, renamed)`` -- make every ``Reference3D`` name in a 3DXML
+    structure unique, keeping the first of each.
+
+    SolidWorks writes ONE tessellation per CONFIGURATION, so a part used with
+    two configurations lands in the file as two ``Reference3D`` nodes carrying
+    the SAME name.  That is valid -- the structure is driven by ``id``, and the
+    name is only a label -- but trimesh's reader re-keys geometry BY NAME
+    ("remap geometry names from id numbers to the name string",
+    trimesh/exchange/threedxml.py), so the second silently overwrites the
+    first and every instance is then drawn with whichever variant survived: a
+    mirrored bracket on the wrong side, a spacer 8 mm short.  Both the editor's
+    viewer and the ROS export read these files through trimesh.
+
+    Renaming the duplicates costs nothing structurally and fixes all of them.
+    The suffix is appended to the RAW attribute bytes, so an XML-escaped or
+    CJK name is never re-encoded."""
+    seen = {}
+    n = 0
+
+    def sub(m):
+        nonlocal n
+        tag = m.group(0)
+        mn = _XML_NAME.search(tag)
+        if mn is None:
+            return tag
+        raw_name = mn.group(1)
+        seen[raw_name] = seen.get(raw_name, 0) + 1
+        if seen[raw_name] == 1:
+            return tag
+        n += 1
+        new = raw_name + b"__" + str(seen[raw_name]).encode()
+        return tag[:mn.start(1)] + new + tag[mn.end(1):]
+
+    return _REF3D.sub(sub, raw), n
+
+
+def _unique_part_names(path):
+    """Rewrite ``path`` in place so no two ``Reference3D`` share a name.
+
+    Returns how many were renamed (0 = the file was already unambiguous and
+    nothing was rewritten).  Best-effort: any failure leaves the original file
+    untouched, since a mesh with ambiguous names still beats no mesh."""
+    try:
+        with zipfile.ZipFile(path) as z:
+            root_name = None
+            try:
+                man = ET.fromstring(z.read("Manifest.xml"))
+                root_name = next(
+                    (e.text for e in man.iter()
+                     if e.tag.split("}")[-1] == "Root" and e.text), None)
+            except KeyError:
+                pass
+            if root_name is None or root_name not in z.namelist():
+                return 0
+            raw = z.read(root_name)
+            fixed, n = _dedupe_reference_names(raw)
+            if not n:
+                return 0
+            items = [(i, z.read(i.filename)) for i in z.infolist()]
+    except (OSError, zipfile.BadZipFile, ET.ParseError) as e:
+        print(f"    could not inspect {os.path.basename(path)}: {e!r}")
+        return 0
+
+    tmp = path + ".uniq"
+    try:
+        with zipfile.ZipFile(tmp, "w", zipfile.ZIP_DEFLATED) as out:
+            for info, data in items:
+                zi = zipfile.ZipInfo(info.filename, _safe_date(info.date_time))
+                zi.compress_type = info.compress_type
+                zi.external_attr = info.external_attr
+                out.writestr(zi, fixed if info.filename == root_name else data)
+        os.replace(tmp, path)
+    except OSError as e:
+        print(f"    could not rewrite {os.path.basename(path)}: {e!r}")
+        try:
+            os.remove(tmp)
+        except OSError:
+            pass
+        return 0
+    return n
+
+
+def _declared_counts(path):
+    """``(tessellations, part instances)`` the 3DXML itself declares, or None.
+
+    Read straight from the file's own product structure, so it is what
+    SolidWorks says it wrote -- the yardstick a loader has to match."""
+    try:
+        with zipfile.ZipFile(path) as z:
+            man = ET.fromstring(z.read("Manifest.xml"))
+            root_name = next(
+                (e.text for e in man.iter()
+                 if e.tag.split("}")[-1] == "Root" and e.text), None)
+            if root_name is None or root_name not in z.namelist():
+                return None
+            root = ET.fromstring(z.read(root_name))
+    except (OSError, KeyError, StopIteration, zipfile.BadZipFile,
+            ET.ParseError):
+        return None
+
+    def tag(e):
+        return e.tag.split("}")[-1]
+
+    # a Reference3D that owns an InstanceRep carries geometry; one that does
+    # not is a sub-assembly node and draws nothing itself
+    with_geometry = set()
+    for e in root.iter():
+        if tag(e) == "InstanceRep":
+            for ch in e:
+                if tag(ch) == "IsAggregatedBy":
+                    with_geometry.add(ch.text)
+    instances = 0
+    for e in root.iter():
+        if tag(e) == "Instance3D":
+            for ch in e:
+                if tag(ch) == "IsInstanceOf" and ch.text in with_geometry:
+                    instances += 1
+    return len(with_geometry), instances
+
+
+def verify_mesh(path):
+    """``None`` if the mesh reads back whole, else a one-line complaint.
+
+    The export hands geometry to a third-party loader and never sees it again,
+    so anything the loader drops or merges is silently WRONG output: two
+    configuration variants of one part collapsed into one shape, superimposed,
+    and the part COUNT still looked right, which is why it went unnoticed.
+    Comparing the file's own declared counts against what the loader returns
+    turns that class of failure -- not just the one we know about -- into a
+    visible one."""
+    declared = _declared_counts(path)
+    if declared is None:
+        return None                     # not a structured 3DXML; nothing to check
+    n_geom, n_inst = declared
+    try:
+        import trimesh
+        scene = trimesh.load(path)
+    except Exception as e:
+        return f"{os.path.basename(path)}: could not be read back ({e!r})"
+    got_geom = len(getattr(scene, "geometry", {}) or {})
+    got_nodes = len(getattr(getattr(scene, "graph", None),
+                            "nodes_geometry", []) or [])
+    if got_geom != n_geom:
+        return (f"{os.path.basename(path)}: declares {n_geom} shape(s) but "
+                f"reads back as {got_geom} -- geometry was merged or dropped")
+    # A single-PART export has no Instance3D at all: the root reference IS the
+    # geometry, and the loader still yields one node.  Only an assembly, which
+    # does declare its instances, can be checked this way.
+    if n_inst and got_nodes != n_inst:
+        return (f"{os.path.basename(path)}: declares {n_inst} instance(s) but "
+                f"reads back as {got_nodes} -- placements were lost")
+    return None
+
+
+def verify_meshes(paths, say=None):
+    """Check every written mesh reads back whole; return the complaints."""
+    bad = []
+    for p in paths:
+        try:
+            problem = verify_mesh(p)
+        except Exception as e:                     # never fail an export here
+            problem = f"{os.path.basename(p)}: verification raised {e!r}"
+        if problem:
+            bad.append(problem)
+            print(f"      MESH FIDELITY: {problem}")
+    if say:
+        # plain ASCII: this can reach a cp932 console that has not been through
+        # _tolerant_console(), and a status line must never raise
+        say(f"verified {len(paths)} mesh(es)"
+            + (f" -- {len(bad)} PROBLEM(S), see the log" if bad
+               else " -- all read back whole"))
+    return bad
+
+
+def _safe_date(dt):
+    """A zip date these files can actually be written with.  SolidWorks stamps
+    3DXML entries with impossible dates (day 0, month 13), which zipfile
+    refuses to pack -- fall back to the DOS epoch rather than lose the entry."""
+    try:
+        y, mo, d, h, mi, s = dt
+        if 1980 <= y <= 2107 and 1 <= mo <= 12 and 1 <= d <= 31 \
+                and 0 <= h <= 23 and 0 <= mi <= 59 and 0 <= s <= 59:
+            return dt
+    except (TypeError, ValueError):
+        pass
+    return (1980, 1, 1, 0, 0, 0)
+
+
 def _save_3dxml(model_doc, out_path):
     # SolidWorks resolves a RELATIVE SaveAs path against ITS OWN working
     # directory (the SLDWORKS.exe process), not ours -- a `-o output` relative
@@ -88,6 +284,13 @@ def _save_3dxml(model_doc, out_path):
         raise
     ok = bool(res[0]) if isinstance(res, (tuple, list)) else bool(res)
     if ok and os.path.exists(tmp) and os.path.getsize(tmp) >= _MIN_MESH_BYTES:
+        # one tessellation per configuration means same-named Reference3D
+        # nodes, which collapse to one geometry in trimesh -- see
+        # _dedupe_reference_names.  Every 3DXML we write goes through here.
+        n = _unique_part_names(tmp)
+        if n:
+            print(f"    {os.path.basename(out_path)}: disambiguated {n} "
+                  f"config variant(s) sharing a part name")
         os.replace(tmp, out_path)
         return True
     # say WHY: a res=True but tiny file is the empty-envelope failure mode

--- a/sw2robot/exporter/model.py
+++ b/sw2robot/exporter/model.py
@@ -741,10 +741,17 @@ def extract_components(doc, exclude=None, progress=None,
     used = set()
     n_skipped = 0
     n_excluded = 0
-    matcache = {}        # part_path -> (material name, density kg/m^3)
+    # (part_path, configuration) -> (material name, density kg/m^3, mass props).
+    # The CONFIGURATION belongs in the key: mass, centre of mass and inertia are
+    # per-configuration (a part saved on 'variant_b' weighs 18.7 g where the
+    # 'Default' the assembly references weighs 10.2 g), and the shared document
+    # opens on the file's saved-active config, not this instance's.
+    matcache = {}
 
-    def _material_of(ct, path):
-        key = path.lower()
+    def _material_of(ct, path, config):
+        from .mesh import _show_config  # lazy: mesh imports model back
+
+        key = (path.lower(), config or None)
         if key in matcache:
             return matcache[key]
         props = (None, None, None)
@@ -752,6 +759,9 @@ def extract_components(doc, exclude=None, progress=None,
         try:
             md = safe_call(ct, "GetModelDoc2")
             if md is not None:
+                # read on the config this INSTANCE references, not on whatever
+                # the shared doc happens to show
+                _show_config(md, config)
                 props = _read_part_props(md)
         except Exception:
             pass
@@ -802,12 +812,12 @@ def extract_components(doc, exclude=None, progress=None,
         used.add(ln)
         if progress:
             progress(ln)
+        cfg = safe_prop(ct, "ReferencedConfiguration") or None
         material = density = None
         sw = None
         if path and not is_asm:
-            material, density, sw = _material_of(ct, path)
+            material, density, sw = _material_of(ct, path, cfg)
         sw = sw or {}
-        cfg = safe_prop(ct, "ReferencedConfiguration") or None
         comps.append(Component(name=name, link_name=ln, part_path=path,
                                is_subassembly=is_asm, world=world,
                                fixed=fixed, dof=dof,
@@ -3473,7 +3483,8 @@ def to_graph_state(comps, adjacency, ground, robot_name, source_assembly,
                    hidden=None, limit_joints=None, coordinate_systems=None,
                    subassembly_coordinate_systems=None, reference_axes=None,
                    sw2urdf_marker=None, sw2urdf_config_xml=None,
-                   part_coordinate_systems=None):
+                   part_coordinate_systems=None, configuration=None,
+                   configurations=None):
     subs = {}
     for path, (scomps, sadj, sground) in (subassemblies or {}).items():
         subs[path] = SubGraph(components=_component_states(scomps),
@@ -3496,7 +3507,9 @@ def to_graph_state(comps, adjacency, ground, robot_name, source_assembly,
                       subassemblies=subs,
                       deep_worlds=deep_worlds or {}, hidden=hidden or [],
                       limit_joints=[LimitJoint(**j) for j in
-                                    (limit_joints or [])])
+                                    (limit_joints or [])],
+                      configuration=configuration,
+                      configurations=list(configurations or []))
 
 
 def capture_deep_worlds(doc):

--- a/sw2robot/exporter/state.py
+++ b/sw2robot/exporter/state.py
@@ -191,6 +191,14 @@ class GraphState(BaseModel):
     # LimitDistance/LimitAngle mates = the assembly's real sliders/hinges; the
     # build promotes these edges to prismatic/revolute (empty on older extracts)
     limit_joints: list[LimitJoint] = []
+    # Which CONFIGURATION of the top-level assembly this graph was read from,
+    # and every configuration the file offers.  A configuration suppresses
+    # components and swaps part variants, so two graphs of one .SLDASM can
+    # legitimately differ; recording the choice makes a package say which
+    # variant it is, and lets the editor offer the others without SolidWorks.
+    # Both empty/None on older extracts.
+    configuration: str | None = None
+    configurations: list[str] = []
 
     def save(self, path):
         with open(path, "w", encoding="utf-8") as f:

--- a/tests/e2e/run.mjs
+++ b/tests/e2e/run.mjs
@@ -479,6 +479,7 @@ await page.evaluate(() => {
     const url = typeof u === 'string' ? u : u?.url;
     const J = o => new Response(JSON.stringify(o),
       { headers: { 'Content-Type': 'application/json' } });
+    if (url && url.includes('/api/configurations')) return J({ configurations: [] });
     if (url && url.includes('/api/extract?')) return J({ started: true });
     if (url && url.includes('/api/progress')) return J(window._P[window._phase]);
     return of(u, opts);
@@ -520,6 +521,7 @@ await page.evaluate(() => {
       return J([{ name: 'built_pkg', path: 'C:/out/built_pkg' }]);
     if (url && url.includes('/api/fs'))           // server browser root
       return J({ path: '', parent: null, dirs: [], files: [] });
+    if (url && url.includes('/api/configurations')) return J({ configurations: [] });
     if (url && url.includes('/api/extract?')) return J({ started: true });
     if (url && url.includes('/api/progress'))
       return J({ job: 'extract', running: true, done: false, cancelled: false,

--- a/tests/test_3dxml_unique_names.py
+++ b/tests/test_3dxml_unique_names.py
@@ -1,0 +1,128 @@
+"""Two configurations of one part must not collapse into one shape.
+
+SolidWorks writes a 3DXML with one tessellation per CONFIGURATION, so a part
+used with two of them appears as two Reference3D nodes carrying the SAME name.
+trimesh re-keys geometry by that name, so the second overwrites the first and
+BOTH instances get drawn with whichever survived -- a mirrored bracket on the
+wrong side, a spacer 8 mm short, while the part COUNT still looks right.
+_unique_part_names disambiguates the names in the file we ship.
+"""
+import zipfile
+
+import pytest
+
+from sw2robot.exporter.mesh import _dedupe_reference_names, _unique_part_names
+
+MANIFEST = b'<?xml version="1.0" encoding="UTF-8"?>\n' \
+           b'<Manifest><Root>NameSetTree.3dxml</Root></Manifest>'
+
+
+def _tree(*refs):
+    body = b"".join(
+        b'<Reference3D xsi:type="Reference3DType" id="%d" name="%s"/>'
+        % (i + 1, n) for i, n in enumerate(refs))
+    return (b'<?xml version="1.0" encoding="UTF-8"?>'
+            b'<Model_3dxml xmlns="http://www.3ds.com/xsd/3DXML">'
+            b'<ProductStructure root="1">' + body +
+            b'</ProductStructure></Model_3dxml>')
+
+
+def _make(tmp_path, tree, extra=None, root="NameSetTree.3dxml"):
+    p = tmp_path / "m.3dxml"
+    with zipfile.ZipFile(p, "w") as z:
+        z.writestr("Manifest.xml", MANIFEST)
+        z.writestr(root, tree)
+        z.writestr("TessPart_5.3DRep", b"tessellation bytes")
+        for k, v in (extra or {}).items():
+            z.writestr(k, v)
+    return p
+
+
+def _names(path):
+    with zipfile.ZipFile(path) as z:
+        import re
+        return re.findall(rb'name="([^"]*)"', z.read("NameSetTree.3dxml"))
+
+
+def test_duplicate_names_are_disambiguated(tmp_path):
+    p = _make(tmp_path, _tree(b"bracket", b"bracket", b"screw"))
+    assert _unique_part_names(str(p)) == 1
+    assert _names(p) == [b"bracket", b"bracket__2", b"screw"]
+
+
+def test_first_occurrence_keeps_its_name(tmp_path):
+    # renaming the survivor would churn every package for no reason
+    p = _make(tmp_path, _tree(b"a", b"a", b"a"))
+    assert _unique_part_names(str(p)) == 2
+    assert _names(p) == [b"a", b"a__2", b"a__3"]
+
+
+def test_unique_file_is_left_alone(tmp_path):
+    p = _make(tmp_path, _tree(b"a", b"b", b"c"))
+    before = p.read_bytes()
+    assert _unique_part_names(str(p)) == 0
+    assert p.read_bytes() == before          # not even rewritten
+
+
+def test_other_entries_survive_the_rewrite(tmp_path):
+    p = _make(tmp_path, _tree(b"a", b"a"),
+              extra={"CATMaterialRef.3dxml": b"<materials/>"})
+    assert _unique_part_names(str(p)) == 1
+    with zipfile.ZipFile(p) as z:
+        assert set(z.namelist()) == {"Manifest.xml", "NameSetTree.3dxml",
+                                     "TessPart_5.3DRep",
+                                     "CATMaterialRef.3dxml"}
+        assert z.read("TessPart_5.3DRep") == b"tessellation bytes"
+        assert z.read("CATMaterialRef.3dxml") == b"<materials/>"
+
+
+def test_escaped_and_cjk_names_are_not_re_encoded(tmp_path):
+    # the suffix goes onto the RAW attribute bytes, so an &amp; stays &amp;
+    # and a CJK name keeps its exact encoding
+    cjk = "ネジ".encode()
+    p = _make(tmp_path, _tree(b"a&amp;b", b"a&amp;b", cjk, cjk))
+    assert _unique_part_names(str(p)) == 2
+    assert _names(p) == [b"a&amp;b", b"a&amp;b__2", cjk, cjk + b"__2"]
+
+
+def test_impossible_zip_dates_do_not_lose_entries(tmp_path):
+    # SolidWorks stamps 3DXML entries with day 0 / month 13; zipfile refuses to
+    # pack those, and dropping the entry would mean dropping geometry
+    p = _make(tmp_path, _tree(b"a", b"a"))
+    src = p.read_bytes()
+    bad = tmp_path / "bad.3dxml"
+    with zipfile.ZipFile(p) as z, zipfile.ZipFile(bad, "w") as out:
+        for info in z.infolist():
+            zi = zipfile.ZipInfo(info.filename)
+            zi.date_time = (1980, 1, 0, 0, 0, 0)      # day 0, as SolidWorks
+            out.writestr(zi, z.read(info.filename))
+    assert _unique_part_names(str(bad)) == 1
+    with zipfile.ZipFile(bad) as z:
+        assert z.read("TessPart_5.3DRep") == b"tessellation bytes"
+    assert src                                        # sanity
+
+
+def test_not_a_zip_is_survivable(tmp_path):
+    p = tmp_path / "broken.3dxml"
+    p.write_bytes(b"not a zip at all")
+    assert _unique_part_names(str(p)) == 0
+    assert p.read_bytes() == b"not a zip at all"
+
+
+def test_missing_manifest_is_survivable(tmp_path):
+    p = tmp_path / "m.3dxml"
+    with zipfile.ZipFile(p, "w") as z:
+        z.writestr("SomethingElse.xml", b"<x/>")
+    assert _unique_part_names(str(p)) == 0
+
+
+def test_dedupe_is_pure_on_the_bytes():
+    raw = _tree(b"x", b"x")
+    fixed, n = _dedupe_reference_names(raw)
+    assert n == 1
+    assert b'name="x"' in fixed and b'name="x__2"' in fixed
+    assert _dedupe_reference_names(fixed)[1] == 0     # idempotent
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_clear_mesh_cache.py
+++ b/tests/test_clear_mesh_cache.py
@@ -1,0 +1,161 @@
+"""The 'drop meshes & re-extract' button: POST /api/clear_mesh_cache.
+
+meshes/ is a cache -- it invalidates itself on a CAD edit (mtime) and on a
+configuration change (meshes/cache_manifest.json) -- but there was no way to
+rule it out by hand short of finding %TEMP%\\sw2robot\\output and deleting the
+folder.
+
+Invalidating must not DESTROY.  The re-extract that follows can fail --
+SolidWorks busy with the user's own documents hands back an empty component
+tree -- and a first version that deleted the meshes up front left the package
+rendering nothing, with no way back.  So only the manifest goes: without it
+every mesh is of unknown configuration and gets re-exported, while the files
+stay on disk as a fallback.  graph.json (the extraction result) and
+<name>.joints.yaml (the user's joint edits) are not cache and are never touched.
+"""
+import json
+import os
+import socket
+import threading
+import urllib.error
+import urllib.request
+
+import pytest
+
+
+@pytest.fixture
+def server(tmp_path):
+    from sw2robot.editor import webserver
+
+    s = socket.socket()
+    s.bind(("", 0))
+    port = s.getsockname()[1]
+    s.close()
+    httpd, port = webserver._bind_free_port(webserver._Handler, port)
+    httpd.daemon_threads = True
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{port}", webserver
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        webserver._Handler.pkg_dir = None
+
+
+def _post(base, path):
+    req = urllib.request.Request(base + path, data=b"", method="POST")
+    try:
+        with urllib.request.urlopen(req) as r:
+            return r.status, json.loads(r.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read().decode("utf-8"))
+
+
+def _pkg(tmp_path, source_assembly=None, configuration=None):
+    """A minimal CAD package: graph.json + joints.yaml + a populated meshes/."""
+    pkg = tmp_path / "pkg"
+    (pkg / "meshes").mkdir(parents=True)
+    graph = {"robot_name": "m", "source_assembly": str(source_assembly or ""),
+             "components": [], "edges": [], "ground": []}
+    if configuration is not None:
+        graph["configuration"] = configuration
+    (pkg / "graph.json").write_text(json.dumps(graph), encoding="utf-8")
+    (pkg / "m.joints.yaml").write_text("joints: {}\n", encoding="utf-8")
+    for name in ("a.3dxml", "a.3dxml.glb", "b.glb", "cache_manifest.json"):
+        (pkg / "meshes" / name).write_bytes(b"x" * 100)
+    return pkg
+
+
+def test_invalidates_the_cache_without_destroying_it(server, tmp_path):
+    base, webserver = server
+    asm = tmp_path / "m.SLDASM"
+    asm.write_bytes(b"stub")
+    pkg = _pkg(tmp_path, source_assembly=asm, configuration="alt_mount")
+    webserver._Handler.pkg_dir = str(pkg)
+
+    code, r = _post(base, "/api/clear_mesh_cache")
+    assert code == 200 and r["ok"]
+    assert r["removed"] == 3 and r["bytes"] == 300      # the meshes, counted
+    # ONLY the manifest is gone -- a failed re-extract must still have meshes
+    assert sorted(p.name for p in (pkg / "meshes").iterdir()) == [
+        "a.3dxml", "a.3dxml.glb", "b.glb"]
+    # ... and the things that are NOT cache survived
+    assert (pkg / "graph.json").is_file()
+    assert (pkg / "m.joints.yaml").read_text(encoding="utf-8") == "joints: {}\n"
+    # the client re-extracts from these two
+    assert r["source_assembly"] == str(asm)
+    assert r["configuration"] == "alt_mount"
+
+
+def test_invalidated_meshes_are_no_longer_reusable(server, tmp_path):
+    # the point of dropping the manifest: mesh.py refuses to reuse a mesh whose
+    # configuration it cannot vouch for, so the re-extract rebuilds every one
+    from sw2robot.exporter.mesh import _cache_holds_config, _manifest_record
+
+    base, webserver = server
+    pkg = _pkg(tmp_path)
+    meshes = str(pkg / "meshes")
+    _manifest_record(meshes, os.path.join(meshes, "a.3dxml"), "a.SLDPRT", "L1")
+    assert _cache_holds_config(meshes, os.path.join(meshes, "a.3dxml"), "L1")
+    webserver._Handler.pkg_dir = str(pkg)
+    _post(base, "/api/clear_mesh_cache")
+    assert not _cache_holds_config(meshes,
+                                   os.path.join(meshes, "a.3dxml"), "L1")
+
+
+def test_missing_source_assembly_is_reported_not_guessed(server, tmp_path):
+    # source moved away: the cache still clears, but the client must not be
+    # told to re-extract from a path that no longer exists
+    base, webserver = server
+    pkg = _pkg(tmp_path, source_assembly=tmp_path / "gone.SLDASM")
+    webserver._Handler.pkg_dir = str(pkg)
+    code, r = _post(base, "/api/clear_mesh_cache")
+    assert code == 200 and r["removed"] == 3
+    assert r["source_assembly"] is None
+
+
+def test_older_package_without_a_configuration(server, tmp_path):
+    base, webserver = server
+    asm = tmp_path / "m.SLDASM"
+    asm.write_bytes(b"stub")
+    pkg = _pkg(tmp_path, source_assembly=asm)      # no "configuration" key
+    webserver._Handler.pkg_dir = str(pkg)
+    code, r = _post(base, "/api/clear_mesh_cache")
+    assert code == 200 and r["configuration"] is None
+
+
+def test_no_package_open_is_a_400(server):
+    base, webserver = server
+    webserver._Handler.pkg_dir = None
+    code, r = _post(base, "/api/clear_mesh_cache")
+    assert code == 400 and "no package open" in r["error"]
+
+
+def test_refused_while_an_extraction_runs(server, tmp_path):
+    # deleting meshes under a running export would race the exporter
+    base, webserver = server
+    pkg = _pkg(tmp_path)
+    webserver._Handler.pkg_dir = str(pkg)
+    with webserver._job_lock:
+        webserver._job.update(running=True)
+    try:
+        code, r = _post(base, "/api/clear_mesh_cache")
+    finally:
+        with webserver._job_lock:
+            webserver._job.update(running=False)
+    assert code == 409 and "extraction is running" in r["error"]
+    assert len(list((pkg / "meshes").iterdir())) == 4     # manifest still there
+
+
+def test_empty_cache_is_not_an_error(server, tmp_path):
+    base, webserver = server
+    pkg = tmp_path / "bare"
+    (pkg / "meshes").mkdir(parents=True)
+    (pkg / "graph.json").write_text('{"robot_name": "m"}', encoding="utf-8")
+    webserver._Handler.pkg_dir = str(pkg)
+    code, r = _post(base, "/api/clear_mesh_cache")
+    assert code == 200 and r["removed"] == 0 and r["bytes"] == 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_extract_configuration.py
+++ b/tests/test_extract_configuration.py
@@ -1,0 +1,143 @@
+"""Choosing WHICH assembly configuration to extract, from the web editor.
+
+An assembly configuration suppresses whole components and points instances at
+other variants of a part, so it decides what the URDF contains.  Only the
+`sw2urdf --configuration` CLI could pick one; the editor always took the file's
+saved-active configuration, with no way to see -- let alone change -- that.
+These cover the plumbing: /api/configurations lists the choices without loading
+the document, and /api/extract carries the choice through to extract().
+"""
+import json
+import socket
+import threading
+import urllib.error
+import urllib.request
+
+import pytest
+
+
+@pytest.fixture
+def server(tmp_path, monkeypatch):
+    from sw2robot.editor import webserver
+
+    s = socket.socket()
+    s.bind(("", 0))
+    port = s.getsockname()[1]
+    s.close()
+    httpd, port = webserver._bind_free_port(webserver._Handler, port)
+    httpd.daemon_threads = True
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{port}", webserver
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+
+def _get(base, path):
+    try:
+        with urllib.request.urlopen(base + path) as r:
+            return r.status, json.loads(r.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read().decode("utf-8"))
+
+
+def test_configurations_lists_what_the_file_offers(server, tmp_path,
+                                                   monkeypatch):
+    base, webserver = server
+    asm = tmp_path / "module.SLDASM"
+    asm.write_bytes(b"not really CAD, the SolidWorks call is stubbed")
+    monkeypatch.setattr(webserver, "_configurations_of",
+                        lambda p: (["デフォルト",
+                                    "alt_mount"], "warm"))
+    code, r = _get(base, f"/api/configurations?path={asm}")
+    assert code == 200
+    assert r["configurations"] == ["デフォルト",
+                                   "alt_mount"]
+    assert r["source"] == "warm"
+
+
+def test_configurations_rejects_a_non_cad_path(server, tmp_path):
+    base, _ = server
+    txt = tmp_path / "notes.txt"
+    txt.write_text("hello", encoding="utf-8")
+    code, r = _get(base, f"/api/configurations?path={txt}")
+    assert code == 400
+    assert "not a .sldasm/.sldprt file" in r["error"]
+
+
+def test_no_solidworks_is_not_an_error(server, tmp_path, monkeypatch):
+    # with nothing to ask, the picker must stay silent and the extract fall
+    # back to the file's saved-active configuration -- not fail
+    base, webserver = server
+    asm = tmp_path / "module.SLDASM"
+    asm.write_bytes(b"stub")
+    monkeypatch.setattr(webserver, "_configurations_of",
+                        lambda p: ([], "unavailable"))
+    code, r = _get(base, f"/api/configurations?path={asm}")
+    assert code == 200
+    assert r == {"configurations": [], "source": "unavailable"}
+
+
+def test_extract_forwards_the_chosen_configuration(server, tmp_path,
+                                                   monkeypatch):
+    base, webserver = server
+    asm = tmp_path / "module.SLDASM"
+    asm.write_bytes(b"stub")
+    seen = {}
+    done = threading.Event()
+
+    def fake_run(sldasm, configuration=None):
+        seen["path"], seen["configuration"] = sldasm, configuration
+        with webserver._job_lock:
+            webserver._job.update(running=False)
+        webserver._prog_finish(result={"package": str(tmp_path)})
+        done.set()
+
+    monkeypatch.setattr(webserver, "_run_extract", fake_run)
+    code, r = _get(base, f"/api/extract?path={asm}&configuration=alt_mount")
+    assert code == 200 and r == {"started": True}
+    assert done.wait(5)
+    assert seen["configuration"] == "alt_mount"
+
+
+def test_extract_without_a_choice_keeps_saved_active(server, tmp_path,
+                                                     monkeypatch):
+    # "" from the picker's default option must arrive as None (= don't switch),
+    # never as an empty configuration name
+    base, webserver = server
+    asm = tmp_path / "module.SLDASM"
+    asm.write_bytes(b"stub")
+    seen = {}
+    done = threading.Event()
+
+    def fake_run(sldasm, configuration=None):
+        seen["configuration"] = configuration
+        with webserver._job_lock:
+            webserver._job.update(running=False)
+        webserver._prog_finish(result={"package": str(tmp_path)})
+        done.set()
+
+    monkeypatch.setattr(webserver, "_run_extract", fake_run)
+    code, _ = _get(base, f"/api/extract?path={asm}&configuration=")
+    assert code == 200
+    assert done.wait(5)
+    assert seen["configuration"] is None
+
+
+def test_graph_state_records_the_configuration_it_came_from():
+    # a package must be able to say WHICH variant it is, without SolidWorks
+    from sw2robot.exporter.state import GraphState
+
+    g = GraphState(robot_name="m", source_assembly="m.SLDASM",
+                   configuration="alt_mount",
+                   configurations=["デフォルト",
+                                   "alt_mount"])
+    assert json.loads(g.model_dump_json())["configuration"] == "alt_mount"
+    # older extracts carry neither
+    old = GraphState(robot_name="m", source_assembly="m.SLDASM")
+    assert old.configuration is None and old.configurations == []
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_mesh_cache_config.py
+++ b/tests/test_mesh_cache_config.py
@@ -1,0 +1,95 @@
+"""The per-part mesh cache must not hand back ANOTHER configuration's geometry.
+
+meshes/<link>.3dxml is keyed on the link name, and a .3dxml records nothing
+about the configuration it was tessellated from.  Switching a part (or the
+assembly) to another configuration leaves the previous config's mesh sitting at
+exactly the filename the new one would take, and it passes the mtime gate --
+the .SLDPRT itself did not change -- so it was reused and the export came out
+with geometry from two configurations mixed together.  A sidecar manifest
+records (source, config) per mesh so the reuse is checkable.
+"""
+import json
+import os
+
+import pytest
+
+from sw2robot.exporter.mesh import (
+    _CACHE_MANIFEST,
+    _MIN_MESH_BYTES,
+    _cache_holds_config,
+    _manifest_record,
+)
+
+
+def _mesh(meshes_dir, name="link.3dxml"):
+    p = meshes_dir / name
+    p.write_bytes(b"x" * _MIN_MESH_BYTES)
+    return str(p)
+
+
+def test_unrecorded_mesh_is_never_reused(tmp_path):
+    # written by an older sw2robot (or by hand): its config is unknowable, so
+    # re-export rather than risk mixing configurations
+    cand = _mesh(tmp_path)
+    assert _cache_holds_config(str(tmp_path), cand, "Default") is False
+
+
+def test_recorded_config_matches(tmp_path):
+    cand = _mesh(tmp_path)
+    _manifest_record(str(tmp_path), cand, "C:/parts/link.SLDPRT", "Default")
+    assert _cache_holds_config(str(tmp_path), cand, "Default") is True
+
+
+def test_other_config_forces_reexport(tmp_path):
+    # the reported bug: mesh cached as 'variant_b', assembly references 'Default'
+    cand = _mesh(tmp_path)
+    _manifest_record(str(tmp_path), cand, "C:/parts/link.SLDPRT", "variant_b")
+    assert _cache_holds_config(str(tmp_path), cand, "Default") is False
+
+
+def test_empty_config_is_the_same_as_none(tmp_path):
+    cand = _mesh(tmp_path)
+    _manifest_record(str(tmp_path), cand, "C:/parts/link.SLDPRT", None)
+    assert _cache_holds_config(str(tmp_path), cand, "") is True
+    assert _cache_holds_config(str(tmp_path), cand, None) is True
+    assert _cache_holds_config(str(tmp_path), cand, "Default") is False
+
+
+def test_records_accumulate_and_survive_rewrites(tmp_path):
+    a, b = _mesh(tmp_path, "a.3dxml"), _mesh(tmp_path, "b.3dxml")
+    _manifest_record(str(tmp_path), a, "a.SLDPRT", "left")
+    _manifest_record(str(tmp_path), b, "b.SLDPRT", "right")
+    assert _cache_holds_config(str(tmp_path), a, "left") is True
+    assert _cache_holds_config(str(tmp_path), b, "right") is True
+    with open(tmp_path / _CACHE_MANIFEST, encoding="utf-8") as f:
+        man = json.load(f)
+    assert man["a.3dxml"]["source"] == "a.SLDPRT"
+    assert set(man) == {"a.3dxml", "b.3dxml"}
+
+
+def test_reexport_on_the_same_name_updates_the_record(tmp_path):
+    cand = _mesh(tmp_path)
+    _manifest_record(str(tmp_path), cand, "link.SLDPRT", "variant_b")
+    _manifest_record(str(tmp_path), cand, "link.SLDPRT", "Default")
+    assert _cache_holds_config(str(tmp_path), cand, "Default") is True
+    assert _cache_holds_config(str(tmp_path), cand, "variant_b") is False
+
+
+def test_corrupt_manifest_is_ignored_not_fatal(tmp_path):
+    cand = _mesh(tmp_path)
+    (tmp_path / _CACHE_MANIFEST).write_text("{not json", encoding="utf-8")
+    assert _cache_holds_config(str(tmp_path), cand, "Default") is False
+    _manifest_record(str(tmp_path), cand, "link.SLDPRT", "Default")
+    assert _cache_holds_config(str(tmp_path), cand, "Default") is True
+
+
+def test_manifest_is_written_next_to_the_meshes(tmp_path):
+    cand = _mesh(tmp_path)
+    _manifest_record(str(tmp_path), cand, "link.SLDPRT", "Default")
+    assert os.path.exists(tmp_path / _CACHE_MANIFEST)
+    # no half-written temp left behind
+    assert not os.path.exists(tmp_path / (_CACHE_MANIFEST + ".part"))
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_mesh_fidelity.py
+++ b/tests/test_mesh_fidelity.py
@@ -1,0 +1,141 @@
+"""Read every written mesh back and check it survived the round trip.
+
+The export hands geometry to a third-party loader and never looks at it again,
+so anything the loader drops or merges ships into the URDF silently.  That is
+how two configuration variants of one part came to be collapsed into a single
+shape, drawn superimposed, with the part COUNT still correct -- nothing in the
+pipeline was in a position to notice.  Comparing what the file declares against
+what the loader returns catches that whole class, not just the known cause.
+"""
+import zipfile
+
+import pytest
+
+from sw2robot.exporter.mesh import _declared_counts, verify_mesh, verify_meshes
+
+MANIFEST = b'<Manifest><Root>NameSetTree.3dxml</Root></Manifest>'
+
+
+def _doc(refs, reps, instances):
+    """refs: [(id, name)]; reps: [ref_id owning geometry];
+    instances: [ref_id being instanced]."""
+    out = [b'<Model_3dxml xmlns="http://www.3ds.com/xsd/3DXML">']
+    for i, n in refs:
+        out.append(b'<Reference3D id="%d" name="%s"/>' % (i, n))
+    for r in reps:
+        out.append(b'<InstanceRep><IsAggregatedBy>%d</IsAggregatedBy>'
+                   b'<IsInstanceOf>99</IsInstanceOf></InstanceRep>' % r)
+    for r in instances:
+        out.append(b'<Instance3D name="x-1"><IsInstanceOf>%d</IsInstanceOf>'
+                   b'</Instance3D>' % r)
+    out.append(b'</Model_3dxml>')
+    return b"".join(out)
+
+
+def _make(tmp_path, tree, name="m.3dxml"):
+    p = tmp_path / name
+    with zipfile.ZipFile(p, "w") as z:
+        z.writestr("Manifest.xml", MANIFEST)
+        z.writestr("NameSetTree.3dxml", tree)
+    return p
+
+
+def test_declared_counts_ignores_subassembly_nodes(tmp_path):
+    # ref 1 is a sub-assembly (no InstanceRep) -- it draws nothing itself and
+    # must not be counted as a shape
+    p = _make(tmp_path, _doc(refs=[(1, b"asm"), (2, b"part")],
+                             reps=[2], instances=[1, 2, 2]))
+    assert _declared_counts(str(p)) == (1, 2)
+
+
+def test_two_configs_of_one_part_count_as_two_shapes(tmp_path):
+    p = _make(tmp_path, _doc(refs=[(1, b"D"), (2, b"D")],
+                             reps=[1, 2], instances=[1, 2]))
+    assert _declared_counts(str(p)) == (2, 2)
+
+
+def test_a_loader_that_merges_two_shapes_is_reported(tmp_path, monkeypatch):
+    # the bug as it happened: 2 declared shapes, 1 returned
+    p = _make(tmp_path, _doc(refs=[(1, b"D"), (2, b"D")],
+                             reps=[1, 2], instances=[1, 2]))
+    _fake_loader(monkeypatch, geometries=1, nodes=2)
+    msg = verify_mesh(str(p))
+    assert msg and "declares 2 shape(s) but reads back as 1" in msg
+    assert "merged or dropped" in msg
+
+
+def test_a_loader_that_drops_an_instance_is_reported(tmp_path, monkeypatch):
+    p = _make(tmp_path, _doc(refs=[(1, b"a")], reps=[1], instances=[1, 1, 1]))
+    _fake_loader(monkeypatch, geometries=1, nodes=2)
+    assert "declares 3 instance(s) but reads back as 2" in verify_mesh(str(p))
+
+
+def test_a_single_part_export_is_not_a_false_alarm(tmp_path, monkeypatch):
+    # a lone .SLDPRT has no Instance3D at all -- the root reference IS the
+    # geometry -- yet the loader still yields one node.  Flagging that would
+    # bury the real complaints under one per part file.
+    p = _make(tmp_path, _doc(refs=[(1, b"part")], reps=[1], instances=[]))
+    _fake_loader(monkeypatch, geometries=1, nodes=1)
+    assert verify_mesh(str(p)) is None
+
+
+def test_a_faithful_read_is_silent(tmp_path, monkeypatch):
+    p = _make(tmp_path, _doc(refs=[(1, b"a"), (2, b"b")],
+                             reps=[1, 2], instances=[1, 2, 2]))
+    _fake_loader(monkeypatch, geometries=2, nodes=3)
+    assert verify_mesh(str(p)) is None
+
+
+def test_an_unreadable_mesh_is_reported_not_raised(tmp_path, monkeypatch):
+    p = _make(tmp_path, _doc(refs=[(1, b"a")], reps=[1], instances=[1]))
+
+    class Boom:
+        @staticmethod
+        def load(_):
+            raise RuntimeError("nope")
+
+    monkeypatch.setitem(__import__("sys").modules, "trimesh", Boom)
+    assert "could not be read back" in verify_mesh(str(p))
+
+
+def test_a_non_3dxml_file_is_skipped(tmp_path):
+    p = tmp_path / "plain.3dxml"
+    p.write_bytes(b"not a zip")
+    assert _declared_counts(str(p)) is None
+    assert verify_mesh(str(p)) is None      # nothing to check, not a failure
+
+
+def test_verify_meshes_collects_every_complaint(tmp_path, monkeypatch):
+    good = _make(tmp_path, _doc(refs=[(1, b"a")], reps=[1], instances=[1]),
+                 name="good.3dxml")
+    bad = _make(tmp_path, _doc(refs=[(1, b"D"), (2, b"D")],
+                               reps=[1, 2], instances=[1, 2]),
+                name="bad.3dxml")
+    _fake_loader(monkeypatch, geometries=1, nodes=1)
+    said = []
+    problems = verify_meshes([str(good), str(bad)], say=said.append)
+    assert len(problems) == 1 and "bad.3dxml" in problems[0]
+    assert said and "1 PROBLEM" in said[0]
+
+
+def _fake_loader(monkeypatch, geometries, nodes):
+    """Stand in for trimesh so the check is tested, not the CAD reader."""
+    class Graph:
+        def __init__(self):
+            self.nodes_geometry = ["n"] * nodes
+
+    class Scene:
+        def __init__(self):
+            self.geometry = {str(i): None for i in range(geometries)}
+            self.graph = Graph()
+
+    class Fake:
+        @staticmethod
+        def load(_):
+            return Scene()
+
+    monkeypatch.setitem(__import__("sys").modules, "trimesh", Fake)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
A part used with two configurations came out wrong: mass and geometry were read
from whatever the shared document happened to show, and because SolidWorks gives
both variants the same name in a 3DXML, a name-keyed reader merged them into one
shape drawn twice in the same place — so a part vanished while the count still
looked right.

Every mesh is now exported on the configuration its instance references, the
cache is keyed on it, the editor can pick the assembly configuration, and each
written mesh is read back and compared with what the file declares.
