### PR TITLE
Honour an explicit --port instead of quietly drifting off it

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Python or clone this repo. Grab the prebuilt editor and run it:
    - Windows SmartScreen may warn that the publisher is unknown (the binary is
      unsigned). Click **More info → Run anyway**.
    - To pick a different port or skip auto-opening the browser, run it from a
-     terminal: `sw2robot-web-windows-x64-v<version>.exe --port 8090 --no-browser`.
+     terminal: `sw2robot-web-windows-x64-v<version>.exe --port 9000 --no-browser`.
 3. **Extract a robot.** Open your `.sldasm` assembly with the in-app file
    picker — the **🗄 file browser** (lists SolidWorks' recent files for
    one-click access) or **📋 paste a full path**. SolidWorks needs the real
@@ -194,14 +194,14 @@ browser at `http://localhost:8090`).
 # Gatekeeper blocks unsigned apps on first launch — clear the quarantine once,
 # then double-click, or run it from a terminal to see the server log / URL:
 xattr -dr com.apple.quarantine sw2robot-web.app
-./sw2robot-web.app/Contents/MacOS/sw2robot-web --port 8090
+./sw2robot-web.app/Contents/MacOS/sw2robot-web
 ```
 
 **Linux (x64)** — `sw2robot-web-linux-x64-v<version>` (a single binary):
 
 ```bash
 chmod +x sw2robot-web-linux-x64-v<version>          # mark it executable once
-./sw2robot-web-linux-x64-v<version> --port 8090     # opens http://localhost:8090
+./sw2robot-web-linux-x64-v<version>                 # opens http://localhost:8090
 ```
 
 The binary is frozen against GLIBC 2.35, so it runs on **Ubuntu 22.04 or newer**
@@ -214,7 +214,7 @@ below):
 ```bash
 pip install -e ".[ui]"
 # edit an already-extracted package, or open any URDF directly:
-python -m sw2robot.editor.webserver path/to/robot.urdf --port 8090
+python -m sw2robot.editor.webserver path/to/robot.urdf
 ```
 
 The editor opens in URDF-input mode when you point it at a `.urdf` file: re-root,
@@ -338,7 +338,7 @@ needs an assembly with mates.
 needed — a sample is included):
 
 ```bash
-python -m sw2robot.editor.webserver examples/fingertip --port 8090
+python -m sw2robot.editor.webserver examples/fingertip
 # then open http://localhost:8090
 ```
 

--- a/build_exe.py
+++ b/build_exe.py
@@ -356,7 +356,7 @@ def main() -> int:
             invoke = f"./{exe_name}"
             sep = "/"
         print("Run it like the module:  "
-              f"{invoke} output{sep}<your_package> --port 8090")
+              f"{invoke} output{sep}<your_package>")
     if IS_WINDOWS:
         print("NOTE: the target machine still needs SolidWorks installed for "
               "the extract step; view/edit/build/export work without it.")

--- a/sw2robot/editor/webserver.py
+++ b/sw2robot/editor/webserver.py
@@ -1,6 +1,6 @@
 """Serve sw2robot.exporter module packages to the urdf-loaders web viewer.
 
-    uv run python -m sw2robot.editor.webserver [package_dir] [--root output] [--port 8090]
+    uv run python -m sw2robot.editor.webserver [package_dir] [--root output] [--port N]
 
 Prototype of the sw2robot.editor web View: a static gkjohnson/urdf-loaders page
 (``sw2robot/editor/web/``) + this tiny stdlib server.
@@ -41,6 +41,8 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 PACKAGE_ROOT = os.path.dirname(HERE)
 PROJECT_ROOT = os.path.dirname(PACKAGE_ROOT)
 WEB_DIR = os.path.join(HERE, "web")
+
+DEFAULT_PORT = 8090
 
 # The port the running server bound (set in serve()).  The self-update relaunch
 # reads this (sw2robot.editor.update._current_bound_port) to reclaim the SAME
@@ -7458,9 +7460,44 @@ def _bind_free_port(handler, port, tries=20, wait_first=0.0):
     raise OSError(f"no free port in {port}..{port + tries - 1}: {last}")
 
 
-def serve(package_dir=None, root_dir=None, port=8090, open_browser=True,
+class PortInUse(OSError):
+    """An explicitly requested port was taken, so nothing was served."""
+
+
+def _bind(handler, port, explicit, reclaim_port, wait_first=None):
+    """Bind the server socket.  Returns ``(httpd, bound_port)``.
+
+    Drifting to the next free port is what lets a SECOND instance come up
+    instead of dying on WinError 10048 -- but only when nobody named a port.
+    If one was named, drifting hands the caller a server on an address it never
+    asked for while whatever already owns the requested one keeps answering
+    there; a script that then talks to the port it asked for reaches the wrong
+    server and nothing says so.  So: named port, or PortInUse.
+
+    A self-update relaunch names the port it is reclaiming and must still
+    drift -- the instance it replaces is mid-exit, hence the wait."""
+    if explicit and not reclaim_port:
+        try:
+            return socketserver.ThreadingTCPServer(("", port), handler), port
+        except OSError as e:
+            raise PortInUse(
+                f"port {port} is already in use ({e}); nothing was served. "
+                f"Something else is answering there -- stop it, pick another "
+                f"--port, or omit --port to take the next free one."
+            ) from e
+    if wait_first is None:
+        wait_first = 8.0 if reclaim_port else 0.0
+    return _bind_free_port(handler, port, wait_first=wait_first)
+
+
+def serve(package_dir=None, root_dir=None, port=None, open_browser=True,
           reclaim_port=False):
+    """Serve the editor.  ``port=None`` means "pick one": DEFAULT_PORT, walking
+    forward if it is busy.  A number means THAT port, or PortInUse."""
     global BOUND_PORT
+    explicit_port = port is not None
+    if not explicit_port:
+        port = DEFAULT_PORT
     import atexit
     import signal
     # reap any private SolidWorks instance a PREVIOUS run spawned and leaked
@@ -7492,10 +7529,7 @@ def serve(package_dir=None, root_dir=None, port=8090, open_browser=True,
     else:
         print(f"[sw2robot.web] no package yet -- pick one in the browser "
               f"(root: {_Handler.root_dir})")
-    # a self-update relaunch reclaims the exact port the old instance had (it is
-    # mid-exit), so wait briefly for it instead of immediately drifting forward
-    httpd, bound = _bind_free_port(_Handler, port,
-                                   wait_first=8.0 if reclaim_port else 0.0)
+    httpd, bound = _bind(_Handler, port, explicit_port, reclaim_port)
     if bound != port:
         print(f"[sw2robot.web] port {port} busy -> using {bound}")
     port = bound
@@ -7667,7 +7701,12 @@ def main():
                          "extractions are written (default: ./output in a "
                          "source checkout, %%TEMP%%\\sw2robot\\output for the "
                          "frozen .exe)")
-    ap.add_argument("--port", type=int, default=8090)
+    ap.add_argument("--port", type=int, default=None,
+                    help=f"port to serve on.  Omitted, the server takes "
+                         f"{DEFAULT_PORT} or the next free port after it, so a "
+                         f"second instance still comes up.  Given, THAT port is "
+                         f"used or the server exits -- it never moves to one "
+                         f"you did not ask for")
     ap.add_argument("--no-browser", action="store_true",
                     help="do not open the editor in the default browser on "
                          "startup")
@@ -7679,8 +7718,11 @@ def main():
                     help=argparse.SUPPRESS)   # internal: set on the relaunch from
                     # the %LOCALAPPDATA% install copy so it doesn't re-relocate
     args = ap.parse_args()
-    serve(args.package_dir, root_dir=args.root, port=args.port,
-          open_browser=not args.no_browser, reclaim_port=args.reclaim_port)
+    try:
+        serve(args.package_dir, root_dir=args.root, port=args.port,
+              open_browser=not args.no_browser, reclaim_port=args.reclaim_port)
+    except PortInUse as e:
+        raise SystemExit(f"[sw2robot.web] {e}") from None
 
 
 if __name__ == "__main__":

--- a/tests/test_port_selection.py
+++ b/tests/test_port_selection.py
@@ -1,0 +1,105 @@
+"""An explicitly requested port is honoured or refused -- never silently moved.
+
+Drifting to the next free port is deliberate when nobody named one: it is what
+lets a second editor instance come up instead of dying on "address in use".
+But when ``--port`` IS given, drifting is a trap.  Whatever already owns the
+requested port keeps answering there, so a script that starts a server on 8591
+and then talks to 8591 reaches somebody else's server and measures it happily.
+"""
+
+import socket
+import subprocess
+import sys
+
+import pytest
+
+from sw2robot.editor import webserver
+
+
+def _busy_port():
+    """Bind an ephemeral port and keep it held for the duration of the test."""
+    s = socket.socket()
+    s.bind(("", 0))
+    s.listen(1)
+    return s, s.getsockname()[1]
+
+
+def test_explicit_port_in_use_refuses_to_serve():
+    held, port = _busy_port()
+    try:
+        # If this regresses, the server comes up on some OTHER port and runs
+        # forever, so the failure is a timeout rather than a non-zero exit --
+        # keep it short and report it as the failure it is, not as a hang.
+        proc = subprocess.run(
+            [sys.executable, "-m", "sw2robot.editor.webserver",
+             "--port", str(port), "--no-browser"],
+            capture_output=True, text=True, timeout=30,
+        )
+    except subprocess.TimeoutExpired as e:
+        out = (e.stdout or b"").decode(errors="replace") \
+            + (e.stderr or b"").decode(errors="replace")
+        pytest.fail(f"still serving after 30s on a port that was taken:\n{out}")
+    finally:
+        held.close()
+
+    out = proc.stdout + proc.stderr
+    assert proc.returncode != 0, f"served anyway on a taken port:\n{out}"
+    assert f"port {port} is already in use" in out, out
+    # and it must not claim to be serving somewhere else
+    assert "open http://localhost:" not in out, out
+
+
+def _bind_on_busy(**kw):
+    """Run _bind against a port that is held, and return (bound, exc)."""
+    held, port = _busy_port()
+    try:
+        httpd, bound = webserver._bind(webserver._Handler, port, **kw)
+    except OSError as e:
+        return port, None, e
+    finally:
+        held.close()
+    httpd.server_close()
+    return port, bound, None
+
+
+def test_no_port_named_walks_forward():
+    """The behaviour we are keeping: nothing named -> take the next free one.
+
+    This goes through _bind, not _bind_free_port: testing the helper alone
+    leaves the branch that chooses it untested, and a mutation that made the
+    default path strict survived exactly that way.
+    """
+    port, bound, exc = _bind_on_busy(explicit=False, reclaim_port=False)
+    assert exc is None, exc
+    assert bound != port
+
+
+def test_named_port_in_use_raises():
+    port, bound, exc = _bind_on_busy(explicit=True, reclaim_port=False)
+    assert isinstance(exc, webserver.PortInUse), (bound, exc)
+    assert f"port {port} is already in use" in str(exc)
+
+
+def test_reclaim_still_walks_forward():
+    """A self-update relaunch names its port but must still drift: the old
+    instance it is replacing has not finished exiting."""
+    port, bound, exc = _bind_on_busy(
+        explicit=True, reclaim_port=True, wait_first=0.1)
+    assert exc is None, exc
+    assert bound != port
+
+
+def test_serve_signature_defaults_to_no_port():
+    """``port=None`` is what distinguishes "pick one" from "use this one"."""
+    import inspect
+    sig = inspect.signature(webserver.serve)
+    assert sig.parameters["port"].default is None
+
+
+def test_port_in_use_is_an_oserror():
+    """Callers that already catch OSError around serve() keep working."""
+    assert issubclass(webserver.PortInUse, OSError)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Walking forward to the next free port is deliberate — it is what lets a second editor instance come up instead of dying on "address in use" — but it also applied when `--port` was given, and there it is a trap: whatever already owns the requested port keeps answering on it, so a script that starts a server on 8591 and then talks to 8591 reaches a different server entirely and measures it happily. The drift is printed, but into a log nobody reads.
No `--port` still means 8090 or the next free one; a named port is now bound or the server exits with `PortInUse` saying which port and what to do. `--reclaim-port` (the self-update relaunch) keeps drifting, because the instance it replaces is mid-exit.
The README passed `--port 8090` in five places where it is already the default — running those while the app is up would now fail rather than drift, so the redundant flag is gone.

Six tests, mutation-tested with six mutations, no survivors. Two of those tests exist because a mutation survived the first attempt: the "still walks forward" test called the binding helper directly, so the branch that *chooses* it was never covered, and making the default path strict went unnoticed. The choice now lives in `_bind()` and the tests go through it. `PortInUse` subclasses `OSError` so callers already guarding `serve()` keep working, and that is pinned by a test too. Full suite: 543 passed / 10 skipped, no lost names.

AI usage: Claude Code, drafted the change and the tests.
